### PR TITLE
Mile 1 — Prune scene-memory bloat: kill Session End stubs (C-2) + fix scene-dir path divergence

### DIFF
--- a/python/synapse/mcp/session.py
+++ b/python/synapse/mcp/session.py
@@ -214,7 +214,10 @@ class MCPSessionManager:
                     ),
                 })
 
-            # Write session end to memory.md
+            # Write session end to memory.md. Bodyless payload is intentional:
+            # write_session_end skips bare timestamps, so MCP session teardown
+            # leaves no '### Session End' stub (Mile 1 / C-2). Pass real
+            # accomplishments/next_actions/summary_text here to record one.
             write_session_end(paths["scene_dir"], {
                 "stopped_at": _time.strftime(
                     "%Y-%m-%dT%H:%M:%SZ", _time.gmtime(),

--- a/python/synapse/memory/scene_memory.py
+++ b/python/synapse/memory/scene_memory.py
@@ -322,19 +322,33 @@ def write_blocker(scene_dir: str, blocker: Dict[str, Any]) -> None:
 
 def write_session_end(scene_dir: str, summary: Dict[str, Any]) -> None:
     """
-    Append session end block.
-    summary: {stopped_at, next_actions, accomplishments}
+    Append a session-end block -- but only when there is something to record.
+
+    A bare timestamp (no accomplishments, next actions, or summary text) is
+    NOT written. Those bodyless writes produced the ~200 empty
+    '### Session End' stubs that bloated memory.md and slowed session-start
+    parsing (Mile 1 / C-2). Skipping them here is what stops the spam from
+    regrowing after a one-time prune.
+
+    summary: {stopped_at, summary_text, next_actions, accomplishments}
     """
+    accomplishments = summary.get("accomplishments", [])
+    next_actions = summary.get("next_actions", [])
+    summary_text = (summary.get("summary_text") or "").strip()
+
+    if not accomplishments and not next_actions and not summary_text:
+        return  # no body -> don't write a bare stub
+
     entry = (
         f"### Session End\n"
         f"- **Stopped at:** {summary.get('stopped_at', _now())}\n"
     )
-    accomplishments = summary.get("accomplishments", [])
+    if summary_text:
+        entry += f"\n{summary_text}\n"
     if accomplishments:
         entry += "- **Accomplished:**\n"
         for a in accomplishments:
             entry += f"  - {a}\n"
-    next_actions = summary.get("next_actions", [])
     if next_actions:
         entry += "- **Next:**\n"
         for n in next_actions:

--- a/python/synapse/memory/scene_memory.py
+++ b/python/synapse/memory/scene_memory.py
@@ -81,6 +81,21 @@ def _get_file_lock(path: str) -> _ProcessFileLock:
 # DIRECTORY & FILE MANAGEMENT
 # =============================================================================
 
+def resolve_hip_dir(hip_path: str) -> str:
+    """Resolve the directory whose ``claude/`` holds this scene's memory.
+
+    For a SAVED hip (a real file on disk) that is the file's parent directory.
+    For an UNSAVED/untitled hip (``hou.hipFile.path()`` returns a path that is
+    not yet a real file) it is the hip path itself.
+
+    Single source of truth: readers (status, context, query, project_setup)
+    and the writer (ensure_scene_structure) MUST resolve this identically, or
+    they read and write different ``claude/`` dirs for unsaved scenes.
+    """
+    hip_path = os.path.normpath(hip_path)
+    return os.path.dirname(hip_path) if os.path.isfile(hip_path) else hip_path
+
+
 def ensure_scene_structure(hip_path: str, job_path: str) -> Dict[str, str]:
     """
     Create claude/ directories at $JOB and $HIP levels if they don't exist.
@@ -94,7 +109,7 @@ def ensure_scene_structure(hip_path: str, job_path: str) -> Dict[str, str]:
     hip_path = os.path.normpath(hip_path)
     job_path = os.path.normpath(job_path)
 
-    hip_dir = os.path.dirname(hip_path) if os.path.isfile(hip_path) else hip_path
+    hip_dir = resolve_hip_dir(hip_path)
     hip_name = os.path.basename(hip_path)
     job_name = os.path.basename(job_path)
 

--- a/python/synapse/server/handlers_memory.py
+++ b/python/synapse/server/handlers_memory.py
@@ -35,10 +35,14 @@ class MemoryHandlerMixin:
             raise RuntimeError(_HOUDINI_UNAVAILABLE)
 
         from .main_thread import run_on_main
+        from ..memory.scene_memory import resolve_hip_dir
 
         def _on_main():
             hip_path = hou.hipFile.path()
-            hip_dir = os.path.dirname(hip_path)
+            # Must match the writer's scene-dir resolution (ensure_scene_structure)
+            # so reads land on the same claude/ dir writes use -- critical for
+            # unsaved/untitled scenes where dirname(hip) != the writer's dir.
+            hip_dir = resolve_hip_dir(hip_path)
             job_path = hou.getenv("JOB", hip_dir)
             return {"hip_path": hip_path, "hip_dir": hip_dir, "job_path": job_path}
 

--- a/python/synapse/server/websocket.py
+++ b/python/synapse/server/websocket.py
@@ -450,11 +450,19 @@ class SynapseServer:
                 self._session_manager.remove_by_client(client_id)
 
             # End session
+            session_had_activity = False
+            session_summary_text = ""
             if session_id:
                 try:
                     bridge = get_bridge()
+                    ended = bridge.get_session(session_id)  # capture before pop
+                    if ended:
+                        session_had_activity = (
+                            ended.commands_executed > 0 or bool(ended.nodes_created)
+                        )
                     summary = bridge.end_session(session_id)
                     if summary:
+                        session_summary_text = summary
                         logger.info("Session summary:\n%s", summary)
                 except Exception as e:
                     logger.error("End session error: %s", e)
@@ -478,9 +486,12 @@ class SynapseServer:
                                 "summary_text": f"Session ended (client: {client_id})",
                             })
 
-                        # Write session end to memory.md
+                        # Write session end to memory.md -- only a consolidated
+                        # summary for sessions that actually did something. Empty
+                        # sessions write nothing (no '### Session End' stub).
                         write_session_end(paths["scene_dir"], {
                             "stopped_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                            "summary_text": session_summary_text if session_had_activity else "",
                         })
                 except Exception as e:
                     logger.warning("Living Memory disconnect hook error: %s", e)

--- a/python/synapse/session/tracker.py
+++ b/python/synapse/session/tracker.py
@@ -514,10 +514,12 @@ class SynapseBridge:
         # Living Memory: merge file-based memory
         file_context = {}
         try:
-            from ..memory.scene_memory import load_full_context
+            from ..memory.scene_memory import load_full_context, resolve_hip_dir
             if HOU_AVAILABLE:
                 hip_path = hou.hipFile.path()
-                hip_dir = os.path.dirname(hip_path)
+                # Match the writer's scene-dir resolution so unsaved scenes
+                # load from the same claude/ dir they were written to.
+                hip_dir = resolve_hip_dir(hip_path)
                 job_path = hou.getenv("JOB", hip_dir)
                 file_context = load_full_context(hip_dir, job_path)
         except Exception as e:

--- a/tests/test_scene_memory.py
+++ b/tests/test_scene_memory.py
@@ -216,6 +216,26 @@ class TestSessionWriteOps:
         assert "Render turntable" in content
         assert "---" in content  # separator
 
+    def test_scene_dir_read_write_agree_unsaved_hip(self, tmp_path):
+        """Readers and the writer must resolve the same claude/ dir.
+
+        Regression: _scene_paths/handle_memory_context used dirname(hip)
+        while ensure_scene_structure used the hip path itself for unsaved
+        scenes, so status/context read an empty dir while writes landed
+        elsewhere. resolve_hip_dir is now the single source of truth.
+        """
+        import os as _os
+        # Unsaved hip: a path that is NOT a real file on disk.
+        hip = str(tmp_path / "untitled.hip")
+        paths = sm.ensure_scene_structure(hip, hip)
+        reader_scene_dir = _os.path.join(sm.resolve_hip_dir(hip), "claude")
+        assert _os.path.normpath(reader_scene_dir) == _os.path.normpath(paths["scene_dir"])
+
+        # Saved hip: a real file -> both resolve to its parent dir.
+        saved = tmp_path / "shot.hip"
+        saved.write_text("bgeo", encoding="utf-8")
+        assert sm.resolve_hip_dir(str(saved)) == _os.path.normpath(str(tmp_path))
+
     def test_write_session_end_skips_bare_stub(self, tmp_project):
         """Bodyless session-end (timestamp only) must NOT write a stub.
 

--- a/tests/test_scene_memory.py
+++ b/tests/test_scene_memory.py
@@ -216,6 +216,33 @@ class TestSessionWriteOps:
         assert "Render turntable" in content
         assert "---" in content  # separator
 
+    def test_write_session_end_skips_bare_stub(self, tmp_project):
+        """Bodyless session-end (timestamp only) must NOT write a stub.
+
+        Regression for C-2: ~200 empty '### Session End' blocks bloated
+        memory.md because the disconnect hook wrote a bare timestamp every
+        session. The writer now skips when there is no body.
+        """
+        result = sm.ensure_scene_structure(tmp_project["hip"], tmp_project["job"])
+        before = _P(result["scene_md"]).read_text(encoding="utf-8")
+        sm.write_session_end(result["scene_dir"], {
+            "stopped_at": "2026-05-30T15:00:00Z",
+        })
+        after = _P(result["scene_md"]).read_text(encoding="utf-8")
+        assert after == before, "bare session-end must not append anything"
+        assert "### Session End" not in after
+
+    def test_write_session_end_writes_summary_text(self, tmp_project):
+        """A consolidated summary_text IS written (meaningful session)."""
+        result = sm.ensure_scene_structure(tmp_project["hip"], tmp_project["job"])
+        sm.write_session_end(result["scene_dir"], {
+            "stopped_at": "2026-05-30T15:00:00Z",
+            "summary_text": "## Session Summary\n**Commands:** 12",
+        })
+        content = _P(result["scene_md"]).read_text(encoding="utf-8")
+        assert "### Session End" in content
+        assert "**Commands:** 12" in content
+
     def test_write_parameter_experiment(self, tmp_project):
         result = sm.ensure_scene_structure(tmp_project["hip"], tmp_project["job"])
         sm.write_parameter_experiment(result["scene_dir"], {


### PR DESCRIPTION
## Mile 1 of 6 — Prune scene-memory bloat

Top-ROI free win from the latency refactor: kill the `### Session End` spam, fix the writer so it can't regrow, and (folded in) fix the scene-dir path divergence that hid the bloat from `memory_status`.

### Commits (atomic, one mutation each)
| SHA | Mutation | Concern |
|---|---|---|
| `c64dda3` | `write_session_end` skips bodyless payloads; accepts `summary_text`; `websocket.py` passes a consolidated summary only for active sessions | **C-2** writer fix (1b) — prevents regrowth |
| `0e872d9` | `resolve_hip_dir()` single source of truth; used by writer + both readers (`_scene_paths`, `handle_memory_context`) | path-divergence fix (folded in) |

### Why
- **C-2:** disconnect hooks called `write_session_end` with only a timestamp every session → a bare `### Session End` block each time. **211 stubs** (14 KB) had piled into one scene's `memory.md`; session-start parses that on every load. The writer now writes nothing when there's no body — that's what stops regrowth after a one-time prune.
- **Path divergence:** readers resolved the scene dir as `dirname(hip_path)`, the writer used the hip path itself for **unsaved** hips. For `untitled.hip`, readers looked in `…/User/claude` while writes landed in `…/untitled.hip/claude` — which is exactly why `memory_status` reported `size_kb=0.0` against a 14 KB file. Now one `resolve_hip_dir()` is shared, so the divergence can't recur.

### Gate evidence
- Live scene `memory.md` pruned **backup-first** (`memory.md.prune.bak`, 14,292 B preserved): bare `### Session End` stubs **211 → 0** ✅; file **13.2 KB → 0.56 KB** (96%); the valuable 221-node Note preserved.
- Session-start parse (median, 25 runs): **2.23 ms → 2.06 ms**. Honest read: ~7% and near the noise floor at this 2 ms scale — the durable win is the 96% size cut (IO + context tokens on every load) and regrowth prevention, which scale with accumulation.
- *(The data prune is a one-time operation on a local scene file, not part of this code PR.)*

### Verification
- New tests: bodyless-skip, summary_text-written, read/write scene-dir agreement (saved + unsaved hips).
- `test_mcp_roundtrip` passes alone (21); `test_scene_memory` targeted suites green (26).
- The 5 failures seen in a combined `test_scene_memory + test_mcp_roundtrip` run are **pre-existing on clean master** (test-isolation pollution + the known `TestCharizardEvolution` set) — reproduced identically on master, not introduced here.

### Out of scope / follow-ups
- Other scenes still hold legacy stubs (`cinema_camera/examples` 57; `SYNAPSE/untitled.hip` 25, gitignored scratch). The writer fix stops regrowth everywhere; legacy prune offered separately.
- `load_full_context` never auto-surfaces `### Note` content (Note is retrievable via `memory_query`/`search`, just not in the summary) — pre-existing extraction limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
