### PR TITLE
feat(memory): Mile 2 — deterministic HashEmbedder (Moneta integration)

### DIFF
--- a/python/synapse/memory/__init__.py
+++ b/python/synapse/memory/__init__.py
@@ -43,6 +43,11 @@ from .markdown import (
     parse_context_md,
 )
 
+from .embedding import (
+    Embedder,
+    HashEmbedder,
+)
+
 __all__ = [
     # Models
     'Memory',
@@ -77,4 +82,8 @@ __all__ = [
     'parse_decisions_md',
     'render_decisions_md',
     'parse_context_md',
+
+    # Embedding
+    'Embedder',
+    'HashEmbedder',
 ]

--- a/python/synapse/memory/embedding.py
+++ b/python/synapse/memory/embedding.py
@@ -1,0 +1,116 @@
+"""Deterministic, dependency-free text embedder for SYNAPSE memory.
+
+Mile 2 of the Moneta <-> SYNAPSE integration (see
+``docs/MONETA_SYNAPSE_INTEGRATION_HARNESS.md`` section 5 and the Mile 2 handoff
+capsule). This is the *bootstrap* embedder: per harness falsification condition
+FC2, the embedding source must be deterministic, offline-capable, and instant so
+it can never block the build. A local semantic model (MiniLM-class) swaps in
+behind the same :class:`Embedder` interface at the quality pass.
+
+Each deposit is stamped with the embedder's :attr:`Embedder.id` for provenance:
+hash vectors and semantic vectors live in different spaces and are not
+comparable, so a later swap queries by id, finds non-matching entries, and
+re-embeds them (handoff capsule, "PARKED" section).
+
+Pure Python. Zero third-party deps. No Houdini, no Moneta, no pxr. Importable
+and testable standalone.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections import Counter
+from typing import Iterator, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Embedder(Protocol):
+    """A pinned, deterministic text -> vector map.
+
+    Implementations MUST be pure functions of their input: the same text yields
+    the same vector on every call and across process restarts (no randomness, no
+    network, no dependence on ``PYTHONHASHSEED``). The returned vector is always
+    exactly :attr:`dim` long and, for any non-empty input, L2-normalized.
+    """
+
+    id: str   # pinned identifier, stamped onto deposits for provenance
+    dim: int
+
+    def embed(self, text: str) -> list[float]:
+        ...
+
+
+class HashEmbedder:
+    """Feature-hashing embedder over character n-grams.
+
+    Maps character n-grams into a fixed-dimension vector via the "hashing
+    trick", with a sign hash so collisions cancel in expectation rather than
+    always accumulating. The hash is :mod:`hashlib`-based (BLAKE2b), so output is
+    independent of ``PYTHONHASHSEED`` and identical across processes, platforms,
+    and Python versions -- unlike the built-in :func:`hash`, which is salted
+    per process for ``str``.
+
+    Contract:
+
+    * **deterministic** -- same text -> identical vector, across calls and
+      across process restarts.
+    * **fixed length** -- every output is exactly :attr:`dim` floats.
+    * **normalized** -- ``||v|| == 1`` for every non-empty input. The empty
+      string is the sole input that returns the zero vector.
+
+    n-grams span ``ngram_min..ngram_max`` characters. Including unigrams
+    (``ngram_min == 1``) guarantees any non-empty string yields at least one
+    feature, so the only zero vector comes from the empty string.
+    """
+
+    _FAMILY = "hash-ngram-v1"
+
+    def __init__(self, dim: int = 256, ngram_min: int = 1, ngram_max: int = 3) -> None:
+        if dim <= 0:
+            raise ValueError(f"dim must be positive, got {dim}")
+        if not (1 <= ngram_min <= ngram_max):
+            raise ValueError(
+                f"require 1 <= ngram_min <= ngram_max, got "
+                f"ngram_min={ngram_min}, ngram_max={ngram_max}"
+            )
+        self.dim = dim
+        self.ngram_min = ngram_min
+        self.ngram_max = ngram_max
+        # id encodes every parameter that defines the vector space so a swap --
+        # or even a re-config -- is detectable from the stamped provenance.
+        self.id = f"{self._FAMILY}-d{dim}-n{ngram_min}_{ngram_max}"
+
+    def _ngrams(self, text: str) -> Iterator[str]:
+        n_chars = len(text)
+        for n in range(self.ngram_min, self.ngram_max + 1):
+            if n_chars < n:
+                break
+            for i in range(n_chars - n + 1):
+                yield text[i:i + n]
+
+    def embed(self, text: str) -> list[float]:
+        vec = [0.0] * self.dim
+        # Counter dedups identical n-grams so each is hashed once, weighted by
+        # frequency. Bounds work on very long text: unique n-grams plateau.
+        counts = Counter(self._ngrams(text))
+        for token, weight in counts.items():
+            digest = hashlib.blake2b(token.encode("utf-8"), digest_size=9).digest()
+            bucket = int.from_bytes(digest[:8], "big") % self.dim
+            sign = 1.0 if (digest[8] & 1) else -1.0
+            vec[bucket] += sign * weight
+
+        norm = math.sqrt(sum(x * x for x in vec))
+        if norm != 0.0:
+            return [x / norm for x in vec]
+
+        if not text:
+            # The empty string produces no n-grams -> zero vector. This is the
+            # documented, deterministic degenerate output.
+            return vec
+        # Non-empty but fully cancelled (reachable only for tiny ``dim`` or
+        # adversarial input where signed buckets sum to exactly zero): fall back
+        # to a deterministic unit spike so "non-empty => unit norm" always holds.
+        digest = hashlib.blake2b(text.encode("utf-8"), digest_size=8).digest()
+        vec[int.from_bytes(digest, "big") % self.dim] = 1.0
+        return vec

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,0 +1,204 @@
+"""CRUCIBLE suite for synapse.memory.embedding (Mile 2 bootstrap embedder).
+
+Hostile by design. The contract under attack (handoff capsule "FIRST TASK"):
+
+  * determinism    -- same input -> identical vector, across calls AND across
+                      process restarts (the real trap: str hash() is salted by
+                      PYTHONHASHSEED, so a naive impl passes in-process and fails
+                      across processes).
+  * fixed dim      -- every output is exactly ``dim`` long.
+  * normalization  -- ||v|| == 1 for non-empty input.
+  * edges          -- empty, whitespace-only, unicode, very long, near-dupes.
+
+Pure standalone: no Houdini, no Moneta, no pxr. Never weaken a test to pass --
+fix forward.
+"""
+
+import json
+import math
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_PYDIR = _ROOT / "python"
+sys.path.insert(0, str(_PYDIR))
+
+from synapse.memory.embedding import Embedder, HashEmbedder  # noqa: E402
+
+TOL = 1e-9
+
+
+def _norm(v):
+    return math.sqrt(sum(x * x for x in v))
+
+
+def _cosine(a, b):
+    return sum(x * y for x, y in zip(a, b))  # both unit vectors
+
+
+# --------------------------------------------------------------------------- #
+# interface / provenance
+# --------------------------------------------------------------------------- #
+
+def test_implements_embedder_protocol():
+    assert isinstance(HashEmbedder(), Embedder)
+
+
+def test_id_and_dim_exposed():
+    emb = HashEmbedder()
+    assert emb.dim == 256
+    assert emb.id.startswith("hash-ngram-v1")
+    # id must encode every parameter that defines the vector space, so a swap
+    # or re-config is detectable from stamped provenance.
+    assert emb.id == "hash-ngram-v1-d256-n1_3"
+    assert HashEmbedder(dim=384).id == "hash-ngram-v1-d384-n1_3"
+    assert HashEmbedder(dim=256).id != HashEmbedder(dim=384).id
+    assert HashEmbedder(ngram_max=4).id != HashEmbedder(ngram_max=3).id
+
+
+def test_invalid_construction_rejected():
+    with pytest.raises(ValueError):
+        HashEmbedder(dim=0)
+    with pytest.raises(ValueError):
+        HashEmbedder(dim=-5)
+    with pytest.raises(ValueError):
+        HashEmbedder(ngram_min=0)
+    with pytest.raises(ValueError):
+        HashEmbedder(ngram_min=3, ngram_max=2)
+
+
+# --------------------------------------------------------------------------- #
+# fixed dim
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("dim", [2, 16, 256, 384, 1000])
+def test_fixed_dim_holds_for_every_input(dim):
+    emb = HashEmbedder(dim=dim)
+    for text in ["", " ", "a", "hello world", "x" * 5000, "café 🧠 déjà"]:
+        v = emb.embed(text)
+        assert isinstance(v, list)
+        assert len(v) == dim
+        assert all(isinstance(x, float) for x in v)
+
+
+# --------------------------------------------------------------------------- #
+# determinism
+# --------------------------------------------------------------------------- #
+
+def test_determinism_same_process():
+    emb = HashEmbedder()
+    text = "Synapse routes tasks to specialist agents."
+    assert emb.embed(text) == emb.embed(text)
+    # Two independent instances with identical config agree exactly.
+    assert HashEmbedder().embed(text) == HashEmbedder().embed(text)
+
+
+# This is the load-bearing test. A naive implementation built on the built-in
+# hash() for str passes every in-process check and silently fails here, because
+# CPython salts str/bytes hashing per process (PYTHONHASHSEED). Vectors stamped
+# into Moneta deposits would then differ run-to-run -- catastrophic for recall.
+def test_determinism_across_processes_and_hashseed():
+    driver = (
+        "import sys, json;"
+        f"sys.path.insert(0, {str(_PYDIR)!r});"
+        "from synapse.memory.embedding import HashEmbedder;"
+        "print(json.dumps(HashEmbedder().embed('Synapse\\u2194Moneta caf\\u00e9 "
+        "\\U0001f9e0 d\\u00e9j\\u00e0 vu')))"
+    )
+
+    def run(seed):
+        env = dict(os.environ)
+        env["PYTHONHASHSEED"] = seed
+        out = subprocess.check_output([sys.executable, "-c", driver], env=env)
+        return json.loads(out)
+
+    a = run("0")
+    b = run("1")
+    c = run("123456789")
+    assert a == b == c
+    assert abs(_norm(a) - 1.0) < 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# normalization
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("text", [
+    "a",
+    "hello",
+    "The quick brown fox jumps over the lazy dog.",
+    "   ",                       # whitespace-only is NON-empty -> must normalize
+    "\t\n  \r",
+    "café déjà vu naïve",        # latin-1 supplement
+    "日本語のテキスト",            # CJK
+    "🧠🔥✨ emoji run 🚀",          # astral plane
+    # Wrapped in pytest.param with an explicit id: a 100k-char value used as a
+    # raw param becomes the node id, which pytest writes into PYTEST_CURRENT_TEST
+    # -- and Windows caps env vars at 32767 chars, erroring at teardown.
+    pytest.param("a" * 100_000, id="very-long"),
+])
+def test_unit_norm_for_nonempty(text):
+    v = HashEmbedder().embed(text)
+    assert abs(_norm(v) - 1.0) < 1e-6
+
+
+def test_empty_string_is_the_only_zero_vector():
+    v = HashEmbedder().embed("")
+    assert len(v) == 256
+    assert _norm(v) == 0.0
+    assert all(x == 0.0 for x in v)
+
+
+def test_tiny_dim_nonempty_still_unit_norm():
+    # Adversarial: with dim this small the signed buckets can sum to exactly
+    # zero. The fallback unit-spike must still deliver a normalized vector.
+    emb = HashEmbedder(dim=2)
+    for text in ["a", "ab", "abc", "the cat sat", "  ", "🧠"]:
+        v = emb.embed(text)
+        assert len(v) == 2
+        assert abs(_norm(v) - 1.0) < 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# discrimination / near-duplicates
+# --------------------------------------------------------------------------- #
+
+def test_distinct_inputs_give_distinct_vectors():
+    emb = HashEmbedder()
+    a = emb.embed("render the karma beauty pass")
+    b = emb.embed("evolve the scene memory to charizard")
+    assert a != b
+    assert _cosine(a, b) < 0.99
+
+
+def test_near_duplicates_are_close_but_not_identical():
+    emb = HashEmbedder()
+    base = "The shot is rendering on the farm tonight."
+    near = "The shot is rendering on the farm tonigth."  # one transposition
+    va, vn = emb.embed(base), emb.embed(near)
+    assert va != vn
+    sim = _cosine(va, vn)
+    assert 0.85 < sim < 1.0  # sensitive, yet stable under a tiny edit
+
+
+def test_unicode_is_deterministic_and_distinct():
+    emb = HashEmbedder()
+    assert emb.embed("naïve café") == emb.embed("naïve café")
+    assert emb.embed("café") != emb.embed("cafe")  # accent is signal, not noise
+
+
+# --------------------------------------------------------------------------- #
+# performance guard for "very long text"
+# --------------------------------------------------------------------------- #
+
+def test_very_long_text_terminates_cheaply():
+    # Counter-dedup keeps this bounded by the count of UNIQUE n-grams, which
+    # plateaus, not by raw length. Half a megabyte must embed without blowing up.
+    emb = HashEmbedder()
+    v = emb.embed("lorem ipsum dolor sit amet " * 20_000)
+    assert len(v) == 256
+    assert abs(_norm(v) - 1.0) < 1e-6


### PR DESCRIPTION
## Mile 2 — Moneta↔SYNAPSE integration harness

The embedding source is the hard prerequisite for the Moneta backend (harness **FC2**): it must be **deterministic, offline-capable, and instant** so it can never block the build. This lands the *bootstrap* embedder; a local semantic model (MiniLM-class) swaps in behind the same `Embedder` interface at the quality pass.

### What's here
- **`synapse.memory.embedding`** — `Embedder` Protocol (`id`, `dim`, `embed`) + `HashEmbedder`:
  - Char n-gram (1–3) feature hashing with a **signed-bucket "hashing trick"** so collisions cancel in expectation rather than always accumulating.
  - **BLAKE2b**, not the built-in `hash()`. CPython salts `str` hashing per process (`PYTHONHASHSEED`), so a naive impl passes in-process and silently produces different vectors across restarts — fatal for stored-vector recall. `hashlib` is seed-independent and identical across processes / platforms / Python versions.
  - **Contract:** deterministic · fixed `dim` · L2-normalized for non-empty input · the empty string is the *sole* zero vector · tiny-dim total-cancellation falls back to a deterministic unit spike so "non-empty ⇒ unit norm" is total.
  - `id` encodes `dim` + n-gram range, so a later embedder swap is detectable from stamped deposit provenance (the parked re-embed mechanism for the Mile-8 backfill).
  - Pure Python, **zero deps**, no Houdini / Moneta / pxr. Plus a curated `__init__` export.

### Tests — 25 hostile CRUCIBLE cases, all green
`tests/test_embedding.py` covers the four capsule axes + adversarial cases:
- **`test_determinism_across_processes_and_hashseed`** (load-bearing): spawns child processes with `PYTHONHASHSEED` = `0` / `1` / `123456789`, embeds the same unicode string, asserts **bit-identical** output. A `hash()`-based impl fails this.
- Fixed dim across `dim ∈ {2,16,256,384,1000}`; unit-norm battery (whitespace-only, latin-1, CJK, astral-plane emoji, 100k chars); empty-is-only-zero-vector; tiny-dim cancellation fallback; near-duplicate sensitivity (`0.85 < cos < 1.0`); invalid-construction rejection.

### Scope / halts
- **No Mile-4 adapter code.** `MonetaBackedStore` is gated on the unratified Reconcile→Replace reversal — not in this PR.
- No Moneta API surface is used, so no `dir()` H21 verification was owed. Fully standalone.
- 3 pre-existing `TestCharizardEvolution` failures are pxr-env and unrelated (the only shared-file change is an `__init__` export; full memory suite otherwise green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public text embedding interface with configurable dimensions and n-gram parameters. Generates deterministic, normalized vectors for consistent embedding output across processes.

* **Tests**
  * Added comprehensive test suite validating embedding determinism, normalization, parameter validation, and performance characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->