### PR TITLE
Mile 0 — Observability spine: fix memory gauge (C-3), close count divergence (C-1), add per-tool duration histogram

### DIFF
--- a/python/synapse/server/handlers.py
+++ b/python/synapse/server/handlers.py
@@ -1117,8 +1117,9 @@ class SynapseHandler(NodeHandlerMixin, UsdHandlerMixin, RenderHandlerMixin, Tops
         memory_count = 0
         try:
             bridge = self._get_bridge()
-            if hasattr(bridge, "_memory") and bridge._memory:
-                memory_count = len(bridge._memory.get_all())
+            synapse_mem = getattr(bridge, "_synapse", None)
+            if synapse_mem is not None:
+                memory_count = synapse_mem.store.count()
         except Exception as e:
             _log.debug("Bridge memory count fetch failed: %s", e)
 

--- a/python/synapse/server/handlers.py
+++ b/python/synapse/server/handlers.py
@@ -8,11 +8,17 @@ Routes incoming commands to appropriate handler functions.
 import logging
 import math
 import os
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, Any, Callable, Optional
 
 _log = logging.getLogger(__name__)
+
+# Prometheus histogram bucket boundaries (milliseconds) for per-tool call
+# duration. Cumulative "le" semantics: an observation counts toward every
+# boundary >= its duration. Mile 0 observability spine.
+_TOOL_DURATION_BUCKETS_MS = (5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000)
 
 try:
     import hou
@@ -244,7 +250,40 @@ class SynapseHandler(NodeHandlerMixin, UsdHandlerMixin, RenderHandlerMixin, Tops
         self._session_id: Optional[str] = None
         self._user_id: str = ""
         self._bridge = None
+        # Per-tool call-duration accumulator (Mile 0). Thread-safe: handle()
+        # may run under the FastMCP executor on worker threads.
+        self._tool_durations: Dict[str, Dict[str, Any]] = {}
+        self._tool_durations_lock = threading.Lock()
         self._register_handlers()
+
+    def _record_tool_duration(self, tool: str, duration_ms: float):
+        """Record one timed tool call into the cumulative histogram."""
+        with self._tool_durations_lock:
+            rec = self._tool_durations.get(tool)
+            if rec is None:
+                rec = {
+                    "count": 0,
+                    "sum_ms": 0.0,
+                    "buckets": {b: 0 for b in _TOOL_DURATION_BUCKETS_MS},
+                }
+                self._tool_durations[tool] = rec
+            rec["count"] += 1
+            rec["sum_ms"] += duration_ms
+            for b in _TOOL_DURATION_BUCKETS_MS:
+                if duration_ms <= b:
+                    rec["buckets"][b] += 1
+
+    def tool_duration_stats(self) -> Dict[str, Dict[str, Any]]:
+        """Return a snapshot copy of per-tool duration stats for export."""
+        with self._tool_durations_lock:
+            return {
+                tool: {
+                    "count": rec["count"],
+                    "sum_ms": rec["sum_ms"],
+                    "buckets": dict(rec["buckets"]),
+                }
+                for tool, rec in self._tool_durations.items()
+            }
 
     def set_session_id(self, session_id: str):
         """Set the current session ID for action logging."""
@@ -288,7 +327,9 @@ class SynapseHandler(NodeHandlerMixin, UsdHandlerMixin, RenderHandlerMixin, Tops
                     sequence=command.sequence,
                 )
 
+            _t0 = time.perf_counter()
             result = handler(command.payload)
+            self._record_tool_duration(cmd_type, (time.perf_counter() - _t0) * 1000.0)
 
             # Log action asynchronously — don't block the response path
             if cmd_type not in _READ_ONLY_COMMANDS:
@@ -1135,6 +1176,7 @@ class SynapseHandler(NodeHandlerMixin, UsdHandlerMixin, RenderHandlerMixin, Tops
             router_stats=router_stats,
             circuit_breaker_state=cb_state,
             memory_entry_count=memory_count,
+            tool_durations=self.tool_duration_stats(),
             live_snapshot=live_snapshot,
         )
         return {"format": "prometheus", "text": text}

--- a/python/synapse/server/handlers_memory.py
+++ b/python/synapse/server/handlers_memory.py
@@ -166,7 +166,22 @@ class MemoryHandlerMixin:
         from ..memory.scene_memory import get_memory_status
 
         sp = self._scene_paths()
-        return get_memory_status(sp["hip_dir"], sp["job_path"])
+        status = get_memory_status(sp["hip_dir"], sp["job_path"])
+
+        # Single source of truth (Contract 1): the live entry store (Store A,
+        # the JSONL-backed SynapseMemory) is the authority for "how many
+        # entries", not the markdown file stats. Surface it here so status no
+        # longer contradicts synapse_context -- which read 176 from the live
+        # store while status reported 0 from a near-empty markdown file.
+        try:
+            bridge = self._get_bridge()  # type: ignore[attr-defined]
+            synapse_mem = getattr(bridge, "_synapse", None)
+            if synapse_mem is not None:
+                status["entries_total"] = synapse_mem.store.count()
+        except Exception:
+            pass
+
+        return status
 
     def _handle_evolve_memory(self, payload: Dict) -> Dict:
         """Manually trigger memory evolution."""

--- a/python/synapse/server/metrics.py
+++ b/python/synapse/server/metrics.py
@@ -24,6 +24,7 @@ def render_prometheus(
     command_counts: Optional[Dict[str, int]] = None,
     circuit_breaker_state: str = "closed",
     memory_entry_count: int = 0,
+    tool_durations: Optional[Dict[str, Any]] = None,
     live_snapshot: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Render metrics in Prometheus text exposition format.
@@ -33,6 +34,7 @@ def render_prometheus(
         command_counts: Dict mapping command type to call count
         circuit_breaker_state: Current circuit breaker state string
         memory_entry_count: Number of entries in memory store
+        tool_durations: Per-tool duration stats {tool: {count, sum_ms, buckets}}
         live_snapshot: Optional MetricSnapshot dict from MetricsAggregator
 
     Returns:
@@ -81,6 +83,26 @@ def render_prometheus(
     lines.append("# HELP synapse_memory_entries_total Total entries in memory store")
     lines.append("# TYPE synapse_memory_entries_total gauge")
     lines.append(f"synapse_memory_entries_total {memory_entry_count}")
+
+    # Per-tool call duration histogram (Mile 0 observability spine)
+    if tool_durations:
+        lines.append("")
+        lines.append("# HELP synapse_tool_duration_ms Per-tool call duration in milliseconds")
+        lines.append("# TYPE synapse_tool_duration_ms histogram")
+        for tool, rec in sorted(tool_durations.items()):
+            buckets = rec.get("buckets", {})
+            for le in sorted(buckets, key=float):
+                lines.append(
+                    f'synapse_tool_duration_ms_bucket{{tool="{tool}",le="{le}"}} {buckets[le]}'
+                )
+            count = rec.get("count", 0)
+            lines.append(
+                f'synapse_tool_duration_ms_bucket{{tool="{tool}",le="+Inf"}} {count}'
+            )
+            lines.append(
+                f'synapse_tool_duration_ms_sum{{tool="{tool}"}} {round_float(rec.get("sum_ms", 0.0))}'
+            )
+            lines.append(f'synapse_tool_duration_ms_count{{tool="{tool}"}} {count}')
 
     # Live metrics (Sprint E) — scene, session, uptime
     if live_snapshot:


### PR DESCRIPTION
## Mile 0 of 6 — Observability spine

Latency refactor on-ramp. **Measurement only, zero code optimization** — this is the eval metric for Miles 1–4. Nothing downstream optimizes before duration data exists.

Derived from the Phase 0 read-only diagnostic (Contract 1). Decision taken at the gate: **Reconcile**, with the live JSONL entry store (Store A) as the single count/status authority.

### The bug, in one line each
- **C-3 (gauge lied):** `synapse_memory_entries_total` read `bridge._memory.get_all()`. The bridge has no `_memory` attribute (it is `_synapse`) and `SynapseMemory` has no `get_all()`; the swallowed `AttributeError` pinned the gauge at **0** regardless of contents. Live store held **176**.
- **C-1 (two stores, divergent counts):** `synapse_memory_status` read only markdown file stats (reporting `0/0.0/none`) while `synapse_context` reported **176** from the live JSONL store. Different stores, no reconciliation.
- **No per-tool timing:** every latency fix's gate is "did latency drop?" — unanswerable without per-tool duration data.

### Commits (atomic, one mutation each)
| SHA | Mutation | Files |
|---|---|---|
| `b231c39` | C-3: gauge → `bridge._synapse.store.count()` | `handlers.py` |
| `f3dfcf1` | C-1: status surfaces authoritative `entries_total` from Store A | `handlers_memory.py` |
| `d3a8cc6` | per-tool cumulative duration histogram on `/metrics` | `handlers.py`, `metrics.py` |

### Gate evidence
| Criterion | Before (live) | After (proven) |
|---|---|---|
| `synapse_memory_entries_total` | **0** (captured live, pre-fix) | **176** — standalone-proven vs a 176-entry store |
| status vs context count | status `0` / context `176` | both `176`, single authority — C-1 closed |
| per-tool histogram | absent | populated & valid: cumulative buckets monotonic, `le="+Inf"` == count, `_sum` present, ≥2 tools over a sample |

`render_prometheus()` gains a backward-compatible `tool_durations` kwarg; `handle()` is timed with `perf_counter` and accumulates a thread-safe per-tool histogram (buckets 5..5000ms).

### Verification
- Regression: `test_mcp_roundtrip`, `test_v5_features`, `test_live_metrics`, `test_handler_edge` + `-k metric/handler/memory` sweep → **all green**.
- The 3 `TestCharizardEvolution` failures are **pre-existing on clean master** (verified by checkout) — unrelated to this PR.

### Live gate caveat
Standalone proofs establish the mechanism end-to-end. The **live** `/metrics ≈176` check requires the running SYNAPSE MCP server to reimport/restart — the live server still holds old code (`entries_total 0`). The Houdini session was **not** restarted here; reload + `synapse_metrics` closes the live gate.

### Out of scope (parked, diagnosed not touched)
- **H-4**: `recent_activity` shows repeated `"## Session Summary"` (summary auto-derived from first content line).
- **C-2**: bodyless `### Session End` writes (`websocket.py:482`, `mcp/session.py:218`) — Contract 2 / Mile 1 write-path work.
- `sqlite_store.py` dormant — Reconcile keeps it parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-tool execution duration metrics now tracked and exported via Prometheus, providing detailed visibility into command performance.

* **Improvements**
  * Memory metrics collection enhanced with live store data integration for more accurate entry counting and status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->