### PR TITLE
Hardening — observability invariants (gauge==count) + reusable compact_memory tool

### DIFF
--- a/python/synapse/memory/scene_memory.py
+++ b/python/synapse/memory/scene_memory.py
@@ -373,6 +373,93 @@ def write_session_end(scene_dir: str, summary: Dict[str, Any]) -> None:
     _append_to_md(os.path.join(scene_dir, "memory.md"), entry)
 
 
+def _is_bare_session_end(section_lines: List[str]) -> bool:
+    """True if a '### ' section is a bodyless Session End (timestamp only)."""
+    if not section_lines or section_lines[0].strip() != "### Session End":
+        return False
+    body = [l for l in section_lines[1:] if l.strip() and l.strip() != "---"]
+    return len(body) == 1 and body[0].strip().startswith("- **Stopped at:**")
+
+
+def compact_memory(scene_dir: str, dry_run: bool = True, backup: bool = True) -> Dict[str, Any]:
+    """Strip bodyless '### Session End' stubs from a scene memory.md.
+
+    Idempotent maintenance op. Preserves the preamble and every section that
+    carries real content (Notes, decisions, session-ends WITH a body). Backs
+    up before writing so the prune is reversible. This is the reusable form of
+    the one-time Mile 1 prune -- safe to sweep across many scenes.
+
+    Returns a report: {path, exists, stubs_before, stubs_after, removed,
+                       bytes_before, bytes_after, changed, dry_run, backup_path}.
+    """
+    path = os.path.join(scene_dir, "memory.md")
+    report: Dict[str, Any] = {
+        "path": path, "exists": False, "stubs_before": 0, "stubs_after": 0,
+        "removed": 0, "bytes_before": 0, "bytes_after": 0,
+        "changed": False, "dry_run": dry_run, "backup_path": None,
+    }
+    if not os.path.exists(path):
+        return report
+
+    content = _read_file(path)
+    report["exists"] = True
+    report["stubs_before"] = content.count("### Session End")
+    report["bytes_before"] = len(content.encode("utf-8"))
+
+    # Parse into a preamble (everything before the first '### ' header) plus
+    # one section per '### ' header. Separator '---' lines are normalised away
+    # and re-added on join, so dropping a stub never orphans a separator.
+    preamble: List[str] = []
+    sections: List[List[str]] = []
+    cur: Optional[List[str]] = None
+    for ln in content.splitlines():
+        if ln.startswith("### "):
+            if cur is not None:
+                sections.append(cur)
+            cur = [ln]
+        elif cur is None:
+            preamble.append(ln)
+        else:
+            cur.append(ln)
+    if cur is not None:
+        sections.append(cur)
+
+    kept: List[str] = []
+    removed = 0
+    for sec in sections:
+        if _is_bare_session_end(sec):
+            removed += 1
+            continue
+        text = "\n".join(l for l in sec if l.strip() != "---").strip()
+        if text:
+            kept.append(text)
+
+    report["removed"] = removed
+    if removed == 0:
+        report["stubs_after"] = report["stubs_before"]
+        report["bytes_after"] = report["bytes_before"]
+        return report
+
+    pre = "\n".join(l for l in preamble if l.strip() != "---").rstrip()
+    parts = ([pre] if pre else []) + kept
+    new_content = "\n\n---\n\n".join(parts).rstrip() + "\n"
+    report["stubs_after"] = new_content.count("### Session End")
+    report["bytes_after"] = len(new_content.encode("utf-8"))
+    report["changed"] = True
+
+    if not dry_run:
+        if backup:
+            import shutil
+            backup_path = path + ".compact.bak"
+            shutil.copy2(path, backup_path)
+            report["backup_path"] = backup_path
+        with _get_file_lock(path):
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(new_content)
+
+    return report
+
+
 def write_memory_entry(scene_dir: str, entry: Dict[str, Any], entry_type: str) -> None:
     """
     Write a memory entry to the scene's memory file.

--- a/tests/test_metrics_invariants.py
+++ b/tests/test_metrics_invariants.py
@@ -1,0 +1,62 @@
+"""Observability invariants for the Mile 0 metrics spine.
+
+These pin the bugs that Mile 0 fixed so they cannot silently regress:
+- synapse_memory_entries_total must equal the live store's count (C-3).
+- the per-tool duration histogram must be a well-formed Prometheus histogram.
+"""
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "python"))
+
+from synapse.server.handlers import SynapseHandler  # noqa: E402
+from synapse.server.metrics import render_prometheus  # noqa: E402
+from synapse.memory.store import SynapseMemory  # noqa: E402
+from synapse.memory.models import MemoryType  # noqa: E402
+
+
+class _FakeBridge:
+    """Minimal stand-in exposing the attribute the gauge path reads."""
+    def __init__(self, synapse):
+        self._synapse = synapse
+
+
+def test_memory_gauge_equals_store_count(tmp_path):
+    """The Prometheus gauge must report the live store count, not 0.
+
+    Regression for C-3: the gauge read a non-existent bridge attribute and
+    was pinned at 0 against a populated store. The invariant is simply
+    gauge == bridge._synapse.store.count().
+    """
+    handler = SynapseHandler()
+    mem = SynapseMemory(project_path=str(tmp_path))
+    for i in range(37):
+        mem.add(content=f"entry {i}", memory_type=MemoryType.NOTE, source="test")
+
+    handler._bridge = _FakeBridge(mem)  # _get_bridge() returns cached _bridge
+    out = handler._handle_get_metrics({})
+    text = out["text"]
+
+    assert f"synapse_memory_entries_total {mem.store.count()}" in text
+    assert "synapse_memory_entries_total 37" in text
+    assert "synapse_memory_entries_total 0" not in text
+
+
+def test_tool_duration_histogram_is_well_formed():
+    """Per-tool histogram: cumulative buckets, +Inf == count, sum present."""
+    handler = SynapseHandler()
+    for ms in [3.0, 7.0, 40.0, 120.0, 600.0]:
+        handler._record_tool_duration("scene_info", ms)
+
+    stats = handler.tool_duration_stats()
+    buckets = stats["scene_info"]["buckets"]
+    ordered = [buckets[k] for k in sorted(buckets, key=float)]
+    assert ordered == sorted(ordered)                       # monotonic cumulative
+    assert max(ordered) <= stats["scene_info"]["count"]      # bounded by count
+
+    text = render_prometheus(memory_entry_count=0, tool_durations=stats)
+    assert 'synapse_tool_duration_ms_bucket{tool="scene_info",le="+Inf"} 5' in text
+    assert 'synapse_tool_duration_ms_count{tool="scene_info"} 5' in text
+    assert 'synapse_tool_duration_ms_sum{tool="scene_info"}' in text

--- a/tests/test_scene_memory.py
+++ b/tests/test_scene_memory.py
@@ -287,6 +287,58 @@ class TestSessionWriteOps:
         assert "SSS artifacts" in content
 
 
+class TestCompactMemory:
+    """Tests for compact_memory -- the reusable Session-End stub sweeper."""
+
+    def test_compact_removes_bare_keeps_content(self, tmp_path):
+        cd = tmp_path / "claude"; cd.mkdir()
+        md = cd / "memory.md"
+        md.write_text(
+            "# Scene Memory\n\n---\n\n"
+            "### Note\nReal content here.\n\n---\n\n"
+            "### Session End\n- **Stopped at:** 2026-01-01T00:00:00Z\n\n---\n\n"
+            "### Session End\n- **Stopped at:** 2026-01-02T00:00:00Z\n\n---\n\n"
+            "### Session End\n- **Stopped at:** 2026-01-03T00:00:00Z\n"
+            "- **Accomplished:**\n  - Did a thing\n\n---\n",
+            encoding="utf-8",
+        )
+        rep = sm.compact_memory(str(cd), dry_run=False)
+        content = md.read_text(encoding="utf-8")
+        assert rep["removed"] == 2          # the two bodyless stubs
+        assert rep["stubs_after"] == 1       # the one WITH a body survives
+        assert "Real content here." in content
+        assert "Did a thing" in content
+        assert rep["backup_path"] and _P(rep["backup_path"]).exists()
+
+    def test_compact_dry_run_does_not_write(self, tmp_path):
+        cd = tmp_path / "claude"; cd.mkdir()
+        md = cd / "memory.md"
+        original = "### Session End\n- **Stopped at:** 2026-01-01T00:00:00Z\n\n---\n"
+        md.write_text(original, encoding="utf-8")
+        rep = sm.compact_memory(str(cd), dry_run=True)
+        assert rep["removed"] == 1
+        assert rep["changed"] is True
+        assert md.read_text(encoding="utf-8") == original   # untouched
+        assert rep["backup_path"] is None
+
+    def test_compact_idempotent(self, tmp_path):
+        cd = tmp_path / "claude"; cd.mkdir()
+        md = cd / "memory.md"
+        md.write_text(
+            "### Note\nx\n\n---\n\n### Session End\n- **Stopped at:** T\n\n---\n",
+            encoding="utf-8",
+        )
+        sm.compact_memory(str(cd), dry_run=False, backup=False)
+        rep2 = sm.compact_memory(str(cd), dry_run=False, backup=False)
+        assert rep2["removed"] == 0
+        assert rep2["changed"] is False
+
+    def test_compact_missing_file(self, tmp_path):
+        rep = sm.compact_memory(str(tmp_path / "claude"), dry_run=True)
+        assert rep["exists"] is False
+        assert rep["removed"] == 0
+
+
 class TestLoadMemory:
     """Tests for load_memory and load_full_context."""
 


### PR DESCRIPTION
## Hardening pass — observability invariants + reusable memory compaction

Turns two Mile 0/1 manual verifications into permanent, automated capabilities. No behavior change to runtime paths; pure hardening + a maintenance tool.

### Commits
| SHA | Mutation |
|---|---|
| `a93d15d` | `compact_memory()` — reusable, tested Session-End stub sweeper |
| `83b67be` | metrics invariants test — gauge==count + histogram shape |

### `compact_memory(scene_dir, dry_run=True, backup=True)`
Promotes the one-time Mile 1 prune into an idempotent maintenance op:
- Backup-first (`memory.md.compact.bak`), reversible.
- Preserves the preamble and every section with real content (Notes, decisions, session-ends **with a body**); drops only bodyless `### Session End` stubs.
- Section-aware parse handles embedded stubs that the ad-hoc `---` split missed (no orphaned separators).
- `dry_run=True` default — safe to preview before writing.
- 4 tests: remove-bare/keep-content, dry-run-no-write, idempotent, missing-file.

### Metrics invariants (`test_metrics_invariants.py`)
- **`gauge == bridge._synapse.store.count()`** via the real `_handle_get_metrics` path — catches the C-3 "metric lies" class forever (37-entry store → gauge 37, never 0).
- Histogram well-formedness: cumulative buckets monotonic, `le="+Inf"` == count, `_sum` present.

### Why
The Mile 0 live-gate and the Mile 1 prune were both manual checks. These convert them into invariants/tools, per the single-source-of-truth theme: stop relying on a human to notice the metric lied or the bloat returned.

### Note
The mass data-sweep of *other* scenes' legacy stubs (cinema_camera, gitignored scratch) is intentionally **not** in this PR — it's a destructive op on out-of-repo personal files and awaits explicit per-target confirmation. The tool that does it safely is what ships here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
