### PR TITLE
Mile 3a — default inspect_node include_geometry=false (+ order-independent test fixture)

### DIFF
--- a/python/synapse/mcp/_tool_registry.py
+++ b/python/synapse/mcp/_tool_registry.py
@@ -791,7 +791,7 @@ TOOL_DEFS: list[tuple] = [
      {"type": "object", "properties": {
          "node": {"type": "string", "description": "Full node path"},
          "include_code": {"type": "boolean", "description": "Include VEX/Python code (default: true)"},
-         "include_geometry": {"type": "boolean", "description": "Include geometry attributes (default: true)"},
+         "include_geometry": {"type": "boolean", "description": "Include geometry attributes -- point/prim counts, bounds, attrs (default: false; opt in when you need geo)"},
          "include_expressions": {"type": "boolean", "description": "Include expressions (default: true)"},
      }, "required": ["node"]},
      True, False, True),

--- a/python/synapse/server/handlers.py
+++ b/python/synapse/server/handlers.py
@@ -1137,7 +1137,10 @@ class SynapseHandler(NodeHandlerMixin, UsdHandlerMixin, RenderHandlerMixin, Tops
         from .main_thread import run_on_main
         node_path = resolve_param(payload, "node")
         include_code = resolve_param_with_default(payload, "include_code", True)
-        include_geometry = resolve_param_with_default(payload, "include_geometry", True)
+        # Geometry is the expensive part of an inspect (full _geometry_summary).
+        # Default it OFF so the common "what are this node's parms/code" inspect
+        # stays cheap; callers opt in with include_geometry=true (Mile 3a).
+        include_geometry = resolve_param_with_default(payload, "include_geometry", False)
         include_expressions = resolve_param_with_default(payload, "include_expressions", True)
         return run_on_main(lambda: inspect_node_detail(
             node_path=node_path,

--- a/tests/test_inspect_node_default.py
+++ b/tests/test_inspect_node_default.py
@@ -1,0 +1,42 @@
+"""Mile 3a: synapse_inspect_node defaults to include_geometry=False.
+
+Geometry is the expensive part of an inspect. The handler must NOT fetch it
+unless the caller opts in, and must still honor an explicit request.
+"""
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "python"))
+
+from synapse.server import handlers as handlers_mod  # noqa: E402
+from synapse.server import introspection as introspection_mod  # noqa: E402
+from synapse.server import main_thread as main_thread_mod  # noqa: E402
+
+
+def _capture_include_geometry(monkeypatch, payload):
+    captured = {}
+
+    def fake_detail(node_path, include_code=True, include_geometry=True,
+                    include_expressions=True):
+        captured["include_geometry"] = include_geometry
+        return {"ok": True}
+
+    monkeypatch.setattr(handlers_mod, "HOU_AVAILABLE", True)
+    monkeypatch.setattr(introspection_mod, "inspect_node_detail", fake_detail)
+    monkeypatch.setattr(main_thread_mod, "run_on_main", lambda fn: fn())
+
+    handler = handlers_mod.SynapseHandler()
+    handler._handle_inspect_node(payload)
+    return captured["include_geometry"]
+
+
+def test_inspect_node_omits_geometry_by_default(monkeypatch):
+    assert _capture_include_geometry(monkeypatch, {"node": "/obj/geo1"}) is False
+
+
+def test_inspect_node_honors_explicit_geometry(monkeypatch):
+    assert _capture_include_geometry(
+        monkeypatch, {"node": "/obj/geo1", "include_geometry": True}
+    ) is True

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -492,13 +492,28 @@ class TestExecutePythonEnhancements:
     @pytest.fixture(autouse=True)
     def handler(self):
         import synapse.server.handlers as handlers_mod
-        # Patch the hou reference that the handler module actually uses
-        # (may differ from sys.modules["hou"] if other tests replaced it)
-        self._handlers_hou = handlers_mod.hou
+        # Order-independent: handlers_mod may have no `hou` attribute at all
+        # (it only binds one when `import hou` succeeds), depending on which
+        # test files imported it first. Save/restore both hou and
+        # HOU_AVAILABLE so this fixture works regardless of collection order.
+        had_hou = hasattr(handlers_mod, "hou")
+        saved_hou = getattr(handlers_mod, "hou", None)
+        saved_avail = handlers_mod.HOU_AVAILABLE
+
+        hou_ref = saved_hou if saved_hou is not None else MagicMock()
         # Ensure undos mock exists on the actual hou reference
-        if not hasattr(self._handlers_hou, "undos") or not hasattr(self._handlers_hou.undos, "group"):
-            self._handlers_hou.undos = MagicMock()
+        if not hasattr(hou_ref, "undos") or not hasattr(hou_ref.undos, "group"):
+            hou_ref.undos = MagicMock()
+        handlers_mod.hou = hou_ref
+        handlers_mod.HOU_AVAILABLE = True
+        self._handlers_hou = hou_ref
         self.h = handlers_mod.SynapseHandler()
+        yield
+        handlers_mod.HOU_AVAILABLE = saved_avail
+        if had_hou:
+            handlers_mod.hou = saved_hou
+        elif hasattr(handlers_mod, "hou"):
+            del handlers_mod.hou
 
     def test_dry_run_valid_code(self):
         result = self.h._handle_execute_python({


### PR DESCRIPTION
## Mile 3a — cheap, safe half of the caching mile

Mile 3 splits into a **safe toggle** (this PR) and a **risky cache** (deferred). Recon verified the Blueprint's three premises against code first:

| Premise | Finding |
|---|---|
| "mandatory pre-flight inspect" | **Overstated** — advisory only (tool-desc / agent-loop), nothing structural enforces it |
| "no dirty-flag cache" | **True** — no read-cache for scene_info/get_parm/stage_info |
| "inspect fetches everything" | **True** — `inspect_node include_geometry=True` by default |

So the one clearly-correct, low-risk win ships now; the cache waits for evidence.

### Change (Mile 3a)
- `synapse_inspect_node` now defaults **`include_geometry=False`** (handler `handlers.py`), schema doc updated. Geometry (`_geometry_summary`) is the expensive part; the common "parms/code/HDA" inspect stays cheap. Callers opt in with `include_geometry=true`. `resources.py` already passed `False` explicitly — unaffected.
- Tests: default omits geometry; explicit `true` honored (Houdini-free spy test).

### Folded-in fix
- `test_introspection.py` execute-python fixture made **order-independent**: it saved `handlers_mod.hou` unconditionally, but `handlers.py` only binds `hou` when `import hou` succeeds. Any handler-importing test file collected first (the already-merged `test_metrics_invariants`, or this PR's new test) caused 6 setup errors; CI's alphabetical order happened to hide it. Now saves/restores `hou` + `HOU_AVAILABLE`.

### Deliberately NOT here — Mile 3b (the cache)
The dirty-flag cache for scene_info/get_parm/stage_info is the high-blast-radius, **safety-sensitive** part (stale cache = wrong scene state returned to Claude). Its ROI is unproven without live Mile 0 timing, and "mandatory pre-flight inspect" (its main rationale) turned out to be advisory, not structural. Held for live timing data + a dedicated CRUCIBLE pass.

### Verification
- New tests green; full suite identical to master (15 pre-existing env failures — `pxr`-present-locally `NoOpWithoutPxr`/Charizard — **zero regressions**, verified by failure-set diff vs master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified `inspect_node` to exclude geometry by default; geometry inspection now requires explicit request via the `include_geometry` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->