### PR TITLE
feat(memory): Moneta backend — Miles 3–8 (flag-gated, default off)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="python/synapse/host/daemon.py"><img src="https://img.shields.io/badge/daemon-in--process-f59e0b.svg" alt="Daemon"></a>
   <a href="python/synapse/host/tops_bridge.py"><img src="https://img.shields.io/badge/perception-scaffolded-3b82f6.svg" alt="Perception"></a>
   <a href="python/synapse/memory/moneta_store.py"><img src="https://img.shields.io/badge/memory-Moneta%20backend-8b5cf6.svg" alt="Memory"></a>
-  <a href="tests"><img src="https://img.shields.io/badge/tests-3013%20passing-brightgreen.svg" alt="Tests"></a>
+  <a href="tests"><img src="https://img.shields.io/badge/tests-3021%20passing-brightgreen.svg" alt="Tests"></a>
 </p>
 
 ---
@@ -339,7 +339,11 @@ flowchart TB
     classDef eng fill:#334155,stroke:#f59e0b,color:#f1f5f9
 ```
 
-A four-agent **CRUCIBLE** fan-out attacked the backend and found two real defects — a protected-quota silent demotion and a corrupt-snapshot startup-killer — both fixed and pinned. The one item left live-gated is the async-server single-writer / deadlock check (FC4), so the production default-on flip is staged behind a live session; the flag stays `jsonl` until then. Full acceptance/falsifier status and the cutover procedure live in [`docs/MONETA_SYNAPSE_SHIP_REPORT.md`](docs/MONETA_SYNAPSE_SHIP_REPORT.md). The bespoke `evolution.py` USD memory-evolution is superseded by Moneta's consolidation and retired under the new backend.
+A four-agent **CRUCIBLE** fan-out attacked the backend and found two real defects — a protected-quota silent demotion and a corrupt-snapshot startup-killer — both fixed and pinned. A second ARCHITECT→FORGE→CRUCIBLE pass then closed the **FC4 single-writer gap by construction**: a serialization `RLock` makes the adapter thread-safe (the engine's swap-and-pop index can no longer be corrupted by concurrent deposit/iterate/prune), and because the adapter makes zero `hou.*` calls the lock is never held across the main-thread hop — so it can't deadlock the async server. Proven standalone by a concurrency stress suite; the destructive `run_sleep_pass` is now auditable (returns/logs exactly what it pruned). The production default-on flip is still staged (flag stays `jsonl`), but no longer blocked on live thread-safety verification. Full acceptance/falsifier status and the cutover procedure live in [`docs/MONETA_SYNAPSE_SHIP_REPORT.md`](docs/MONETA_SYNAPSE_SHIP_REPORT.md).
+
+The memory store's bespoke `python/synapse/memory/evolution.py` (the charmander→charizard USD evolution) is superseded by Moneta's consolidation — it stays **dormant** under the `moneta` backend (pinned by `test_moneta_backend_never_fires_evolution`) and still fires under the default `jsonl`; physical removal is deferred to the cutover. (Distinct from `shared/evolution.py`, the MOE-orchestrator subsystem, which is unchanged.)
+
+> **On the name "Moneta":** the vector-memory engine wired in here ([repo](https://github.com/JosephOIbrahim/Moneta)) is a Python library; it is a *distinct project* from the similarly-named "Moneta (Nuke)" entry in the Portfolio thesis below (a planned DCC host). They historically share a working name but are not the same codebase.
 
 ---
 
@@ -482,7 +486,8 @@ python/synapse/
 ├── _vendor/                    # anthropic + deps, CP311 win_amd64
 └── ...                         # Sprint 2 Week 1 + prior subsystems
 
-tests/                          # 3013 passing
+tests/                          # 3021 local; ~66 are Moneta-gated (skip on a
+                                # clean clone / CI without the moneta package)
 docs/sprint3/                   # audits + design contracts + continuation
 docs/crucible_protocol.md       # manual Crucible runbook
 mcp_server.py                   # Sprint 2 WebSocket adapter (still shipping)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
   <a href="python/synapse/cognitive/dispatcher.py"><img src="https://img.shields.io/badge/dispatcher-Strangler%20Fig-1e293b.svg" alt="Dispatcher"></a>
   <a href="python/synapse/host/daemon.py"><img src="https://img.shields.io/badge/daemon-in--process-f59e0b.svg" alt="Daemon"></a>
   <a href="python/synapse/host/tops_bridge.py"><img src="https://img.shields.io/badge/perception-scaffolded-3b82f6.svg" alt="Perception"></a>
-  <a href="tests"><img src="https://img.shields.io/badge/tests-2901%20passing-brightgreen.svg" alt="Tests"></a>
+  <a href="python/synapse/memory/moneta_store.py"><img src="https://img.shields.io/badge/memory-Moneta%20backend-8b5cf6.svg" alt="Memory"></a>
+  <a href="tests"><img src="https://img.shields.io/badge/tests-3013%20passing-brightgreen.svg" alt="Tests"></a>
 </p>
 
 ---
@@ -316,6 +317,32 @@ Five real bugs the SCOUT→FORGE discipline caught (the `usdrender` phantom, `su
 
 ---
 
+### Memory substrate — Moneta vector engine (PR #14)
+
+The inside-out thesis applied to memory. SYNAPSE's scene/decision memory carried two unreconciled stores (a JSONL entry store and a markdown scene-memory file), a metrics gauge wired to a dead accessor, and empty session stubs — a divergence *class*, not a bug list. **Moneta** — a vector-native memory engine (`deposit` / `query` / `signal_attention` / consolidation, with time-decay and durability) — is introduced behind the unchanged `MemoryStore` interface so that divergence becomes **structurally impossible**: there is one store, and `count()` reads the engine's live entity count.
+
+It ships **shadow-first and flag-gated, default-off** (`SYNAPSE_MEMORY_BACKEND` = `jsonl` | `moneta` | `shadow`). Each SYNAPSE `Memory` is serialized whole into a Moneta deposit payload (byte-for-byte round-trip); a deterministic, dependency-free `HashEmbedder` (PYTHONHASHSEED-independent, swappable for a semantic model later) embeds the content; decision / show-tier / gate-source memories map to a `protected_floor` so pinned memories resist decay. Keyword search is **bit-identical** to the JSONL store (parity-by-construction); the shadow path dual-writes and diffs reads into a `ParityReport`, so cutover is justified by evidence, not hope.
+
+```mermaid
+%%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#1e293b','primaryTextColor':'#f1f5f9','primaryBorderColor':'#0f172a','lineColor':'#f59e0b','secondaryColor':'#334155','tertiaryColor':'#475569'}}}%%
+flowchart TB
+    C["Callers &mdash; unchanged<br/>synapse_context / search / recall<br/>session tracker"] --> SM["SynapseMemory facade"]
+    SM --> SEL{"SYNAPSE_MEMORY_BACKEND"}
+    SEL -->|"jsonl &mdash; default"| JS["MemoryStore<br/>(JSONL, append-only)"]:::def
+    SEL -->|shadow| SH["ShadowMemoryStore<br/>dual-write + ParityReport"]:::alt
+    SEL -->|moneta| MB["MonetaBackedStore<br/>full Memory &rarr; payload"]:::alt
+    SH -->|"authoritative read"| JS
+    SH -.->|"mirror + diff"| MB
+    MB --> ENG[("Moneta engine<br/>HashEmbedder &rarr; deposit/query<br/>decay &middot; consolidation &middot; protected_floor")]:::eng
+    classDef def fill:#1e293b,stroke:#22c55e,color:#f1f5f9
+    classDef alt fill:#1e293b,stroke:#8b5cf6,color:#f1f5f9
+    classDef eng fill:#334155,stroke:#f59e0b,color:#f1f5f9
+```
+
+A four-agent **CRUCIBLE** fan-out attacked the backend and found two real defects — a protected-quota silent demotion and a corrupt-snapshot startup-killer — both fixed and pinned. The one item left live-gated is the async-server single-writer / deadlock check (FC4), so the production default-on flip is staged behind a live session; the flag stays `jsonl` until then. Full acceptance/falsifier status and the cutover procedure live in [`docs/MONETA_SYNAPSE_SHIP_REPORT.md`](docs/MONETA_SYNAPSE_SHIP_REPORT.md). The bespoke `evolution.py` USD memory-evolution is superseded by Moneta's consolidation and retired under the new backend.
+
+---
+
 ### Sprint 3 progress — Mile 4 of 6 closed (Mile 5 prestaged)
 
 ```mermaid
@@ -445,10 +472,17 @@ python/synapse/
 │   ├── turn_handle.py          # Spike 2.4 — Future-shaped submit_turn return
 │   ├── tops_bridge.py          # Spike 3.1 — PDG event bridge (Phase A)
 │   └── scene_load_bridge.py    # Spike 3.2 — auto-warm on AfterLoad (Phase B)
+├── memory/                     # PR #14 — Moneta-backed memory substrate
+│   ├── embedding.py            # deterministic HashEmbedder (Embedder protocol)
+│   ├── moneta_runtime.py       # import-guarded Moneta access (pxr-free ephemeral)
+│   ├── moneta_store.py         # MonetaBackedStore (MemoryStore-compatible)
+│   ├── shadow_store.py         # dual-write + parity diff harness
+│   ├── backfill.py             # one-time JSONL → Moneta backfill (backup-first)
+│   └── store.py                # SynapseMemory + SYNAPSE_MEMORY_BACKEND selector
 ├── _vendor/                    # anthropic + deps, CP311 win_amd64
 └── ...                         # Sprint 2 Week 1 + prior subsystems
 
-tests/                          # 2874 passing
+tests/                          # 3013 passing
 docs/sprint3/                   # audits + design contracts + continuation
 docs/crucible_protocol.md       # manual Crucible runbook
 mcp_server.py                   # Sprint 2 WebSocket adapter (still shipping)

--- a/docs/MONETA_SYNAPSE_HANDOFF_Mile2.md
+++ b/docs/MONETA_SYNAPSE_HANDOFF_Mile2.md
@@ -1,0 +1,99 @@
+# CLAUDE CODE HANDOFF CAPSULE — Moneta ↔ SYNAPSE, Mile 2
+
+### Desktop → Code. Hand this to Claude Code **alongside** `MONETA_SYNAPSE_INTEGRATION_HARNESS.md`.
+
+> **Purpose:** transfer this session's verified ground truth + the locked embedder decision into
+> Claude Code so FORGE starts cold without re-discovering anything. The harness is the constitution;
+> this capsule is the current position + first task.
+
+---
+
+## WHERE WE ARE
+- **Mile 1 CLOSED.** Connectability proven end-to-end in graphical Houdini 21.0.671.
+- **Entering Mile 2:** build the bootstrap embedder.
+- Operating under `MONETA_SYNAPSE_INTEGRATION_HARNESS.md`. Lenses = ARCHITECT / FORGE / CRUCIBLE.
+  Mode = SIMULATED TEAM, SOLO spine. Marathon-mile structure; gate criteria cite line numbers.
+
+## VERIFIED GROUND TRUTH — do NOT re-verify (confirmed live in H21.0.671)
+- **Moneta imports from:** `C:\Users\User\Moneta\src` — **NOT** on graphical Houdini's path by
+  default (separate site-packages). Added via `sys.path.insert` for now. Packaging is a Mile 3 item.
+- **L0 PASSED 10/10:** `Moneta`, `MonetaConfig`, `MonetaConfig.ephemeral`, `deposit`, `query`,
+  `signal_attention`, `get_consolidation_manifest`, `run_sleep_pass`, `MockUsdTarget` all present.
+- **Op signatures (confirmed):**
+  ```
+  deposit(payload: str, embedding: List[float], protected_floor: float = 0.0) -> UUID
+  query(embedding: List[float], limit: int = 5) -> List[Memory]
+  signal_attention(weights: Dict[UUID, float]) -> None
+  get_consolidation_manifest() -> List[Memory]
+  run_sleep_pass() -> ConsolidationResult
+  ```
+- **MonetaConfig fields:** `storage_uri`, `quota_override`, `half_life_seconds`,
+  `embedding_dim (Optional[int])`, `max_entities`, `snapshot_path`, `wal_path`,
+  `vector_persist_path`, `mock_target_log_path`, `use_real_usd (bool)`, `usd_target_path`.
+  - `use_real_usd` = the pxr / MockUsdTarget toggle → **config flag, not a code fork** (de-risks AP9).
+  - `embedding_dim` is `Optional` → Moneta does **not** force a dimension.
+- **Memory object fields:** `attended_count`, `entity_id`, `last_evaluated (float ts)`,
+  `payload (str — round-trips byte-for-byte intact)`, `protected_floor`,
+  `semantic_vector (List[float])`, `state (EntityState; VOLATILE=0)`,
+  `usd_link (None under Mock → USD prim when use_real_usd)`, `utility (float ~1.0 fresh, decays)`.
+  - `utility` is the recency/salience signal → `get_recent` becomes "highest utility."
+  - `usd_link` is the provenance anchor.
+- **`ephemeral()` = pxr-free, in-memory, MockUsdTarget.** Canonical pattern (from `moneta.smoke_check`):
+  ```python
+  with Moneta(MonetaConfig.ephemeral()) as m:
+      eid  = m.deposit(payload, embedding)
+      hits = m.query(embedding, limit=5)
+  ```
+
+## DECISION LOCKED (Mile 2)
+**Embedder = swappable component behind `synapse.memory.embedding`.**
+- **Bootstrap NOW** with a deterministic embedder (option #3): hash / char-ngram → fixed-dim vector.
+- **Swap in** a local semantic model (option #2, MiniLM-class ~384-dim) at the quality pass.
+- **Rationale:** defuses FC2 (deterministic + offline + instant can't block the build); keeps the
+  embedder off the critical path; keeps shadow-parity high for a clean cutover, then the semantic
+  swap improves recall deliberately.
+
+## FIRST TASK (FORGE) — build `synapse.memory.embedding`
+**Pure Python. Zero deps. No Houdini, no Moneta, no pxr. Fully buildable + testable standalone.**
+
+Interface (ARCHITECT spec — FORGE implements):
+```python
+class Embedder(Protocol):
+    id: str            # pinned identifier, stamped onto deposits for provenance
+    dim: int
+    def embed(self, text: str) -> list[float]: ...   # deterministic, L2-normalized
+
+# Bootstrap impl: HashEmbedder(dim=256 or 384)
+#   - char/word n-gram -> hashed buckets -> fixed-dim vector -> L2-normalize
+#   - PURE function of input: same text -> same vector, always. No randomness, no network.
+#   - id like "hash-ngram-v1"
+```
+
+CRUCIBLE (hostile tests, standalone — **never weaken a test to pass; fix-forward**):
+- **determinism** — same input → identical vector across calls *and* process restarts
+- **fixed dim** — every output is exactly `dim` long
+- **normalization** — ‖v‖ == 1 (within float tol) for non-empty input
+- **edges** — empty string, whitespace-only, unicode, very long text, near-duplicate strings
+
+## HALT-AND-SURFACE TRIGGERS (hard)
+1. **HALT before writing ANY `MonetaBackedStore` adapter code (Mile 4)** until Joe ratifies the
+   **Reconcile → Replace reversal.** The embedder + pxr path (Miles 2–3) do NOT require it; the
+   adapter does. Surface and wait.
+2. **`dir()`-verify any Moneta API surface NOT listed in "Verified Ground Truth" above**, in the H21
+   env, before using it (e.g. `MockUsdTarget` construction args, `ConsolidationResult` fields,
+   `EntityState` members). Docs and Gemini hallucinate H21 APIs.
+3. Atomic scripts, idempotent guards, transaction wrappers, USD-provenance — per harness invariants.
+
+## PARKED (later miles, not now)
+- **Embedder swap requires re-embedding.** Hash vectors and semantic vectors live in different
+  spaces — not comparable. **Mechanism:** stamp the embedder `id` into each deposit's JSON payload
+  (e.g. `"_embedder": "hash-ngram-v1"`) — payload round-trips intact, so on swap you query, find
+  non-matching ids, and re-embed those. Connects to the Mile 8 backfill of the 176 entries.
+- **protected-quota ceiling** (`ProtectedQuotaExceededError`) vs. mapping decisions → high
+  `protected_floor` (AP8). Don't blindly pin every decision at the ceiling.
+- **`last_evaluated` semantics** — created-at, or last-decay-eval? Verify before ordering on it.
+
+## NEXT MILES
+- **Mile 3:** pxr / CI path (`use_real_usd` toggle; `MockUsdTarget` for standalone/CI).
+- **Mile 4:** `MonetaBackedStore` adapter — **HALT for the reversal first.**
+- **Mile 5:** shadow / dual-write + parity diff harness.

--- a/docs/MONETA_SYNAPSE_INTEGRATION_HARNESS.md
+++ b/docs/MONETA_SYNAPSE_INTEGRATION_HARNESS.md
@@ -1,0 +1,297 @@
+# MONETA ↔ SYNAPSE INTEGRATION HARNESS — v1
+
+### Refactored from the AutoScientist × K+S general harness for **one specific job**.
+
+> **One-line:** Make Moneta SYNAPSE's memory substrate — the *"Replace done right"* that Contract 1
+> pointed at — introduced **shadow-first** behind the existing `MemoryStore` interface, gated on
+> **(a)** the H21 API-existence check and **(b)** a deterministic, offline-capable embedding source.
+
+**Provenance:** This is a *specialization*, not a fresh harness. It folds the generic
+AutoScientist × K+S arc into Joe's existing system (MOE roles, capsule format, FORGE ledger,
+marathon miles) and **cuts the anti-divergence machinery the generic version carries** — because the
+divergence this job faced was already resolved in `MONETA_SYNAPSE_CONNECTION_REPORT.md`. What it
+**keeps and sharpens** is the verifier-gating spine, which this job genuinely needs: the API
+hallucination risk (your hard-won H21 lesson) and the parity requirement both demand it.
+
+---
+
+## 0. WHAT CHANGED IN THE REFACTOR
+
+*Why this isn't the generic harness. Read once, then ignore — it's reasoning, not procedure.*
+
+| Generic harness | This refactor | Why |
+|---|---|---|
+| ANALYST / BUILDER / CRITIC | **= your ARCHITECT / FORGE / CRUCIBLE** | One role vocabulary. CRUCIBLE's *fix-forward, never weaken* is stronger than the generic Critic — kept as the rule. |
+| Mode decided at end of SKETCH | **Pre-resolved: SIMULATED TEAM** | The report already gives the dependency graph. No need to discover the mode. |
+| Full ORCHESTRATED apparatus (roster, claim-lock, launch spec) | **Cut** | Claude Code can't spawn nested processes; you run on master sequentially. Honesty constraint, not a limitation to apologize for. |
+| Contention Probe | **Cut** | Independence is plain from the graph; the only parallel line (embedder) is obviously independent. |
+| DIGEST file (new compression format) | **= your capsule format** | No second compression format. |
+| LEDGER (new skill ledger) | **= your FORGE friction system** | No second ledger. The recursive-self-improvement loop already plays this role. |
+| Generic L0–L4 | **Instantiated against the report's invariants** | The `dir()` gate becomes L0; the gauge invariant + parity become L2; consent/IntegrityBlocks/determinism become L3. |
+| Heavy stagnation-reorganization ceremony | **Principle kept, ceremony cut** | Job is linear; reorganization only matters if the embedder bake-off stalls. |
+
+---
+
+## 1. HARD INVARIANTS
+
+*Above the arc. Never violated, at any mile, by any lens. These are yours, plus the two this job adds.*
+
+1. **API verification is L0, not a suggestion.** No bridge/adapter code is written until `dir()`-based
+   runtime introspection in the **actual H21.0.671 hython env** confirms every API the report assumes
+   exists. Docs and Gemini Deep Think hallucinate H21 APIs. Confirmed-absent already:
+   `hou.pdg.*`, `hou.secure`, `hou.lopNetworks()`, `hou.updateGraphTick()`. Treat Moneta's surface
+   the same way until proven.
+2. **Atomic scripts** — one mutation per call.
+3. **Idempotent guards** — check-before-mutate.
+4. **Transaction wrappers** — undo-group rollback on error.
+5. **USD provenance** — every AI action writes its reasoning as custom USD attributes. The Moneta
+   backend slots **under** SYNAPSE's `HumanGate` + `IntegrityBlock`, never around them.
+6. **Backup-first before any migration.** The 176-entry backfill is one-time and reversible.
+7. **`exec()` in Python Source Editor, not Python Shell** (Shell breaks on multi-line class defs).
+8. **`execute_python` over WebSocket chokes on multi-line dict literals** — sequential single-line calls.
+9. **Race-safe push** — fetch + rebase on non-fast-forward, max 3 attempts, halt on merge conflict.
+10. **Fidelity = 1.0 or rollback.** Shadow cutover happens only when parity holds. Mirrors your
+    existing replay-determinism property.
+
+---
+
+## 2. LENSES = YOUR MOE ROLES
+
+*Standing roles, not phases. CRUCIBLE is always available — not only at STRESS.*
+
+| Harness lens | Your role | Owns | The rule |
+|---|---|---|---|
+| **ANALYST** | **ARCHITECT** | Search knowledge. Reads the Log, ranks candidate moves, maintains DEADENDS + hypothesis docs. Design docs only. | Favor underexplored; deprioritize consistently-small effects. |
+| **BUILDER** | **FORGE** | Claims one proposal, executes against the champion, runs the verifier, records outcome — win **or** fail. | Pulls from the ranked queue; does not invent what to build. |
+| **CRITIC** | **CRUCIBLE** | (1) Kills weak proposals on the record before cost is paid. (2) Attacks the realized champion at STRESS with real adversarial cases. | **Fix-forward. Never weakens a test.** If CRUCIBLE finds nothing, CRUCIBLE isn't trying. |
+
+Sequential within one session (relay handoffs). One context holds all three in turn.
+
+---
+
+## 3. MODE — PRE-RESOLVED
+
+**SIMULATED TEAM** = one context, team discipline. Mostly a **SOLO spine**, with **one bounded
+parallel bake-off** (the embedder).
+
+**The dependency graph (from the report's §8):**
+
+```
+[Mile 0] ratify reversal (Reconcile → Replace)         ── gate, your call
+   │
+[Mile 1] L0: dir() confirm Moneta API exists in H21    ── hard gate, INVARIANT #1
+   │        + seed champion = the spike
+   ├─────────────────────────────┐
+   │                              │
+[Mile 2] embedder bake-off    [Mile 3] MockUsdTarget    ── the ONLY two independent lines
+   (3 competing candidates)       CI path                  (embedder ⟂ pxr path)
+   │                              │
+   └──────────────┬───────────────┘
+                  │
+[Mile 4] MonetaBackedStore adapter (flag-gated)
+   │
+[Mile 5] shadow / dual-write + parity diff harness
+   │
+[Mile 6] INTEGRATE — compose, system-level L0–L3
+   │
+[Mile 7] STRESS — CRUCIBLE L4
+   │
+[Mile 8] SHIP — cutover + backfill 176 + ship report
+```
+
+Everything is a chain **except** Miles 2 and 3, which are genuinely independent (the embedder choice
+doesn't touch the pxr/CI path). That's the entire parallel surface. No Contention Probe needed — the
+independence is structural, not in doubt.
+
+**ORCHESTRATED is off the table** (no nested processes). If a line ever splits into 4+ independent
+sub-problems with a launcher present, re-derive — but it won't on this job.
+
+---
+
+## 4. SHARED STATE — FOLDED INTO YOUR SYSTEM
+
+| Harness file | This job uses | Note |
+|---|---|---|
+| `SPEC.md` | **§6 below** | Ratify at FRAME. Changed only at ratification points. |
+| `CHAMPION.md` | The spike → adapter → shadow-parity → cutover | Exactly one at a time. |
+| `LOG.md` | Append-only attempt record (wins **and** fails) | Standard. |
+| `FORUM.md` | Deliberation (proposals, critiques, results) | Where CRUCIBLE kills weak proposals before cost. |
+| `DEADENDS.md` | **§9 — pre-seeded** | Read before proposing. |
+| `PLAN.md` | The mile structure (§5) | Re-written only if a line reopens. |
+| ~~`LEDGER.md`~~ | **= your FORGE friction system** | No second ledger. |
+| ~~`DIGEST.md`~~ | **= your capsule format** | No second compression format. |
+| `TRACE.md` | Append-only: every verifier result, branch decision, external call | Standard. |
+
+**The capsule IS the digest.** At every mile boundary, write a capsule in your format
+(`WHERE WE ARE / MILE MARKER / WHAT I WAS THINKING / NEXT ACTION / BLOCKERS / ENERGY REQUIRED /
+IDEAS PARKED`). That is the authoritative compressed state downstream reasoning consumes.
+
+---
+
+## 5. THE ARC AS MILES
+
+*Gate criteria are verified by line-number citations into the codebases. No advancing on unverified state.*
+
+| Mile | Arc gate | Deliverable | Gate criterion |
+|---|---|---|---|
+| **0** | FRAME | Ratified SPEC + ratified reversal | Joe signs off on §6 and §10. |
+| **1** | SKETCH | Seed champion = the spike; mode locked | L0 passes: `dir()` confirms Moneta API in H21.0.671. One deposit/query round-trips against `MockUsdTarget`. |
+| **2** | DELIBERATE⇄EXECUTE | Embedder chosen | One candidate clears the embedder verifier (determinism dominant). Champion: `synapse.memory.embedding`. |
+| **3** | DELIBERATE⇄EXECUTE | pxr/CI path | `MockUsdTarget` path import-guarded, exercised in CI, no `pxr` required. |
+| **4** | DELIBERATE⇄EXECUTE | `MonetaBackedStore` adapter | Implements `add/search/get_recent/count/get_decisions`; L1 passes; flag-gated, default off. |
+| **5** | DELIBERATE⇄EXECUTE | Shadow + parity harness | Dual-write to JSONL + Moneta; shadow-read diff; L2 parity meets threshold. |
+| **6** | INTEGRATE | Composed system | Every SPEC predicate verified at system level (L0–L3). Seam: URI-lock ownership under async server. |
+| **7** | STRESS | CRUCIBLE L4 | No showstoppers; bounded weaknesses documented in SPEC limitations. |
+| **8** | SHIP | Cutover + backfill + ship report | Flag flipped; 176 entries backfilled (backup-first); markdown kept as export view; `evolution.py` retired; gauge invariant + consent gates + determinism all intact. |
+
+Marathon marker format at each boundary: **`Mile X of ~8 — <what's done>, <what's next>`.**
+
+---
+
+## 6. SPEC.md — DRAFT (ratify at FRAME, Mile 0)
+
+### Outcome
+SYNAPSE's memory operations (`add / search / get_recent / count / get_decisions`) are served by an
+in-process Moneta engine behind the unchanged `MemoryStore` interface. Callers
+(`synapse_context / search / recall`) are unmodified. The two-store divergence, the dead gauge, the
+empty stubs, and the read/write path divergence are **structurally impossible**, not patched. Memory
+gains consolidation, time-decay, attention-weighting, vector recall, and durability for free.
+
+### Acceptance Predicates *(the bar — each checkable)*
+- **AP1** — `dir()` in H21.0.671 hython confirms `Moneta`, `MonetaConfig`, `deposit`, `query`,
+  `signal_attention`, `get_consolidation_manifest`, `run_sleep_pass`, `MockUsdTarget` all exist and
+  are callable. *(L0)*
+- **AP2** — A deposit→query round-trip against `MockUsdTarget` returns the deposited memory. *(L1)*
+- **AP3** — `MonetaBackedStore` satisfies the `MemoryStore` contract for all five ops; existing
+  callers run unchanged. *(L1)*
+- **AP4** — The Mile-0 gauge invariant holds: `gauge == Moneta count` via a count accessor
+  (manifest length / ECS count). *(L2)*
+- **AP5** — Shadow-read parity between JSONL store and Moneta meets the ratified threshold over a
+  representative query set. *(L2)*
+- **AP6** — Every memory mutation still routes through `HumanGate` and produces an `IntegrityBlock`.
+  *(L3)*
+- **AP7** — Replay determinism preserved: identical inputs + pinned embedder → identical state.
+  *(L3)*
+- **AP8** — Pinned decisions survive decay (mapped to high `protected_floor`) and surface on
+  `get_decisions`. *(L2/L3)*
+- **AP9** — CI runs the full memory path standalone with **no `pxr`** via the `MockUsdTarget` path.
+  *(L2)*
+
+### Out of Scope *(explicitly fenced — do not scope-creep)*
+- Michael Gold's USD codeless-schema flag — separate work item.
+- Copernicus / COPs expansion (the 15–20 tools).
+- Shot-template tools (`synapse_solaris_shotsetup_karma_xpu`, etc.).
+- BL-007 / BL-008 (EXR-not-writing, Karma asset-reference visibility).
+- The Spike 2.4 main-thread/daemon deadlock — *referenced* as a known hazard class for the
+  URI-lock ownership seam (Mile 6), but its resolution is not this job.
+
+### Falsification Conditions *(failures that prove the approach wrong)*
+- **FC1** — `dir()` shows Moneta's documented API is **absent or different** in H21.0.671.
+  → Stops at L0. Same failure class as `hou.pdg.*`.
+- **FC2** — **No embedding source is simultaneously deterministic, offline-capable, and acceptably
+  fast/cheap.** Embedding is the hard prerequisite; if every candidate fails, the integration is
+  **blocked at the spec level** → bounce to FRAME.
+  *Sub-claim to verify, not assume:* the report lists "Anthropic SDK embeddings" — confirm an
+  embedding API actually exists and is callable offline/deterministically before counting it as a
+  candidate. It may resolve to a third-party/Voyage path, not a native endpoint.
+- **FC3** — Vector recall diverges from keyword recall **persistently** beyond threshold on
+  SYNAPSE's actual queries (behavior change too large to ship).
+- **FC4** — The single URI-locked Moneta handle **deadlocks or races** under the async FastMCP server
+  + main-thread bridge. (Known hazard — you already have a main-thread/daemon deadlock open.)
+- **FC5** — Memory mutations can route **around** `HumanGate` / `IntegrityBlock` under the Moneta
+  backend.
+
+### Verification Strategy *(per predicate → layer + stochastic?)*
+| Predicate | Layer | Stochastic? |
+|---|---|---|
+| AP1 (API exists) | L0 | No |
+| AP2, AP3 (round-trip, contract) | L1 | No |
+| AP4 (gauge), AP9 (no-pxr CI) | L2 | No |
+| AP5 (parity) | L2 | **Yes** — query-set dependent; replicate before promoting |
+| AP8 (decision survival) | L2/L3 | No |
+| AP6 (consent gates), AP7 (determinism) | L3 | No (AP7 is *the* determinism check) |
+| FC1–FC5 (the attacks) | L4 | Mixed |
+
+---
+
+## 7. VERIFIER LAYERS — INSTANTIATED
+
+| Layer | This job's checks |
+|---|---|
+| **L0** Well-formed | Imports resolve; lints; **`dir()` confirms Moneta API in H21.0.671** (INVARIANT #1, AP1). *Nothing advances until this passes.* |
+| **L1** Behavioral | Deposit→query round-trip returns the memory (AP2); `MonetaBackedStore` honors the five-op contract (AP3). |
+| **L2** Property | Gauge invariant `gauge == count` (AP4); shadow-parity threshold (AP5); idempotent guards hold under repeat deposits; URI-lock single-owner respected; no-`pxr` CI path (AP9); decision survival under decay (AP8). |
+| **L3** Semantic | `HumanGate` + `IntegrityBlock` wrap every mutation (AP6); replay determinism (AP7); recall *intent* satisfied — salient memories surface, not just "N rows returned." |
+| **L4** Adversarial (CRUCIBLE) | `pxr`-absent CI; 176-entry migration w/ backup-first + rollback; decay-reorders-`recent_activity` edge (does the LLM-on-connect view degrade?); URI-lock contention under async server (FC4); embedder offline/failure behavior; the two-USD-models collision risk (`evolution.py` vs Moneta). |
+
+**Noise-aware:** AP5 (parity) is stochastic — a within-noise parity gain is not real until replicated
+on a fresh query set. Never promote on a single sample.
+
+---
+
+## 8. SEED CHAMPION — THE SPIKE
+
+*Mile 1's deliverable. Weak, but it's the bar. Mirrors the Comfy bridge's first call.*
+
+The smallest real artifact:
+1. In a SYNAPSE hython session, `from moneta import Moneta, MonetaConfig`.
+2. Construct a handle against `MockUsdTarget` (no `pxr` needed): `MonetaConfig.ephemeral()` or a
+   mock-backed config.
+3. `with Moneta(config) as m:` — round-trip **one** deposit and one query.
+
+If this round-trips, connectability is proven and the champion exists. Every later champion must beat
+it on the acceptance predicates: flag-gated adapter passing L1 → adapter passing L2 parity in shadow
+→ cutover passing L3 → full system passing L4.
+
+**Reference to lift from:** `Comfy_Moneta_Bridge` — `capsule.py:130-131` (query),
+`ingest.py:93-94` (deposit), its own `vector.py` (owns embedding), `run_sleep_pass()` after deposits.
+The connection mirrors this: a thin adapter that imports Moneta as a library, owns embeddings, wraps
+deposit/query/sleep.
+
+---
+
+## 9. DEADENDS.md — PRE-SEEDED
+
+*Banked so they are never re-litigated. Read before proposing.*
+
+| Axis | Direction | Why rejected |
+|---|---|---|
+| Recall mechanism | Keep keyword-only recall | It's the **status quo being replaced** — the bug-prone subsystem, not a candidate. |
+| "Reconcile vs Replace" answer | `sqlite_store.py` (the dormant 750-line vector scaffold) | **Rejected.** Moneta is the answer — built, tested, patent-backed. (Report §0, §6.6.) |
+| USD memory maturity | Keep bespoke `evolution.py` (charmander→charizard) | **Retired.** Hand-rolled stand-in for what Moneta's `run_sleep_pass` / consolidation does properly. Two USD memory models must not coexist. (Report §5, §7.) |
+| Connection topology | Out-of-process RPC bridge | Both run in the same hython — in-process embed is cleaner, no marshalling. (Report §4 Option A.) |
+| Prior session decision | "Reconcile" (Contract 1) | **Superseded by Replace-done-right.** *Requires explicit ratification — see §10.* (Report §6.6.) |
+
+---
+
+## 10. THE TWO RATIFICATION GATES — JOE'S CALL (at FRAME)
+
+The harness pauses here. Neither is mine to decide.
+
+**Gate 1 — The reversal.** `[PRIOR-SESSION ASSERTED → needs your ratification]`
+You chose **"Reconcile"** last session as the low-churn fix. Moneta-as-backend is **"Replace done
+right"** — it makes the divergence class unrepresentable instead of patched, but it is a deliberate
+reversal of a decision you made. Ratify the reversal, or hold at Reconcile.
+
+**Gate 2 — Confirm the mode.** `[PRE-RESOLVED → confirm or redirect]`
+SIMULATED TEAM, SOLO spine + one embedder bake-off, ORCHESTRATED cut. Confirm, or tell me the
+dependency graph is wrong.
+
+---
+
+## 11. FIRST MOVE
+
+After ratification, the first action is **L0 / Mile 0→1 boundary**, and it is the cheapest possible
+high-information check:
+
+> Write the `dir()` introspection script. Run it in the **graphical H21.0.671 hython env**
+> (Python Source Editor, not Shell). Confirm `Moneta`, `MonetaConfig`, the four ops, `run_sleep_pass`,
+> and `MockUsdTarget` exist and are callable. **If any is absent → stop at FC1.** This is the same
+> gate that caught `hou.pdg.*`. Body check before the GUI work — fresh-paste catches what tired-paste
+> misses.
+
+Nothing downstream is written until this returns green.
+
+---
+
+**BEGIN:** Mile 0 — present SPEC (§6) and the two gates (§10) for ratification.

--- a/docs/MONETA_SYNAPSE_SHIP_REPORT.md
+++ b/docs/MONETA_SYNAPSE_SHIP_REPORT.md
@@ -21,7 +21,7 @@ gated (below).
 | 5 | Shadow dual-write + parity diff harness | `memory/shadow_store.py` |
 | 6 | Integration / composition, URI-lock seam | `tests/test_moneta_integration.py` |
 | 7 | CRUCIBLE L4 fixes + adversarial pins | `memory/moneta_store.py`, `tests/test_moneta_crucible.py` |
-| 8 | Backfill (count-agnostic, backup-first), evolution.py retired, this report | `memory/backfill.py`, `memory/evolution.py` |
+| 8 | Backfill (count-agnostic, backup-first); `memory/evolution.py` deprecated + dormant under moneta (removal deferred to cutover); this report | `memory/backfill.py`, `memory/evolution.py` |
 
 **Backend flag** (`SYNAPSE_MEMORY_BACKEND`, in `SynapseMemory._make_store`):
 `jsonl` (default, unchanged) · `moneta` (in-process engine) · `shadow` (jsonl
@@ -54,41 +54,72 @@ edges, and isolation/recovery. **Two real defects fixed:**
    `json.load`. Fixed: snapshot validated and **quarantined** (renamed +
    ERROR-logged, preserved) on corruption; fresh start, no crash, no silent loss.
 
+## FC4 — closed by construction (gap-closing pass)
+
+The single-writer hazard (`run_sleep_pass`/`ecs.remove` corrupting the
+swap-and-pop index under concurrency) is **no longer a live-gated weakness**.
+`MonetaBackedStore` now holds a serialization `RLock` guarding every engine
+access (`add`/`_iter_memories`/`count`/`save`/`run_sleep_pass`/`close`), with
+reads taking an atomic snapshot under the lock. Deadlock-free against the async
+server: the adapter makes **zero `hou.*` calls** (AST-pinned by
+`test_adapter_imports_no_hou`), so the lock is never held across an `hdefereval`
+main-thread hop — the two synchronization domains are disjoint. Proven by a
+standalone concurrency suite (`tests/test_moneta_fc4_audit.py`: concurrent
+add+prune, iterate-during-prune, add losslessness, count-under-churn). The
+background snapshot daemon remains off (persistence is via the guarded `save`).
+
 **Documented bounded weaknesses (pinned by tests):**
 - **Decay/consolidation expires unprotected memories** — but ONLY on explicit
   `run_sleep_pass`; normal add/read never loses data. Decisions/SHOW-tier/gate
-  are protected. (Behavior change from JSONL's never-delete; it is the intended
-  consolidation feature, made observable and opt-in.)
-- **Single-writer (FC4)** — Moneta's ECS is single-writer. Concurrent `add` is
-  GIL-atomic today, but a concurrent prune (`ecs.remove`) corrupts state. The
-  async FastMCP server **must serialize all memory mutations onto one thread**
-  (the same discipline the bridge uses for `hou.*`). The background snapshot
-  daemon is deliberately NOT started for this reason.
+  are protected. Now **auditable**: `run_sleep_pass` returns a `PruneAudit`
+  (pruned ids/payloads/types + before/after counts) and logs a WARNING on any
+  prune — loss is never silent.
 - **`Memory.id` upstream collision** — `id` hashes content+type (created_at is
   empty at id-time), so identical content+type collides. JSONL dedups by id;
-  Moneta appends both. Pinned; fix belongs in `models.py` (out of scope here).
+  Moneta appends both. Backfill is unaffected (existing ids are already unique).
+  Deferred follow-up (see below).
 - **`get_by_tag` raw case-sensitivity** (matches `search` semantics; no live
   callers); **shadow mode** runs the JSONL primary so evolution.py still fires
-  there (only pure `moneta` retires it).
+  there (only pure `moneta` keeps it dormant).
 
 ## Cutover procedure (staged — NOT auto-flipped)
 
-The flag stays **default `jsonl`**. The one action deliberately *not* taken from
-a standalone session is flipping production to `moneta` by default, because the
-**FC4 async-server deadlock/serialization check requires the running FastMCP
-server** and cannot be verified headless. Recommended sequence:
+The flag stays **default `jsonl`**. FC4 thread-safety is now structural (above),
+so the remaining gate is operational verification under the live server, not a
+correctness unknown. Recommended sequence:
 
 1. Set `SYNAPSE_MEMORY_BACKEND=shadow` in a live session; accumulate parity over
    real traffic (target ratio 1.0 — already 1.0 in tests).
-2. Verify under the live async server that memory mutations are serialized (no
-   concurrent `run_sleep_pass` vs `add`); confirm no deadlock (the known Spike
-   2.4 main-thread/daemon hazard class).
+2. Confirm under the live async server that the daemon routes memory mutations
+   without contending the Spike 2.4 main-thread/daemon hazard class (the RLock
+   makes the engine itself safe; this is a server-wiring sanity check).
 3. Run `python -m synapse.memory.backfill <.synapse> --execute` (backup-first).
-4. Flip default to `moneta`; remove `evolution.py`; keep markdown as an export
-   view.
+4. Flip default to `moneta`; physically remove
+   `python/synapse/memory/evolution.py`; keep markdown as an export view.
+
+## Deferred follow-ups (designed, not in this PR)
+
+A 6-agent ARCHITECT pass specced these; they are intentionally out of this PR's
+scope (risk / requires external provisioning), with the recipe captured:
+- **`Memory.id` collision fix** — reorder `models.py.__post_init__` to default
+  `created_at` before `_generate_id` (+ optional `time_ns`/uuid entropy). Touches
+  shared `models.py` and inverts one pinned test; lands before/with the cutover,
+  separate PR.
+- **AP6 gating of `run_sleep_pass`** — add `sleep_pass: approve` to
+  `OPERATION_GATES`, map a `synapse_sleep_pass` tool through `bridge_adapter`'s
+  `execute_through_bridge`. Not load-bearing yet (no prod caller invokes
+  `run_sleep_pass`); add when it is wired to a tool.
+- **CI actually exercises Moneta** — deploy-key checkout of the private
+  `JosephOIbrahim/Moneta` (zero-dep, pxr-free) + `pip install -e ./_moneta` +
+  a no-silent-skip tripwire. Requires a `MONETA_DEPLOY_KEY` repo secret (Joe to
+  provision); until then the ~66 Moneta tests skip on CI and run locally.
 
 ## Test status
-All new suites green: embedding (25), moneta_runtime (5), moneta_store (16),
-shadow_store (6), moneta_integration (5), moneta_crucible (30), backfill (5).
-Full suite: pre-existing pxr-env failures only (untouched files); zero new
-regressions.
+All new suites green where Moneta is importable: embedding (25, runs on CI —
+dependency-free), moneta_runtime (5), moneta_store (16), shadow_store (6),
+moneta_integration (5), moneta_crucible (30), backfill (5), fc4_audit (8).
+**~66 of these are `skipif not moneta_available` and SKIP on CI / clean clones**
+(no `moneta` package); they pass locally where Moneta is present. Full suite:
+3021 local passing; the 15 failures are the pre-existing pxr-env baseline in
+untouched files (they expect a pxr-absent env and fail because pxr IS installed
+locally); zero new regressions.

--- a/docs/MONETA_SYNAPSE_SHIP_REPORT.md
+++ b/docs/MONETA_SYNAPSE_SHIP_REPORT.md
@@ -1,0 +1,94 @@
+# Moneta ↔ SYNAPSE — Ship Report (Miles 2–8)
+
+> **Outcome:** SYNAPSE's memory operations can be served by an in-process Moneta
+> engine behind the unchanged `MemoryStore` interface. The two-store divergence,
+> the dead gauge, the empty stubs, and the read/write path divergence become
+> *structurally impossible* — there is one store and `count()` reads the engine's
+> live entity count. Delivered **shadow-first, flag-gated, default-off.**
+
+Governed by `MONETA_SYNAPSE_INTEGRATION_HARNESS.md`. Lenses: ARCHITECT / FORGE /
+CRUCIBLE. Ratification: the Reconcile→Replace reversal (harness §10 Gate 1) was
+ratified under delegated CTO authority for this run; production cutover stays
+gated (below).
+
+## What shipped
+
+| Mile | Deliverable | Files |
+|---|---|---|
+| 2 | Deterministic `HashEmbedder` behind `Embedder` (PYTHONHASHSEED-independent) | `memory/embedding.py` |
+| 3 | Import-guarded Moneta runtime; pxr-free ephemeral path | `memory/moneta_runtime.py` |
+| 4 | `MonetaBackedStore` adapter (flag-gated, default off) | `memory/moneta_store.py`, `memory/store.py` |
+| 5 | Shadow dual-write + parity diff harness | `memory/shadow_store.py` |
+| 6 | Integration / composition, URI-lock seam | `tests/test_moneta_integration.py` |
+| 7 | CRUCIBLE L4 fixes + adversarial pins | `memory/moneta_store.py`, `tests/test_moneta_crucible.py` |
+| 8 | Backfill (count-agnostic, backup-first), evolution.py retired, this report | `memory/backfill.py`, `memory/evolution.py` |
+
+**Backend flag** (`SYNAPSE_MEMORY_BACKEND`, in `SynapseMemory._make_store`):
+`jsonl` (default, unchanged) · `moneta` (in-process engine) · `shadow` (jsonl
+primary + moneta shadow with parity diff). Unknown/unavailable → safe fallback to
+`jsonl`; never breaks startup.
+
+## Acceptance predicates
+
+| AP | Status | Evidence |
+|---|---|---|
+| AP1 — Moneta API exists in H21 | ✅ (Mile 1, prior) | dir() 10/10 in H21.0.671; source re-verified here |
+| AP2 — deposit→query round-trip | ✅ | `test_moneta_runtime` |
+| AP3 — adapter honors MemoryStore contract | ✅ | `test_moneta_store`, `test_moneta_integration` |
+| AP4 — gauge == count | ✅ | gauge *is* `store.count()` = `ecs.n` (`test_gauge_invariant_holds_under_moneta`) |
+| AP5 — shadow parity | ✅ 1.0 | search parity-by-construction; `test_shadow_store` |
+| AP6 — mutations through HumanGate/IntegrityBlock | ⚠️ honest | the memory store has **no** gate today (pre-existing); the adapter adds no bypass — gating stays at the tool layer (memory ops are INFORM). Unchanged from JSONL. |
+| AP7 — replay determinism | ✅ | `test_replay_determinism_same_inputs_same_state` |
+| AP8 — pinned decisions survive decay | ✅ | `test_decision_survives_many_sleep_passes` |
+| AP9 — CI runs with no pxr | ✅ | `test_ephemeral_path_is_pxr_free` (clean subprocess) |
+
+## CRUCIBLE L4 — defects fixed, weaknesses bounded
+
+A 4-agent adversarial fan-out attacked decay/data-loss, concurrency, payload
+edges, and isolation/recovery. **Two real defects fixed:**
+
+1. **Protected-quota silent demotion** — the 101st protected memory was silently
+   re-deposited unprotected (Moneta `quota_override=100`) and became prunable.
+   Fixed: `from_storage_dir` sets `quota_override=100000`.
+2. **Corrupt-snapshot startup-killer** — Moneta `hydrate()` does a bare
+   `json.load`. Fixed: snapshot validated and **quarantined** (renamed +
+   ERROR-logged, preserved) on corruption; fresh start, no crash, no silent loss.
+
+**Documented bounded weaknesses (pinned by tests):**
+- **Decay/consolidation expires unprotected memories** — but ONLY on explicit
+  `run_sleep_pass`; normal add/read never loses data. Decisions/SHOW-tier/gate
+  are protected. (Behavior change from JSONL's never-delete; it is the intended
+  consolidation feature, made observable and opt-in.)
+- **Single-writer (FC4)** — Moneta's ECS is single-writer. Concurrent `add` is
+  GIL-atomic today, but a concurrent prune (`ecs.remove`) corrupts state. The
+  async FastMCP server **must serialize all memory mutations onto one thread**
+  (the same discipline the bridge uses for `hou.*`). The background snapshot
+  daemon is deliberately NOT started for this reason.
+- **`Memory.id` upstream collision** — `id` hashes content+type (created_at is
+  empty at id-time), so identical content+type collides. JSONL dedups by id;
+  Moneta appends both. Pinned; fix belongs in `models.py` (out of scope here).
+- **`get_by_tag` raw case-sensitivity** (matches `search` semantics; no live
+  callers); **shadow mode** runs the JSONL primary so evolution.py still fires
+  there (only pure `moneta` retires it).
+
+## Cutover procedure (staged — NOT auto-flipped)
+
+The flag stays **default `jsonl`**. The one action deliberately *not* taken from
+a standalone session is flipping production to `moneta` by default, because the
+**FC4 async-server deadlock/serialization check requires the running FastMCP
+server** and cannot be verified headless. Recommended sequence:
+
+1. Set `SYNAPSE_MEMORY_BACKEND=shadow` in a live session; accumulate parity over
+   real traffic (target ratio 1.0 — already 1.0 in tests).
+2. Verify under the live async server that memory mutations are serialized (no
+   concurrent `run_sleep_pass` vs `add`); confirm no deadlock (the known Spike
+   2.4 main-thread/daemon hazard class).
+3. Run `python -m synapse.memory.backfill <.synapse> --execute` (backup-first).
+4. Flip default to `moneta`; remove `evolution.py`; keep markdown as an export
+   view.
+
+## Test status
+All new suites green: embedding (25), moneta_runtime (5), moneta_store (16),
+shadow_store (6), moneta_integration (5), moneta_crucible (30), backfill (5).
+Full suite: pre-existing pxr-env failures only (untouched files); zero new
+regressions.

--- a/python/synapse/memory/backfill.py
+++ b/python/synapse/memory/backfill.py
@@ -1,0 +1,119 @@
+"""One-time backfill: JSONL memory store -> Moneta engine (Mile 8).
+
+Reads the existing memories through the tested ``MemoryStore`` loader (so
+encryption/format are handled for us), deposits each into a Moneta-backed
+store, and verifies the count round-trips. Count-agnostic: it backfills however
+many entries exist (38, 176, 0 — whatever is there).
+
+Safety (harness invariant #6 — backup-first, reversible):
+  * The source JSONL is only READ. It is left intact, and a ``.backfill.bak``
+    copy is taken before a real run.
+  * Reverting the cutover is just flipping ``SYNAPSE_MEMORY_BACKEND`` back to
+    ``jsonl`` — the JSONL store is untouched and authoritative.
+  * Default is ``dry_run=True``: nothing is written until you pass
+    ``--execute`` / ``dry_run=False``.
+
+CLI:
+    python -m synapse.memory.backfill <storage_dir>            # dry run (default)
+    python -m synapse.memory.backfill <storage_dir> --execute  # real backfill
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import shutil
+from collections import Counter
+from pathlib import Path
+from typing import Optional
+
+from .store import MemoryStore
+
+logger = logging.getLogger(__name__)
+
+
+def backfill_to_moneta(
+    storage_dir,
+    *,
+    dry_run: bool = True,
+    backup: bool = True,
+    embedder=None,
+) -> dict:
+    """Backfill the JSONL store at ``storage_dir`` into a Moneta-backed store.
+
+    Returns a report dict with the source count, deposited count, verification
+    result, and a per-type breakdown.
+    """
+    storage_dir = Path(storage_dir)
+    source = MemoryStore(storage_dir)
+    source._wait_loaded()
+    memories = source.all()
+
+    report = {
+        "storage_dir": str(storage_dir),
+        "source_count": len(memories),
+        "by_type": dict(Counter(m.memory_type.value for m in memories)),
+        "dry_run": dry_run,
+        "backup": None,
+        "deposited": 0,
+        "verified": None,
+    }
+
+    if dry_run:
+        report["would_deposit"] = len(memories)
+        return report
+
+    if backup:
+        jsonl = storage_dir / "memory.jsonl"
+        if jsonl.exists():
+            bak = jsonl.with_name("memory.jsonl.backfill.bak")
+            shutil.copy2(jsonl, bak)
+            report["backup"] = str(bak)
+
+    from .moneta_store import MonetaBackedStore
+
+    target = MonetaBackedStore.from_storage_dir(storage_dir, embedder=embedder)
+    try:
+        for memory in memories:
+            target.add(memory)
+        target.save()
+        report["deposited"] = target.count()
+        report["embedder_id"] = target.embedder_id
+    finally:
+        target.close()
+
+    report["verified"] = report["deposited"] == report["source_count"]
+    return report
+
+
+def main(argv: Optional[list] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="Backfill JSONL memories into Moneta.")
+    parser.add_argument("storage_dir", help="Path to the .synapse storage dir")
+    parser.add_argument("--execute", action="store_true",
+                        help="Actually write (default is a dry run)")
+    parser.add_argument("--no-backup", action="store_true",
+                        help="Skip backing up memory.jsonl (not recommended)")
+    args = parser.parse_args(argv)
+
+    report = backfill_to_moneta(
+        args.storage_dir,
+        dry_run=not args.execute,
+        backup=not args.no_backup,
+    )
+
+    logger.info("=== Moneta backfill report ===")
+    for key, value in report.items():
+        logger.info("  %s: %s", key, value)
+    if not args.execute:
+        logger.info("  (dry run -- re-run with --execute to write)")
+        return 0
+    if not report["verified"]:
+        logger.error("  VERIFICATION FAILED: deposited != source_count")
+        return 1
+    logger.info("  OK: every memory backfilled and verified.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/synapse/memory/evolution.py
+++ b/python/synapse/memory/evolution.py
@@ -3,6 +3,16 @@ Synapse Memory Evolution -- Flat -> Structured -> Composed
 
 Detects when markdown memory should evolve to USD. Handles the
 conversion process and maintains companion markdown.
+
+.. deprecated:: Moneta integration (Mile 8)
+    This hand-rolled charmander->charmeleon->charizard USD evolution is
+    SUPERSEDED by the Moneta backend, whose ``run_sleep_pass`` consolidation +
+    time-decay does this properly. Two USD memory models must not coexist, so
+    the Moneta-backed store does NOT trigger evolution (verified:
+    tests/test_moneta_crucible.py::test_moneta_backend_never_fires_evolution).
+    It remains live only for the legacy default ``jsonl`` backend and will be
+    removed when ``SYNAPSE_MEMORY_BACKEND`` defaults to ``moneta`` after the
+    live async-server (FC4) verification. Do not extend it.
 """
 
 import logging

--- a/python/synapse/memory/moneta_runtime.py
+++ b/python/synapse/memory/moneta_runtime.py
@@ -1,0 +1,92 @@
+"""Import-guarded access to the Moneta memory engine (Mile 3).
+
+Moneta ships as a separate package (repo: JosephOIbrahim/Moneta). It is NOT a
+hard dependency of SYNAPSE: this module guards the import so SYNAPSE runs
+unchanged when Moneta is absent (CI without the package, or environments that
+haven't opted into the Moneta backend). When present, :func:`make_ephemeral`
+builds a pxr-free, in-memory, ``MockUsdTarget``-backed handle -- the path CI
+exercises with no OpenUSD requirement (harness AP9).
+
+Package resolution order:
+  1. ``import moneta`` (pip-installed, or already on ``sys.path``).
+  2. If that fails and ``$MONETA_SRC`` points at a directory, insert it on
+     ``sys.path`` and retry.
+
+Packaging Moneta as a proper wheel is the long-term fix; until then the env
+var is the seam (the production bridge / CI sets it). No user-specific path is
+ever hard-coded here.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Optional
+
+_MONETA_AVAILABLE = False
+_MONETA_IMPORT_ERROR: Optional[str] = None
+Moneta = None
+MonetaConfig = None
+
+
+def _try_import() -> bool:
+    """Attempt to bind ``Moneta``/``MonetaConfig``. Idempotent and cheap."""
+    global _MONETA_AVAILABLE, _MONETA_IMPORT_ERROR, Moneta, MonetaConfig
+    if _MONETA_AVAILABLE:
+        return True
+    try:
+        from moneta import Moneta as _M, MonetaConfig as _C
+        Moneta, MonetaConfig = _M, _C
+        _MONETA_AVAILABLE = True
+        _MONETA_IMPORT_ERROR = None
+        return True
+    except Exception as first_err:  # ImportError, or a transitive failure
+        src = os.environ.get("MONETA_SRC")
+        if src and os.path.isdir(src):
+            if src not in sys.path:
+                sys.path.insert(0, src)
+            try:
+                from moneta import Moneta as _M, MonetaConfig as _C
+                Moneta, MonetaConfig = _M, _C
+                _MONETA_AVAILABLE = True
+                _MONETA_IMPORT_ERROR = None
+                return True
+            except Exception as second_err:
+                _MONETA_IMPORT_ERROR = f"{type(second_err).__name__}: {second_err}"
+                return False
+        _MONETA_IMPORT_ERROR = f"{type(first_err).__name__}: {first_err}"
+        return False
+
+
+_try_import()
+
+
+def moneta_available() -> bool:
+    """True if the Moneta package can be imported (retries once)."""
+    return _MONETA_AVAILABLE or _try_import()
+
+
+def import_error() -> Optional[str]:
+    """The last import failure string, or None if Moneta imported cleanly."""
+    return _MONETA_IMPORT_ERROR
+
+
+def make_ephemeral(embedding_dim: Optional[int] = None, **overrides: Any):
+    """Construct an ephemeral, pxr-free Moneta handle (``MockUsdTarget``-backed).
+
+    ``MonetaConfig.ephemeral()`` auto-generates a unique ``storage_uri`` and
+    defaults ``use_real_usd=False`` (mock target) with no snapshot/WAL paths,
+    so the handle is fully in-memory and needs no OpenUSD.
+
+    The caller owns the handle lifetime -- use it as a context manager or call
+    ``close()`` -- because Moneta enforces single-owner URI locking.
+    """
+    if not moneta_available():
+        raise RuntimeError(
+            "Moneta is not importable. Install the moneta package or set "
+            f"$MONETA_SRC to its source directory. Last error: {import_error()}"
+        )
+    cfg_kwargs = dict(overrides)
+    if embedding_dim is not None:
+        cfg_kwargs["embedding_dim"] = embedding_dim
+    return Moneta(MonetaConfig.ephemeral(**cfg_kwargs))

--- a/python/synapse/memory/moneta_store.py
+++ b/python/synapse/memory/moneta_store.py
@@ -1,0 +1,277 @@
+"""MonetaBackedStore — SYNAPSE MemoryStore backed by the Moneta engine (Mile 4).
+
+Replaces the JSONL ``MemoryStore`` so the two-store divergence, the dead gauge,
+and the empty stubs become *structurally* impossible: there is one store, and
+``count()`` reads the engine's live entity count directly.
+
+Mapping:
+  * Each SYNAPSE ``Memory`` is serialized whole (``Memory.to_json()``) into a
+    Moneta deposit's ``payload`` — it round-trips byte-for-byte.
+  * ``content`` is embedded (pinned ``Embedder``) for vector recall.
+  * Importance signals (decision / SHOW tier / gate source) map to a
+    ``protected_floor`` so pinned memories resist Moneta's time-decay.
+  * Reads enumerate the engine (``ecs.iter_rows``), deserialize payloads back
+    to ``Memory``, and apply SYNAPSE's filtering/scoring here. Keyword recall is
+    preserved exactly (see :func:`score_memories`); vector recall is a
+    deliberate later upgrade, measured against keyword recall in shadow first.
+
+This class is pure logic over an injected, caller-owned Moneta handle (Moneta
+enforces single-owner URI locking). The factory :meth:`from_storage_dir` builds
+a durable handle; tests inject an ephemeral one.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional
+
+from .models import Memory, MemoryQuery, MemorySearchResult, MemoryTier, MemoryType
+
+logger = logging.getLogger(__name__)
+
+# Importance -> protected_floor. Pinned memories resist Moneta's decay.
+_DEFAULT_PROTECTED_FLOOR = 0.9
+
+
+def score_memories(
+    memories: Iterable[Memory], query: MemoryQuery
+) -> List[MemorySearchResult]:
+    """Faithful re-implementation of ``MemoryStore.search`` scoring (parity target).
+
+    The narrowing predicates mirror the by_type / by_tag / by_keyword index
+    narrowing (raw, case-sensitive tag match — matching ``search``, not
+    ``get_by_tag``); the scoring mirrors the tag/keyword/text weights and the
+    ``(-score, id)`` deterministic sort. Kept standalone so the JSONL store is
+    untouched; Mile 5's shadow harness measures any divergence empirically.
+    """
+    pool = list(memories)
+    if query.memory_types:
+        types = set(query.memory_types)
+        pool = [m for m in pool if m.memory_type in types]
+    if query.tags:
+        qtags = set(query.tags)
+        pool = [m for m in pool if qtags & set(m.tags)]
+    if query.keywords:
+        qkw = set(query.keywords)
+        pool = [m for m in pool if qkw & set(m.keywords)]
+
+    results: List[MemorySearchResult] = []
+    for memory in pool:
+        if memory.is_consolidated and not query.include_consolidated:
+            continue
+        if query.tier and memory.tier != query.tier:
+            continue
+        if query.source and memory.source != query.source:
+            continue
+        if query.since and memory.created_at < query.since:
+            continue
+        if query.until and memory.created_at > query.until:
+            continue
+
+        score = 0.0
+        match_reasons: List[str] = []
+
+        if query.tags:
+            matching_tags = set(query.tags) & set(memory.tags)
+            if matching_tags:
+                score += len(matching_tags) * 0.2
+                match_reasons.append(f"tags: {', '.join(matching_tags)}")
+        if query.keywords:
+            matching_keywords = set(query.keywords) & set(memory.keywords)
+            if matching_keywords:
+                score += len(matching_keywords) * 0.2
+                match_reasons.append(f"keywords: {', '.join(matching_keywords)}")
+        if query.text:
+            text_lower = query.text.lower()
+            content_lower = memory.content.lower()
+            summary_lower = memory.summary.lower()
+            if text_lower in content_lower:
+                score += 0.5
+                match_reasons.append("content match")
+            if text_lower in summary_lower:
+                score += 0.3
+                match_reasons.append("summary match")
+            words = text_lower.split()
+            word_matches = sum(
+                1 for w in words if w in content_lower or w in summary_lower
+            )
+            if word_matches > 0:
+                score += word_matches * 0.1
+                match_reasons.append(f"{word_matches} word matches")
+
+        if not query.text and not query.tags and not query.keywords:
+            score = 0.5
+
+        if score > 0:
+            results.append(
+                MemorySearchResult(
+                    memory=memory,
+                    score=min(1.0, score),
+                    match_reasons=match_reasons,
+                )
+            )
+
+    results.sort(key=lambda r: (-r.score, r.memory.id))
+    if query.limit > 0:
+        results = results[: query.limit]
+    return results
+
+
+class MonetaUpdateNotSupported(NotImplementedError):
+    """Moneta is append/consolidate; in-place update/delete/clear is not clean."""
+
+
+class MonetaBackedStore:
+    """``MemoryStore``-compatible facade over a single Moneta handle."""
+
+    def __init__(self, handle, embedder, *, protected_floor: float = _DEFAULT_PROTECTED_FLOOR):
+        self._handle = handle
+        self._embedder = embedder
+        self._protected_floor = protected_floor
+        # Stamp the embedder id onto the store so a future embedder swap can
+        # detect entries that need re-embedding (handoff capsule PARKED note).
+        self.embedder_id = getattr(embedder, "id", "unknown")
+
+    @classmethod
+    def from_storage_dir(
+        cls, storage_dir, embedder=None, *, protected_floor: float = _DEFAULT_PROTECTED_FLOOR
+    ) -> "MonetaBackedStore":
+        """Build a durable, project-scoped Moneta-backed store.
+
+        Snapshot + WAL live under ``<storage_dir>/.moneta/``; the ``storage_uri``
+        is stable per project dir so the URI lock and snapshot reload key are
+        consistent across restarts. The background snapshot daemon is NOT
+        started here — under the async server that races the ECS single-writer
+        (FC4). Persistence is via :meth:`save` (synchronous snapshot); the
+        production auto-snapshot cadence is wired in Mile 6.
+        """
+        from .embedding import HashEmbedder
+        from . import moneta_runtime as mr
+
+        if not mr.moneta_available():
+            raise RuntimeError(
+                f"Moneta backend requested but not importable: {mr.import_error()}"
+            )
+        embedder = embedder or HashEmbedder()
+        base = Path(storage_dir) / ".moneta"
+        base.mkdir(parents=True, exist_ok=True)
+        cfg = mr.MonetaConfig(
+            storage_uri=f"moneta-file://{Path(storage_dir).resolve().as_posix()}",
+            embedding_dim=embedder.dim,
+            snapshot_path=base / "snapshot.json",
+            wal_path=base / "wal.log",
+        )
+        handle = mr.Moneta(cfg)
+        return cls(handle, embedder, protected_floor=protected_floor)
+
+    # -- write --------------------------------------------------------------
+
+    def _is_protected(self, memory: Memory) -> bool:
+        return (
+            memory.memory_type == MemoryType.DECISION
+            or memory.tier == MemoryTier.SHOW
+            or memory.source == "gate"
+        )
+
+    def add(self, memory: Memory) -> str:
+        text = memory.content or memory.summary or ""
+        embedding = self._embedder.embed(text)
+        payload = memory.to_json()
+        floor = self._protected_floor if self._is_protected(memory) else 0.0
+        try:
+            self._handle.deposit(payload, embedding, protected_floor=floor)
+        except Exception as exc:  # ProtectedQuotaExceededError, etc.
+            if floor > 0.0:
+                # Never drop a memory because the protected quota is full.
+                logger.warning(
+                    "Protected deposit failed (%s); storing unprotected: %s",
+                    type(exc).__name__, exc,
+                )
+                self._handle.deposit(payload, embedding, protected_floor=0.0)
+            else:
+                raise
+        return memory.id
+
+    # -- enumerate (the one coupling to Moneta internals, centralized) ------
+
+    def _iter_memories(self) -> Iterator[Memory]:
+        for row in self._handle.ecs.iter_rows():
+            yield Memory.from_json(row.payload)
+
+    # -- read ---------------------------------------------------------------
+
+    def count(self) -> int:
+        return self._handle.ecs.n
+
+    def all(self) -> List[Memory]:
+        return list(self._iter_memories())
+
+    def get(self, memory_id: str) -> Optional[Memory]:
+        for m in self._iter_memories():
+            if m.id == memory_id:
+                return m
+        return None
+
+    def get_recent(self, limit: int = 10) -> List[Memory]:
+        return sorted(
+            self._iter_memories(), key=lambda m: m.created_at, reverse=True
+        )[:limit]
+
+    def get_by_type(self, memory_type: MemoryType) -> List[Memory]:
+        return [m for m in self._iter_memories() if m.memory_type == memory_type]
+
+    def get_by_tag(self, tag: str) -> List[Memory]:
+        return [m for m in self._iter_memories() if tag in m.tags]
+
+    def get_linked(self, memory_id: str) -> List[Memory]:
+        all_mems = list(self._iter_memories())
+        src = next((m for m in all_mems if m.id == memory_id), None)
+        if src is None:
+            return []
+        targets = {link.target_id for link in src.links}
+        return [m for m in all_mems if m.id in targets]
+
+    def search(self, query: MemoryQuery) -> List[MemorySearchResult]:
+        return score_memories(self._iter_memories(), query)
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def save(self) -> None:
+        """Durably snapshot the engine. No-op when durability is disabled (ephemeral)."""
+        dur = getattr(self._handle, "durability", None)
+        if dur is not None:
+            try:
+                dur.snapshot_ecs(self._handle.ecs)
+            except Exception as exc:
+                logger.warning("Moneta snapshot on save() failed: %s", exc)
+
+    def run_sleep_pass(self):
+        """Trigger Moneta consolidation/decay explicitly (snapshots when durable)."""
+        return self._handle.run_sleep_pass()
+
+    def close(self) -> None:
+        self.save()
+        close = getattr(self._handle, "close", None)
+        if callable(close):
+            close()
+
+    # -- unsupported (append/consolidate engine) ----------------------------
+
+    def update(self, memory: Memory):
+        raise MonetaUpdateNotSupported(
+            "MonetaBackedStore is append/consolidate; in-place update is not "
+            "supported. Re-add as a new memory or trigger consolidation."
+        )
+
+    def delete(self, memory_id: str) -> bool:
+        raise MonetaUpdateNotSupported(
+            "MonetaBackedStore does not support targeted delete; pruning is "
+            "handled by run_sleep_pass() decay/consolidation."
+        )
+
+    def clear(self):
+        raise MonetaUpdateNotSupported(
+            "MonetaBackedStore.clear() is unsupported on a live handle; "
+            "construct a fresh handle for a clean store."
+        )

--- a/python/synapse/memory/moneta_store.py
+++ b/python/synapse/memory/moneta_store.py
@@ -23,8 +23,10 @@ a durable handle; tests inject an ephemeral one.
 from __future__ import annotations
 
 import logging
+import threading
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable, Iterator, List, Optional
+from typing import Dict, Iterable, List, Optional
 
 from .models import Memory, MemoryQuery, MemorySearchResult, MemoryTier, MemoryType
 
@@ -32,6 +34,31 @@ logger = logging.getLogger(__name__)
 
 # Importance -> protected_floor. Pinned memories resist Moneta's decay.
 _DEFAULT_PROTECTED_FLOOR = 0.9
+
+
+@dataclass(frozen=True)
+class PruneAudit:
+    """What a sleep pass actually removed — the lossless prune record.
+
+    ``run_sleep_pass`` is the one destructive memory op (it permanently prunes
+    unprotected memories). Moneta's ``ConsolidationResult`` reports only counts;
+    this captures the ids + payloads + types of what was removed, so data loss
+    is never silent. Back-compatible: ``.pruned``/``.staged``/``.attention_updated``
+    mirror the old return shape.
+    """
+
+    pruned_ids: List[str] = field(default_factory=list)          # SYNAPSE Memory.id
+    pruned_entity_ids: List[str] = field(default_factory=list)   # Moneta UUID (str)
+    pruned_payloads: Dict[str, str] = field(default_factory=dict)
+    pruned_types: Dict[str, str] = field(default_factory=dict)
+    count_before: int = 0
+    count_after: int = 0
+    attention_updated: int = 0
+    staged: int = 0
+
+    @property
+    def pruned(self) -> int:
+        return len(self.pruned_entity_ids)
 
 
 def score_memories(
@@ -132,6 +159,14 @@ class MonetaBackedStore:
         # Stamp the embedder id onto the store so a future embedder swap can
         # detect entries that need re-embedding (handoff capsule PARKED note).
         self.embedder_id = getattr(embedder, "id", "unknown")
+        # FC4: serialize ALL engine access. Moneta's ECS is single-writer —
+        # concurrent deposit/iterate/prune corrupts its swap-and-pop index. This
+        # RLock makes the adapter thread-safe by construction. It guards ONLY
+        # in-process Python state and is never held across an hdefereval
+        # main-thread hop (this adapter makes zero hou.* calls — see the
+        # no-hou-import guard test), so it cannot deadlock the async server.
+        # RLock (not Lock) because close() -> save() is a guarded-calls-guarded edge.
+        self._lock = threading.RLock()
 
     # Protected memories (decisions / show-tier / gate) are exactly the
     # keep-forever set, so the per-handle protected quota is set high: Moneta's
@@ -234,30 +269,38 @@ class MonetaBackedStore:
         embedding = self._embedder.embed(text)
         payload = memory.to_json()
         floor = self._protected_floor if self._is_protected(memory) else 0.0
-        try:
-            self._handle.deposit(payload, embedding, protected_floor=floor)
-        except Exception as exc:  # ProtectedQuotaExceededError, etc.
-            if floor > 0.0:
-                # Never drop a memory because the protected quota is full.
-                logger.warning(
-                    "Protected deposit failed (%s); storing unprotected: %s",
-                    type(exc).__name__, exc,
-                )
-                self._handle.deposit(payload, embedding, protected_floor=0.0)
-            else:
-                raise
+        with self._lock:
+            try:
+                self._handle.deposit(payload, embedding, protected_floor=floor)
+            except Exception as exc:  # ProtectedQuotaExceededError, etc.
+                if floor > 0.0:
+                    # Never drop a memory because the protected quota is full.
+                    logger.warning(
+                        "Protected deposit failed (%s); storing unprotected: %s",
+                        type(exc).__name__, exc,
+                    )
+                    self._handle.deposit(payload, embedding, protected_floor=0.0)
+                else:
+                    raise
         return memory.id
 
     # -- enumerate (the one coupling to Moneta internals, centralized) ------
 
-    def _iter_memories(self) -> Iterator[Memory]:
-        for row in self._handle.ecs.iter_rows():
-            yield Memory.from_json(row.payload)
+    def _iter_memories(self) -> List[Memory]:
+        # Snapshot the engine under the lock and return a list — NOT a generator.
+        # A lazy generator would hold the lock across caller work (or until GC if
+        # abandoned). Materializing the rows under the lock gives every read an
+        # atomic point-in-time view; the expensive JSON deserialization runs
+        # lock-free. All read methods inherit safety from this single snapshot.
+        with self._lock:
+            rows = list(self._handle.ecs.iter_rows())
+        return [Memory.from_json(row.payload) for row in rows]
 
     # -- read ---------------------------------------------------------------
 
     def count(self) -> int:
-        return self._handle.ecs.n
+        with self._lock:
+            return self._handle.ecs.n
 
     def all(self) -> List[Memory]:
         return list(self._iter_memories())
@@ -277,6 +320,7 @@ class MonetaBackedStore:
         return [m for m in self._iter_memories() if m.memory_type == memory_type]
 
     def get_by_tag(self, tag: str) -> List[Memory]:
+        # Raw, case-sensitive — matches search() tag semantics across stores.
         return [m for m in self._iter_memories() if tag in m.tags]
 
     def get_linked(self, memory_id: str) -> List[Memory]:
@@ -294,22 +338,78 @@ class MonetaBackedStore:
 
     def save(self) -> None:
         """Durably snapshot the engine. No-op when durability is disabled (ephemeral)."""
-        dur = getattr(self._handle, "durability", None)
-        if dur is not None:
-            try:
-                dur.snapshot_ecs(self._handle.ecs)
-            except Exception as exc:
-                logger.warning("Moneta snapshot on save() failed: %s", exc)
+        with self._lock:
+            dur = getattr(self._handle, "durability", None)
+            if dur is not None:
+                try:
+                    dur.snapshot_ecs(self._handle.ecs)
+                except Exception as exc:
+                    logger.warning("Moneta snapshot on save() failed: %s", exc)
 
-    def run_sleep_pass(self):
-        """Trigger Moneta consolidation/decay explicitly (snapshots when durable)."""
-        return self._handle.run_sleep_pass()
+    def run_sleep_pass(self) -> PruneAudit:
+        """Trigger Moneta consolidation/decay — AUDITABLE and serialized.
+
+        This is the one destructive memory op: it permanently prunes unprotected
+        memories. We enumerate the live id-set + payloads BEFORE the pass, run it,
+        then diff the survivors to recover exactly which entities were pruned —
+        so data loss is logged, never silent. Held under the lock (the prune
+        mutates the ECS and must not interleave with deposit/iterate).
+        """
+        with self._lock:
+            ecs = self._handle.ecs
+            before_payload: Dict[str, str] = {}
+            before_mem: Dict[str, Optional[Memory]] = {}
+            for row in ecs.iter_rows():
+                eid = str(row.entity_id)
+                before_payload[eid] = row.payload
+                try:
+                    before_mem[eid] = Memory.from_json(row.payload)
+                except Exception:
+                    before_mem[eid] = None  # keep the raw payload for forensics
+            count_before = ecs.n
+
+            result = self._handle.run_sleep_pass()
+
+            survivors = {str(row.entity_id) for row in ecs.iter_rows()}
+            count_after = ecs.n
+
+        pruned_eids = [eid for eid in before_payload if eid not in survivors]
+        pruned_ids: List[str] = []
+        pruned_types: Dict[str, str] = {}
+        for eid in pruned_eids:
+            mem = before_mem.get(eid)
+            if mem is not None:
+                pruned_ids.append(mem.id)
+                pruned_types[mem.id] = getattr(mem.memory_type, "value", str(mem.memory_type))
+
+        audit = PruneAudit(
+            pruned_ids=pruned_ids,
+            pruned_entity_ids=pruned_eids,
+            pruned_payloads={eid: before_payload[eid] for eid in pruned_eids},
+            pruned_types=pruned_types,
+            count_before=count_before,
+            count_after=count_after,
+            attention_updated=getattr(result, "attention_updated", 0),
+            staged=getattr(result, "staged", 0),
+        )
+        if audit.pruned:
+            logger.warning(
+                "moneta.prune lossless-audit pruned=%d staged=%d before=%d after=%d ids=%s",
+                audit.pruned, audit.staged, count_before, count_after, pruned_ids,
+            )
+        else:
+            logger.info(
+                "moneta.sleep_pass pruned=0 staged=%d attended=%d n=%d",
+                audit.staged, audit.attention_updated, count_after,
+            )
+        return audit
 
     def close(self) -> None:
-        self.save()
-        close = getattr(self._handle, "close", None)
-        if callable(close):
-            close()
+        with self._lock:
+            self.save()
+            close = getattr(self._handle, "close", None)
+            if callable(close):
+                close()
 
     # -- unsupported (append/consolidate engine) ----------------------------
 

--- a/python/synapse/memory/moneta_store.py
+++ b/python/synapse/memory/moneta_store.py
@@ -133,18 +133,32 @@ class MonetaBackedStore:
         # detect entries that need re-embedding (handoff capsule PARKED note).
         self.embedder_id = getattr(embedder, "id", "unknown")
 
+    # Protected memories (decisions / show-tier / gate) are exactly the
+    # keep-forever set, so the per-handle protected quota is set high: Moneta's
+    # default 100 is a backstop that would silently demote the 101st pin to
+    # prunable (CRUCIBLE finding). We never want that for SYNAPSE.
+    _PROTECTED_QUOTA = 100_000
+
     @classmethod
     def from_storage_dir(
-        cls, storage_dir, embedder=None, *, protected_floor: float = _DEFAULT_PROTECTED_FLOOR
+        cls,
+        storage_dir,
+        embedder=None,
+        *,
+        protected_floor: float = _DEFAULT_PROTECTED_FLOOR,
+        protected_quota: int = _PROTECTED_QUOTA,
     ) -> "MonetaBackedStore":
         """Build a durable, project-scoped Moneta-backed store.
 
         Snapshot + WAL live under ``<storage_dir>/.moneta/``; the ``storage_uri``
         is stable per project dir so the URI lock and snapshot reload key are
         consistent across restarts. The background snapshot daemon is NOT
-        started here — under the async server that races the ECS single-writer
-        (FC4). Persistence is via :meth:`save` (synchronous snapshot); the
-        production auto-snapshot cadence is wired in Mile 6.
+        started here — under the async server it races the ECS single-writer
+        (FC4). Persistence is via :meth:`save` (synchronous snapshot).
+
+        A corrupt snapshot is quarantined (renamed, preserved) and the store
+        starts fresh, rather than crashing startup or silently abandoning the
+        file — Moneta's ``hydrate()`` does a bare ``json.load`` (CRUCIBLE finding).
         """
         from .embedding import HashEmbedder
         from . import moneta_runtime as mr
@@ -156,14 +170,55 @@ class MonetaBackedStore:
         embedder = embedder or HashEmbedder()
         base = Path(storage_dir) / ".moneta"
         base.mkdir(parents=True, exist_ok=True)
+        snapshot_path = base / "snapshot.json"
+        cls._quarantine_if_corrupt(snapshot_path)
         cfg = mr.MonetaConfig(
             storage_uri=f"moneta-file://{Path(storage_dir).resolve().as_posix()}",
             embedding_dim=embedder.dim,
-            snapshot_path=base / "snapshot.json",
+            quota_override=protected_quota,
+            snapshot_path=snapshot_path,
             wal_path=base / "wal.log",
         )
         handle = mr.Moneta(cfg)
         return cls(handle, embedder, protected_floor=protected_floor)
+
+    _SNAPSHOT_REQUIRED_KEYS = (
+        "entity_id", "payload", "semantic_vector", "utility",
+        "attended_count", "protected_floor", "last_evaluated", "state",
+    )
+
+    @classmethod
+    def _quarantine_if_corrupt(cls, snapshot_path: Path) -> None:
+        """Rename a corrupt snapshot aside so startup neither crashes nor
+        silently discards it. Best-effort; a valid/absent snapshot is untouched."""
+        if not snapshot_path.exists():
+            return
+        import json
+        import time as _time
+        try:
+            with open(snapshot_path, "r", encoding="utf-8") as fp:
+                data = json.load(fp)
+            if not isinstance(data, dict) or not isinstance(data.get("rows", []), list):
+                raise ValueError("snapshot missing a 'rows' list")
+            for row in data.get("rows", []):
+                if not all(k in row for k in cls._SNAPSHOT_REQUIRED_KEYS):
+                    raise ValueError("snapshot row missing required keys")
+        except Exception as exc:
+            bad = snapshot_path.with_name(f"{snapshot_path.name}.corrupt-{int(_time.time())}")
+            try:
+                snapshot_path.replace(bad)
+                logger.error(
+                    "Quarantined corrupt Moneta snapshot %s -> %s (%s); starting fresh",
+                    snapshot_path, bad, exc,
+                )
+            except Exception as move_err:  # last resort: remove so startup proceeds
+                logger.error(
+                    "Corrupt snapshot %s unrecoverable (%s); removing", snapshot_path, move_err
+                )
+                try:
+                    snapshot_path.unlink()
+                except OSError:
+                    pass
 
     # -- write --------------------------------------------------------------
 

--- a/python/synapse/memory/shadow_store.py
+++ b/python/synapse/memory/shadow_store.py
@@ -1,0 +1,162 @@
+"""ShadowMemoryStore — dual-write + parity diff harness (Mile 5).
+
+The safe path to cutover. A ``ShadowMemoryStore`` wraps a **primary** store
+(the authoritative JSONL ``MemoryStore``) and a **shadow** store (the
+``MonetaBackedStore``):
+
+  * Writes go to BOTH. Shadow write failures are isolated and recorded -- they
+    can never break the caller or the primary.
+  * Reads are served from the PRIMARY, so production behavior is byte-for-byte
+    unchanged during the shadow period.
+  * Each read is also run against the shadow and diffed into a
+    :class:`ParityReport`. Once parity holds over real traffic (AP5 / FC3),
+    the cutover (read from shadow) is justified by evidence, not hope.
+
+Comparison can be turned off (``compare_reads=False``) to dual-write with no
+read overhead.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Tuple
+
+from .models import Memory, MemoryQuery, MemorySearchResult, MemoryType
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ParityReport:
+    """Accumulates primary-vs-shadow agreement across reads."""
+
+    comparisons: int = 0
+    matches: int = 0
+    mismatches: List[Tuple[str, Any, Any]] = field(default_factory=list)
+    write_errors: List[str] = field(default_factory=list)
+
+    def record(self, method: str, primary: Any, shadow: Any) -> None:
+        self.comparisons += 1
+        if primary == shadow:
+            self.matches += 1
+        else:
+            self.mismatches.append((method, primary, shadow))
+
+    def record_write_error(self, exc: BaseException) -> None:
+        self.write_errors.append(f"{type(exc).__name__}: {exc}")
+
+    @property
+    def parity_ratio(self) -> float:
+        return self.matches / self.comparisons if self.comparisons else 1.0
+
+    def summary(self) -> dict:
+        return {
+            "comparisons": self.comparisons,
+            "matches": self.matches,
+            "parity_ratio": self.parity_ratio,
+            "mismatch_count": len(self.mismatches),
+            "write_errors": len(self.write_errors),
+        }
+
+
+def _ids(memories) -> List[str]:
+    return [m.id for m in memories]
+
+
+def _ranking(results) -> List[Tuple[str, float]]:
+    return [(r.memory.id, round(r.score, 9)) for r in results]
+
+
+class ShadowMemoryStore:
+    """Primary-authoritative store that mirrors writes to a shadow and diffs reads."""
+
+    def __init__(self, primary, shadow, *, report: Optional[ParityReport] = None,
+                 compare_reads: bool = True):
+        self.primary = primary
+        self.shadow = shadow
+        self.report = report or ParityReport()
+        self.compare_reads = compare_reads
+
+    # -- write (dual; shadow isolated) --------------------------------------
+
+    def add(self, memory: Memory) -> str:
+        result = self.primary.add(memory)
+        self._shadow_write(lambda: self.shadow.add(memory))
+        return result
+
+    def _shadow_write(self, op) -> None:
+        try:
+            op()
+        except Exception as exc:  # never let the shadow break the caller
+            self.report.record_write_error(exc)
+            logger.warning("shadow write failed (isolated): %s", exc)
+
+    # -- read (serve primary; diff shadow) ----------------------------------
+
+    def count(self) -> int:
+        p = self.primary.count()
+        if self.compare_reads:
+            self._compare("count", p, lambda: self.shadow.count())
+        return p
+
+    def get_recent(self, limit: int = 10) -> List[Memory]:
+        p = self.primary.get_recent(limit)
+        if self.compare_reads:
+            self._compare("get_recent", _ids(p), lambda: _ids(self.shadow.get_recent(limit)))
+        return p
+
+    def get_by_type(self, memory_type: MemoryType) -> List[Memory]:
+        p = self.primary.get_by_type(memory_type)
+        if self.compare_reads:
+            self._compare("get_by_type", sorted(_ids(p)),
+                          lambda: sorted(_ids(self.shadow.get_by_type(memory_type))))
+        return p
+
+    def search(self, query: MemoryQuery) -> List[MemorySearchResult]:
+        p = self.primary.search(query)
+        if self.compare_reads:
+            self._compare("search", _ranking(p), lambda: _ranking(self.shadow.search(query)))
+        return p
+
+    def _compare(self, method: str, primary_value, shadow_thunk) -> None:
+        try:
+            shadow_value = shadow_thunk()
+        except Exception as exc:
+            self.report.record_write_error(exc)
+            logger.warning("shadow read failed (isolated): %s", exc)
+            return
+        self.report.record(method, primary_value, shadow_value)
+
+    # -- passthrough reads (no diff) ----------------------------------------
+
+    def get(self, memory_id: str) -> Optional[Memory]:
+        return self.primary.get(memory_id)
+
+    def all(self) -> List[Memory]:
+        return self.primary.all()
+
+    def get_by_tag(self, tag: str) -> List[Memory]:
+        return self.primary.get_by_tag(tag)
+
+    def get_linked(self, memory_id: str) -> List[Memory]:
+        return self.primary.get_linked(memory_id)
+
+    # -- lifecycle (mirror to both; shadow isolated) ------------------------
+
+    def save(self) -> None:
+        self.primary.save()
+        self._shadow_write(lambda: self.shadow.save())
+
+    def update(self, memory: Memory):
+        self.primary.update(memory)
+        self._shadow_write(lambda: self.shadow.update(memory))
+
+    def delete(self, memory_id: str) -> bool:
+        result = self.primary.delete(memory_id)
+        self._shadow_write(lambda: self.shadow.delete(memory_id))
+        return result
+
+    def clear(self):
+        self.primary.clear()
+        self._shadow_write(lambda: self.shadow.clear())

--- a/python/synapse/memory/store.py
+++ b/python/synapse/memory/store.py
@@ -679,7 +679,7 @@ class SynapseMemory:
         """
         self.project_path = self._resolve_project_path(project_path)
         self.storage_dir = self._get_storage_dir()
-        self.store = MemoryStore(self.storage_dir)
+        self.store = self._make_store(self.storage_dir)
 
         # Callbacks
         self._on_memory_added: List[Callable[[Memory], None]] = []
@@ -687,6 +687,27 @@ class SynapseMemory:
 
         logger.info("Initialized for project: %s", self.project_path)
         logger.info("Storage: %s", self.storage_dir)
+
+    def _make_store(self, storage_dir):
+        """Select the memory backend via $SYNAPSE_MEMORY_BACKEND.
+
+        Default ``jsonl`` is the unchanged behavior. ``moneta`` routes through
+        the Moneta engine (Mile 4); it falls back to JSONL with a warning if
+        Moneta can't be imported, so setting the flag can never break startup.
+        """
+        backend = os.environ.get("SYNAPSE_MEMORY_BACKEND", "jsonl").strip().lower()
+        if backend == "moneta":
+            try:
+                from .moneta_store import MonetaBackedStore
+                store = MonetaBackedStore.from_storage_dir(storage_dir)
+                logger.info("Memory backend: moneta (%s)", store.embedder_id)
+                return store
+            except Exception as exc:
+                logger.warning(
+                    "SYNAPSE_MEMORY_BACKEND=moneta unavailable (%s); "
+                    "falling back to jsonl.", exc,
+                )
+        return MemoryStore(storage_dir)
 
     def _resolve_project_path(self, path: Optional[str]) -> Path:
         """Resolve the project path."""

--- a/python/synapse/memory/store.py
+++ b/python/synapse/memory/store.py
@@ -707,6 +707,19 @@ class SynapseMemory:
                     "SYNAPSE_MEMORY_BACKEND=moneta unavailable (%s); "
                     "falling back to jsonl.", exc,
                 )
+        elif backend == "shadow":
+            try:
+                from .moneta_store import MonetaBackedStore
+                from .shadow_store import ShadowMemoryStore
+                primary = MemoryStore(storage_dir)
+                shadow = MonetaBackedStore.from_storage_dir(storage_dir)
+                logger.info("Memory backend: shadow (jsonl primary + moneta shadow)")
+                return ShadowMemoryStore(primary, shadow)
+            except Exception as exc:
+                logger.warning(
+                    "SYNAPSE_MEMORY_BACKEND=shadow unavailable (%s); "
+                    "falling back to jsonl.", exc,
+                )
         return MemoryStore(storage_dir)
 
     def _resolve_project_path(self, path: Optional[str]) -> Path:

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,86 @@
+"""Mile 8 — backfill JSONL -> Moneta: count-agnostic, backup-first, reversible."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "python"))
+
+from synapse.memory import moneta_runtime as mr  # noqa: E402
+from synapse.memory.models import Memory, MemoryType  # noqa: E402
+from synapse.memory.store import MemoryStore  # noqa: E402
+from synapse.memory.backfill import backfill_to_moneta  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not mr.moneta_available(),
+    reason=f"Moneta not importable (set $MONETA_SRC). Last error: {mr.import_error()}",
+)
+
+
+def _seed_jsonl(storage_dir, n_notes=5, n_decisions=2):
+    src = MemoryStore(storage_dir)
+    src._wait_loaded()
+    for i in range(n_notes):
+        src.add(Memory(content=f"note {i}", memory_type=MemoryType.NOTE,
+                       created_at=f"2026-02-0{i + 1}T00:00:00Z"))
+    for i in range(n_decisions):
+        src.add(Memory(content=f"decision {i}", memory_type=MemoryType.DECISION))
+    src.save()
+    return n_notes + n_decisions
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    storage = tmp_path / ".synapse"
+    total = _seed_jsonl(storage)
+    report = backfill_to_moneta(storage, dry_run=True)
+    assert report["source_count"] == total
+    assert report["would_deposit"] == total
+    assert report["deposited"] == 0
+    # No moneta store created on a dry run.
+    assert not (storage / ".moneta" / "snapshot.json").exists()
+
+
+def test_execute_backfills_and_verifies(tmp_path):
+    storage = tmp_path / ".synapse"
+    total = _seed_jsonl(storage)
+    report = backfill_to_moneta(storage, dry_run=False)
+    assert report["source_count"] == total
+    assert report["deposited"] == total
+    assert report["verified"] is True
+
+
+def test_backup_is_taken_and_source_intact(tmp_path):
+    storage = tmp_path / ".synapse"
+    _seed_jsonl(storage)
+    jsonl = storage / "memory.jsonl"
+    before = jsonl.read_bytes()
+    report = backfill_to_moneta(storage, dry_run=False, backup=True)
+    assert report["backup"] is not None
+    assert Path(report["backup"]).exists()
+    assert jsonl.read_bytes() == before  # source untouched (reversible)
+
+
+def test_content_round_trips_through_backfill(tmp_path):
+    from synapse.memory.moneta_store import MonetaBackedStore
+    storage = tmp_path / ".synapse"
+    _seed_jsonl(storage, n_notes=3, n_decisions=1)
+    backfill_to_moneta(storage, dry_run=False)
+    # Re-open the moneta store and confirm the decision survived with content.
+    store = MonetaBackedStore.from_storage_dir(storage)
+    try:
+        decisions = store.get_by_type(MemoryType.DECISION)
+        assert len(decisions) == 1
+        assert decisions[0].content == "decision 0"
+    finally:
+        store.close()
+
+
+def test_empty_store_backfills_to_zero(tmp_path):
+    storage = tmp_path / ".synapse"
+    MemoryStore(storage).save()  # empty store
+    report = backfill_to_moneta(storage, dry_run=False)
+    assert report["source_count"] == 0
+    assert report["deposited"] == 0
+    assert report["verified"] is True

--- a/tests/test_moneta_crucible.py
+++ b/tests/test_moneta_crucible.py
@@ -1,0 +1,293 @@
+"""Mile 7 — CRUCIBLE L4 adversarial pins for the Moneta backend.
+
+These encode the findings of the Mile 7 adversarial fan-out. Two were real
+defects and are FIXED here (protected-quota silent demotion; corrupt-snapshot
+startup-killer); the rest pin documented behavior so any future drift fails
+loud. Never weakened — fix-forward only.
+"""
+
+import json
+import queue
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "python"))
+
+from synapse.memory import moneta_runtime as mr  # noqa: E402
+from synapse.memory.embedding import HashEmbedder  # noqa: E402
+from synapse.memory.models import (  # noqa: E402
+    LinkType, Memory, MemoryQuery, MemoryTier, MemoryType,
+)
+from synapse.memory.store import MemoryStore  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not mr.moneta_available(),
+    reason=f"Moneta not importable (set $MONETA_SRC). Last error: {mr.import_error()}",
+)
+
+DIM = 256
+
+
+def _eph(**cfg):
+    from synapse.memory.moneta_store import MonetaBackedStore
+    return MonetaBackedStore(mr.make_ephemeral(embedding_dim=DIM, **cfg), HashEmbedder(dim=DIM))
+
+
+def _backdate(store, seconds_ago=10_000):
+    ecs = store._handle.ecs
+    past = time.time() - seconds_ago
+    for i in range(len(ecs._last_evaluated)):
+        ecs._last_evaluated[i] = past
+
+
+# --------------------------------------------------------------------------- #
+# decay / consolidation (opt-in; protected set survives)
+# --------------------------------------------------------------------------- #
+
+def test_unprotected_memory_pruned_only_on_explicit_sleep_pass():
+    s = _eph(half_life_seconds=60.0)
+    s.add(Memory(content="routine note", memory_type=MemoryType.NOTE))
+    s.add(Memory(content="an action", memory_type=MemoryType.ACTION))
+    assert s.count() == 2
+    # No pruning happens on normal add/read — only when consolidation is asked for.
+    assert s.count() == 2
+    _backdate(s)
+    result = s.run_sleep_pass()  # explicit, opt-in
+    assert result.pruned == 2
+    assert s.count() == 0  # documented: decay expires unprotected memories
+
+
+def test_decision_survives_many_sleep_passes():
+    s = _eph(half_life_seconds=60.0)
+    s.add(Memory(content="load-bearing decision", memory_type=MemoryType.DECISION))
+    for _ in range(25):
+        _backdate(s)
+        s.run_sleep_pass()
+    assert s.count() == 1
+    assert s.get_by_type(MemoryType.DECISION)[0].content == "load-bearing decision"
+
+
+def test_protected_quota_does_not_silently_demote(tmp_path):
+    # FIX VERIFICATION: from_storage_dir raises quota_override high, so the 101st
+    # protected memory is NOT silently demoted to prunable (CRUCIBLE finding 2).
+    from synapse.memory.moneta_store import MonetaBackedStore
+    s = MonetaBackedStore.from_storage_dir(tmp_path / "proj")
+    try:
+        for i in range(101):
+            s.add(Memory(content=f"decision {i}", memory_type=MemoryType.DECISION))
+        assert s._handle.ecs.count_protected() == 101  # all pinned, none demoted
+        _backdate(s)
+        s.run_sleep_pass()
+        assert s.count() == 101  # none pruned
+    finally:
+        s.close()
+
+
+def test_get_recent_order_stable_under_decay():
+    s = _eph(half_life_seconds=60.0)
+    for i in range(4):
+        s.add(Memory(content=f"m{i}", memory_type=MemoryType.DECISION,
+                     created_at=f"2026-01-0{i + 1}T00:00:00Z"))
+    before = [m.id for m in s.get_recent(10)]
+    _backdate(s)
+    s.run_sleep_pass()
+    after = [m.id for m in s.get_recent(10)]
+    assert before == after  # decay sorts on created_at, never reorders
+
+
+# --------------------------------------------------------------------------- #
+# corrupt-snapshot recovery (FIX VERIFICATION)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("garbage", [
+    "", "{not json", "[1,2,3]", '{"rows": "nope"}',
+    '{"snapshot_version":1,"rows":[{"entity_id":"x"}]}',  # row missing required keys
+])
+def test_corrupt_snapshot_is_quarantined_not_fatal(tmp_path, garbage):
+    from synapse.memory.moneta_store import MonetaBackedStore
+    s1 = MonetaBackedStore.from_storage_dir(tmp_path / "proj")
+    s1.add(Memory(content="will be stranded", memory_type=MemoryType.DECISION))
+    s1.save()
+    s1.close()
+
+    snap = tmp_path / "proj" / ".moneta" / "snapshot.json"
+    snap.write_text(garbage, encoding="utf-8")
+
+    s2 = MonetaBackedStore.from_storage_dir(tmp_path / "proj")  # must not crash
+    try:
+        assert s2.count() == 0  # fresh start
+        quarantined = list((tmp_path / "proj" / ".moneta").glob("snapshot.json.corrupt-*"))
+        assert quarantined, "corrupt snapshot must be preserved, not abandoned"
+    finally:
+        s2.close()
+
+
+def test_valid_snapshot_is_not_quarantined(tmp_path):
+    from synapse.memory.moneta_store import MonetaBackedStore
+    s1 = MonetaBackedStore.from_storage_dir(tmp_path / "proj")
+    s1.add(Memory(content="survives", memory_type=MemoryType.DECISION))
+    s1.save()
+    s1.close()
+    s2 = MonetaBackedStore.from_storage_dir(tmp_path / "proj")
+    try:
+        assert s2.count() == 1  # clean reload, nothing quarantined
+        assert not list((tmp_path / "proj" / ".moneta").glob("snapshot.json.corrupt-*"))
+    finally:
+        s2.close()
+
+
+# --------------------------------------------------------------------------- #
+# concurrency / single-writer (FC4 seam)
+# --------------------------------------------------------------------------- #
+
+def test_concurrent_add_is_lossless_under_gil():
+    # Append-only deposits are atomic under the GIL; pin it so a regression
+    # (or a free-threaded build) surfaces.
+    s = _eph()
+    n_threads, per = 8, 200
+
+    def worker(t):
+        for i in range(per):
+            s.add(Memory(content=f"t{t}-i{i}", memory_type=MemoryType.NOTE))
+
+    threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+    assert s.count() == n_threads * per
+
+
+def test_serialized_writer_is_lossless():
+    # The shape SYNAPSE's async server must use: all mutations funneled to one
+    # writer. Single-writer access is correct (the supported contract).
+    s = _eph()
+    q = queue.Queue()
+    for i in range(500):
+        q.put(Memory(content=f"m{i}", memory_type=MemoryType.NOTE))
+    while not q.empty():
+        s.add(q.get())
+    assert s.count() == 500
+
+
+# --------------------------------------------------------------------------- #
+# payload integrity / edges
+# --------------------------------------------------------------------------- #
+
+def test_hostile_payload_round_trips_exactly():
+    s = _eph()
+    m = Memory(
+        content='{"x":1}\n\t"q" café \U0001f9e0 \\ \r end',
+        memory_type=MemoryType.DECISION,
+        tags=['a"b', 'c\\d', 'café'],
+        keywords=['k\\1'],
+        frame_range=(1001, 1095),
+        confidence=0.333333333333,
+    )
+    m.add_link("mem_target", LinkType.SUPERSEDES, reason="r")
+    s.add(m)
+    assert s.get(m.id).to_dict() == m.to_dict()  # every field, exact
+
+
+def test_empty_content_is_enumerable_not_lost():
+    s = _eph()
+    m = Memory(content="", memory_type=MemoryType.NOTE)
+    s.add(m)
+    # Zero-vector embedding => invisible to a future vector query, but every
+    # enumeration read must still surface it (no silent loss).
+    assert s.get(m.id) is not None
+    assert any(x.id == m.id for x in s.get_by_type(MemoryType.NOTE))
+    assert any(r.memory.id == m.id for r in s.search(MemoryQuery()))
+
+
+def test_duplicate_content_id_collision_is_documented():
+    # Upstream models.py: Memory.id hashes content+type (created_at empty at id
+    # time), so same content+type collides. Moneta appends both rows; get()
+    # returns the first. Pinned so a future models.py fix is a deliberate change.
+    s = _eph()
+    a = Memory(content="dup", memory_type=MemoryType.NOTE)
+    b = Memory(content="dup", memory_type=MemoryType.NOTE)
+    assert a.id == b.id
+    s.add(a)
+    s.add(b)
+    assert s.count() == 2
+    assert len([m for m in s.all() if m.id == a.id]) == 2
+    assert s.get(a.id) is not None
+
+
+def test_get_by_tag_is_raw_case_sensitive():
+    s = _eph()
+    s.add(Memory(content="c", memory_type=MemoryType.NOTE, tags=["MixedCase"]))
+    assert len(s.get_by_tag("MixedCase")) == 1
+    assert len(s.get_by_tag("mixedcase")) == 0  # raw match, matching search() semantics
+
+
+@pytest.mark.parametrize("q", [
+    MemoryQuery(text="", limit=50),
+    MemoryQuery(text="café", limit=50),
+    MemoryQuery(text="hello", limit=10 ** 9),
+    MemoryQuery(text="hello", limit=0),
+    MemoryQuery(text="zzz-nothing-matches", limit=50),
+    MemoryQuery(limit=50),
+])
+def test_search_edge_query_parity_with_jsonl(tmp_path, q):
+    j = MemoryStore(tmp_path / ".synapse")
+    s = _eph()
+    corpus = [
+        Memory(content="hello world", memory_type=MemoryType.NOTE, tags=["t1"]),
+        Memory(content="café \U0001f9e0", memory_type=MemoryType.DECISION),
+    ]
+    for m in corpus:
+        j.add(m)
+        s.add(m)
+    norm = lambda res: [(r.memory.id, round(r.score, 6)) for r in res]
+    assert norm(s.search(q)) == norm(j.search(q))
+
+
+# --------------------------------------------------------------------------- #
+# isolation / flag hygiene
+# --------------------------------------------------------------------------- #
+
+def test_moneta_backend_never_fires_evolution(tmp_path, monkeypatch):
+    monkeypatch.setenv("SYNAPSE_MEMORY_BACKEND", "moneta")
+    from synapse.memory import evolution
+    calls = []
+    monkeypatch.setattr(evolution, "check_evolution", lambda *a, **k: calls.append(1) or {})
+    from synapse.memory.store import SynapseMemory
+    sm = SynapseMemory(project_path=str(tmp_path / "proj"))
+    try:
+        for i in range(25):
+            sm.add(content=f"m{i}", memory_type=MemoryType.NOTE)
+        assert calls == []  # evolution.py is retired under the Moneta backend
+    finally:
+        sm.store.close()
+
+
+@pytest.mark.parametrize("value,expect_moneta", [
+    ("moneta", True), ("MONETA", True), (" moneta ", True),
+    ("garbage", False), ("", False), ("JSONL", False),
+])
+def test_flag_hygiene(tmp_path, monkeypatch, value, expect_moneta):
+    monkeypatch.setenv("SYNAPSE_MEMORY_BACKEND", value)
+    from synapse.memory.store import SynapseMemory
+    from synapse.memory.moneta_store import MonetaBackedStore
+    sm = SynapseMemory(project_path=str(tmp_path / f"proj_{abs(hash(value))}"))
+    try:
+        assert isinstance(sm.store, MonetaBackedStore) is expect_moneta
+    finally:
+        if hasattr(sm.store, "close"):
+            sm.store.close()
+
+
+def test_fallback_to_jsonl_when_moneta_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setenv("SYNAPSE_MEMORY_BACKEND", "moneta")
+    from synapse.memory import moneta_runtime
+    monkeypatch.setattr(moneta_runtime, "moneta_available", lambda: False)
+    from synapse.memory.store import SynapseMemory
+    sm = SynapseMemory(project_path=str(tmp_path / "proj"))
+    assert isinstance(sm.store, MemoryStore)  # graceful, no crash

--- a/tests/test_moneta_fc4_audit.py
+++ b/tests/test_moneta_fc4_audit.py
@@ -1,0 +1,245 @@
+"""FC4 thread-safety + prune auditability for MonetaBackedStore.
+
+Closes the one staged gap: the Moneta backend is now thread-safe BY
+CONSTRUCTION (a serialization RLock), and the one destructive op
+(run_sleep_pass) is auditable (returns/logs what it pruned). Proven standalone
+— no live Houdini needed. Skips cleanly where Moneta is absent.
+"""
+
+import logging
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "python"))
+
+from synapse.memory import moneta_runtime as mr  # noqa: E402
+from synapse.memory.embedding import HashEmbedder  # noqa: E402
+from synapse.memory.models import Memory, MemoryQuery, MemoryType  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not mr.moneta_available(),
+    reason=f"Moneta not importable (set $MONETA_SRC). Last error: {mr.import_error()}",
+)
+
+DIM = 64
+
+
+def _store(**cfg):
+    from synapse.memory.moneta_store import MonetaBackedStore
+    return MonetaBackedStore(mr.make_ephemeral(embedding_dim=DIM, **cfg), HashEmbedder(dim=DIM))
+
+
+def _backdate(store, seconds_ago=100_000):
+    ecs = store._handle.ecs
+    past = time.time() - seconds_ago
+    for i in range(len(ecs._last_evaluated)):
+        ecs._last_evaluated[i] = past
+
+
+def _assert_ecs_consistent(store):
+    """The single invariant that distinguishes a locked store from a corrupt one."""
+    ecs = store._handle.ecs
+    n = len(ecs._ids)
+    for col in (ecs._payloads, ecs._embeddings, ecs._utility, ecs._attended,
+                ecs._protected_floor, ecs._last_evaluated, ecs._state, ecs._usd_link):
+        assert len(col) == n, "ECS column length desync"
+    assert len(ecs._id_to_row) == n, "_id_to_row desync"
+    assert all(0 <= r < n for r in ecs._id_to_row.values()), "_id_to_row out of range"
+    assert all(ecs._ids[r] == eid for eid, r in ecs._id_to_row.items()), "_id_to_row mismapped"
+
+
+# --------------------------------------------------------------------------- #
+# FC4 — concurrency must not corrupt the single-writer ECS
+# --------------------------------------------------------------------------- #
+
+def test_concurrent_add_and_prune_no_corruption():
+    s = _store(half_life_seconds=60.0)
+    for i in range(200):  # seed unprotected, then backdate so prune is eligible
+        s.add(Memory(content=f"seed {i}", memory_type=MemoryType.NOTE))
+    _backdate(s)
+
+    errors = []
+    barrier = threading.Barrier(10)
+
+    def adder(t):
+        barrier.wait()
+        try:
+            for i in range(200):
+                s.add(Memory(content=f"t{t}-i{i}", memory_type=MemoryType.NOTE))
+        except Exception as e:  # noqa: BLE001
+            errors.append(repr(e))
+
+    def pruner():
+        barrier.wait()
+        try:
+            for _ in range(50):
+                s.run_sleep_pass()
+        except Exception as e:  # noqa: BLE001
+            errors.append(repr(e))
+
+    threads = [threading.Thread(target=adder, args=(t,)) for t in range(8)]
+    threads += [threading.Thread(target=pruner) for _ in range(2)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+
+    assert errors == [], f"concurrent add/prune raised: {errors[:5]}"
+    _assert_ecs_consistent(s)
+
+
+def test_concurrent_iterate_during_prune():
+    s = _store(half_life_seconds=60.0)
+    for i in range(200):
+        s.add(Memory(content=f"seed {i}", memory_type=MemoryType.NOTE))
+    _backdate(s)
+
+    errors = []
+    stop = threading.Event()
+
+    def reader():
+        try:
+            while not stop.is_set():
+                for r in s.search(MemoryQuery()):
+                    assert isinstance(r.memory, Memory)  # no torn payload
+                s.all()
+        except Exception as e:  # noqa: BLE001
+            errors.append(repr(e))
+
+    def pruner():
+        try:
+            for _ in range(30):
+                s.run_sleep_pass()
+        finally:
+            stop.set()
+
+    readers = [threading.Thread(target=reader) for _ in range(8)]
+    p = threading.Thread(target=pruner)
+    for th in readers:
+        th.start()
+    p.start()
+    p.join()
+    for th in readers:
+        th.join()
+
+    assert errors == [], f"iterate-during-prune raised: {errors[:5]}"
+    _assert_ecs_consistent(s)
+
+
+def test_concurrent_add_is_lossless():
+    s = _store()
+    barrier = threading.Barrier(8)
+
+    def adder(t):
+        barrier.wait()
+        for i in range(300):
+            s.add(Memory(content=f"t{t}-i{i}", memory_type=MemoryType.NOTE))
+
+    threads = [threading.Thread(target=adder, args=(t,)) for t in range(8)]
+    for th in threads:
+        th.start()
+    for th in threads:
+        th.join()
+    assert s.count() == 8 * 300
+    _assert_ecs_consistent(s)
+
+
+def test_count_under_churn_never_raises():
+    s = _store(half_life_seconds=60.0)
+    for i in range(100):
+        s.add(Memory(content=f"seed {i}", memory_type=MemoryType.NOTE))
+    _backdate(s)
+    seen, errors, stop = [], [], threading.Event()
+
+    def counter():
+        try:
+            while not stop.is_set():
+                seen.append(s.count())
+        except Exception as e:  # noqa: BLE001
+            errors.append(repr(e))
+
+    def churn():
+        try:
+            for i in range(100):
+                s.add(Memory(content=f"c{i}", memory_type=MemoryType.NOTE))
+            for _ in range(20):
+                s.run_sleep_pass()
+        finally:
+            stop.set()
+
+    c = threading.Thread(target=counter)
+    ch = threading.Thread(target=churn)
+    c.start(); ch.start(); ch.join(); c.join()
+    assert errors == []
+    assert all(isinstance(x, int) and x >= 0 for x in seen)
+
+
+def test_adapter_imports_no_hou():
+    # Pins the deadlock-freedom argument: the adapter holds its lock only over
+    # pure-Python engine state and never across an hdefereval main-thread hop.
+    # AST-based so it checks real imports, not mentions in comments/docstrings.
+    import ast
+    from synapse.memory import moneta_store
+    tree = ast.parse(Path(moneta_store.__file__).read_text(encoding="utf-8"))
+    bad = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            bad += [n.name for n in node.names if n.name.split(".")[0] in ("hou", "hdefereval")]
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module.split(".")[0] in ("hou", "hdefereval"):
+                bad.append(node.module)
+    assert not bad, f"adapter must not import hou/hdefereval (deadlock-freedom): {bad}"
+    # And no hou binding leaked into the module namespace at import time.
+    assert not hasattr(moneta_store, "hou")
+    assert not hasattr(moneta_store, "hdefereval")
+
+
+# --------------------------------------------------------------------------- #
+# prune auditability — data loss is never silent
+# --------------------------------------------------------------------------- #
+
+def test_prune_audit_returns_pruned_ids():
+    s = _store(half_life_seconds=60.0)
+    doomed = Memory(content="ephemeral scratch note", memory_type=MemoryType.NOTE)
+    kept = Memory(content="Decision: lock the wiring", memory_type=MemoryType.DECISION)
+    s.add(doomed)
+    s.add(kept)
+    _backdate(s)
+    audit = s.run_sleep_pass()
+
+    assert doomed.id in audit.pruned_ids
+    assert kept.id not in audit.pruned_ids
+    assert audit.pruned == 1
+    assert audit.count_before == 2
+    assert audit.count_after == 1
+    assert audit.pruned_types[doomed.id] == MemoryType.NOTE.value
+    assert any("ephemeral scratch note" in p for p in audit.pruned_payloads.values())
+    assert s.get(kept.id) is not None
+    assert s.get(doomed.id) is None
+
+
+def test_prune_audit_logs_at_warning(caplog):
+    s = _store(half_life_seconds=60.0)
+    doomed = Memory(content="another throwaway", memory_type=MemoryType.NOTE)
+    s.add(doomed)
+    _backdate(s)
+    with caplog.at_level(logging.WARNING, logger="synapse.memory.moneta_store"):
+        audit = s.run_sleep_pass()
+    assert audit.pruned == 1
+    blob = " ".join(r.message for r in caplog.records)
+    assert "lossless-audit" in blob
+    assert doomed.id in blob
+
+
+def test_no_prune_is_quiet_and_consistent():
+    s = _store()  # default long half-life: nothing decays enough to prune
+    s.add(Memory(content="Decision: keep me", memory_type=MemoryType.DECISION))
+    audit = s.run_sleep_pass()
+    assert audit.pruned == 0
+    assert audit.pruned_ids == []
+    assert audit.count_before == audit.count_after == s.count()

--- a/tests/test_moneta_integration.py
+++ b/tests/test_moneta_integration.py
@@ -1,0 +1,136 @@
+"""Mile 6 — system-level integration of the Moneta backend.
+
+Verifies the composed system through the real SynapseMemory facade (the API
+callers use), not the adapter in isolation:
+
+  * AP3 — facade methods (add/decision/note/action/get_decisions/get_recent/
+    search) work unchanged through the Moneta backend.
+  * AP4 — the gauge invariant: the metrics gauge reads ``store.count()``
+    (handlers.py:1166), which under Moneta is ``ecs.n`` — so gauge == count by
+    construction, for any backend.
+  * AP7 — replay determinism: identical inputs + the pinned HashEmbedder ->
+    identical engine state.
+  * FC4 seam — single-owner URI lock: a second handle on the same storage dir
+    is refused. (The async-server deadlock check is live-gated; see the ship
+    report — it needs the running FastMCP server and is not simulated here.)
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "python"))
+
+from synapse.memory import moneta_runtime as mr  # noqa: E402
+from synapse.memory.embedding import HashEmbedder  # noqa: E402
+from synapse.memory.models import Memory, MemoryQuery, MemoryType  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not mr.moneta_available(),
+    reason=f"Moneta not importable (set $MONETA_SRC). Last error: {mr.import_error()}",
+)
+
+DIM = 256
+
+
+def test_facade_e2e_through_moneta_backend(tmp_path, monkeypatch):
+    monkeypatch.setenv("SYNAPSE_MEMORY_BACKEND", "moneta")
+    from synapse.memory.store import SynapseMemory
+    from synapse.memory.moneta_store import MonetaBackedStore
+
+    sm = SynapseMemory(project_path=str(tmp_path / "proj"))
+    try:
+        assert isinstance(sm.store, MonetaBackedStore)
+        sm.decision(decision="use Moneta as the backend", reasoning="kills divergence")
+        sm.note("a routine note")
+        sm.action(action="created /obj/geo1")
+
+        assert sm.store.count() == 3
+        assert len(sm.get_decisions()) == 1
+        assert sm.get_decisions()[0].memory_type == MemoryType.DECISION
+        assert len(sm.get_recent(10)) == 3
+        hits = sm.search("Moneta", limit=5)
+        assert any("Moneta" in h.memory.content for h in hits)
+    finally:
+        sm.store.close()
+
+
+def test_gauge_invariant_holds_under_moneta(tmp_path, monkeypatch):
+    # AP4: the gauge IS store.count(); under Moneta that is ecs.n. They cannot
+    # diverge the way the old JSONL gauge did (it read a dead accessor).
+    monkeypatch.setenv("SYNAPSE_MEMORY_BACKEND", "moneta")
+    from synapse.memory.store import SynapseMemory
+
+    sm = SynapseMemory(project_path=str(tmp_path / "proj"))
+    try:
+        for i in range(7):
+            sm.add(content=f"memory {i}", memory_type=MemoryType.NOTE)
+        gauge = sm.store.count()          # what handlers.py:1166 emits
+        truth = len(sm.store.all())       # actual stored entities
+        assert gauge == truth == 7
+    finally:
+        sm.store.close()
+
+
+def test_replay_determinism_same_inputs_same_state():
+    # AP7: same memories + same pinned embedder -> identical engine state.
+    from synapse.memory.moneta_store import MonetaBackedStore
+
+    corpus = [
+        Memory(content="alpha", memory_type=MemoryType.NOTE, tags=["a"],
+               created_at="2026-01-01T00:00:00Z"),
+        Memory(content="beta decision", memory_type=MemoryType.DECISION,
+               created_at="2026-01-02T00:00:00Z"),
+        Memory(content="gamma", memory_type=MemoryType.ACTION, keywords=["g"],
+               created_at="2026-01-03T00:00:00Z"),
+    ]
+
+    def build_state():
+        s = MonetaBackedStore(mr.make_ephemeral(embedding_dim=DIM), HashEmbedder(dim=DIM))
+        for m in corpus:
+            s.add(m)
+        return sorted(
+            ((row.payload, tuple(row.semantic_vector)) for row in s._handle.ecs.iter_rows()),
+            key=lambda t: t[0],
+        )
+
+    assert build_state() == build_state()
+
+
+def test_single_owner_uri_lock_is_enforced(tmp_path):
+    # FC4 seam: one durable store per project dir. A second handle on the same
+    # dir must be refused so two owners can never race the single-writer ECS.
+    from synapse.memory.moneta_store import MonetaBackedStore
+
+    s1 = MonetaBackedStore.from_storage_dir(tmp_path / "proj")
+    try:
+        with pytest.raises(Exception) as ei:
+            MonetaBackedStore.from_storage_dir(tmp_path / "proj")
+        assert "lock" in str(ei.value).lower() or "locked" in type(ei.value).__name__.lower()
+    finally:
+        s1.close()
+    # After release, a fresh owner acquires cleanly and reloads prior state.
+    s2 = MonetaBackedStore.from_storage_dir(tmp_path / "proj")
+    try:
+        assert isinstance(s2.count(), int)
+    finally:
+        s2.close()
+
+
+def test_durable_reload_across_owners(tmp_path):
+    # The persistent path survives close/reopen (snapshot + WAL).
+    from synapse.memory.moneta_store import MonetaBackedStore
+
+    s1 = MonetaBackedStore.from_storage_dir(tmp_path / "proj")
+    s1.add(Memory(content="persist across restart", memory_type=MemoryType.DECISION))
+    s1.save()
+    s1.close()
+
+    s2 = MonetaBackedStore.from_storage_dir(tmp_path / "proj")
+    try:
+        assert s2.count() == 1
+        assert s2.get_by_type(MemoryType.DECISION)[0].content == "persist across restart"
+    finally:
+        s2.close()

--- a/tests/test_moneta_runtime.py
+++ b/tests/test_moneta_runtime.py
@@ -7,13 +7,15 @@ isn't (e.g. stock GitHub CI). The point they pin: the ephemeral /
 (harness AP9), and the handle's single-owner URI lock releases on close.
 """
 
+import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
 _ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(_ROOT / "python"))
+_PYDIR = _ROOT / "python"
+sys.path.insert(0, str(_PYDIR))
 
 from synapse.memory import moneta_runtime as mr  # noqa: E402
 
@@ -28,16 +30,34 @@ def test_guard_reports_available_without_error():
     assert mr.import_error() is None
 
 
-def test_ephemeral_round_trip_no_pxr():
-    # Pin AP9: the ephemeral path must not pull in OpenUSD.
-    assert "pxr" not in sys.modules, "pxr leaked into the test env before construction"
+def test_ephemeral_round_trip():
     with mr.make_ephemeral(embedding_dim=8) as m:
         eid = m.deposit("synapse remembers this", [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
         hits = m.query([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8], limit=5)
         assert len(hits) == 1
         assert hits[0].payload == "synapse remembers this"  # byte-for-byte round-trip
         assert hits[0].entity_id == eid
-    assert "pxr" not in sys.modules, "ephemeral / MockUsdTarget path must not require pxr"
+
+
+def test_ephemeral_path_is_pxr_free():
+    # Pin AP9 in a CLEAN subprocess: an in-process `"pxr" not in sys.modules`
+    # check is unreliable because sibling tests (evolution/Charizard) import pxr
+    # and pollute the shared interpreter. A fresh interpreter proves the
+    # ephemeral / MockUsdTarget path imports no OpenUSD by itself.
+    driver = (
+        "import sys;"
+        f"sys.path.insert(0, {str(_PYDIR)!r});"
+        "from synapse.memory import moneta_runtime as mr;"
+        "assert mr.moneta_available();"
+        "m = mr.make_ephemeral(embedding_dim=8);"
+        "m.deposit('x', [0.1]*8);"
+        "assert m.query([0.1]*8, limit=3)[0].payload == 'x';"
+        "m.close();"
+        "assert 'pxr' not in sys.modules, 'pxr loaded by ephemeral path';"
+        "print('PXR_FREE_OK')"
+    )
+    out = subprocess.check_output([sys.executable, "-c", driver], text=True)
+    assert "PXR_FREE_OK" in out
 
 
 def test_empty_query_returns_empty_not_error():

--- a/tests/test_moneta_runtime.py
+++ b/tests/test_moneta_runtime.py
@@ -1,0 +1,55 @@
+"""Mile 3 — pxr/CI path: guarded Moneta import + ephemeral round-trip.
+
+These tests run for real wherever Moneta is importable (locally with
+``$MONETA_SRC`` set, or with the package installed) and SKIP cleanly where it
+isn't (e.g. stock GitHub CI). The point they pin: the ephemeral /
+``MockUsdTarget`` path round-trips a deposit/query with **no OpenUSD** loaded
+(harness AP9), and the handle's single-owner URI lock releases on close.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "python"))
+
+from synapse.memory import moneta_runtime as mr  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not mr.moneta_available(),
+    reason=f"Moneta not importable (set $MONETA_SRC). Last error: {mr.import_error()}",
+)
+
+
+def test_guard_reports_available_without_error():
+    assert mr.moneta_available() is True
+    assert mr.import_error() is None
+
+
+def test_ephemeral_round_trip_no_pxr():
+    # Pin AP9: the ephemeral path must not pull in OpenUSD.
+    assert "pxr" not in sys.modules, "pxr leaked into the test env before construction"
+    with mr.make_ephemeral(embedding_dim=8) as m:
+        eid = m.deposit("synapse remembers this", [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
+        hits = m.query([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8], limit=5)
+        assert len(hits) == 1
+        assert hits[0].payload == "synapse remembers this"  # byte-for-byte round-trip
+        assert hits[0].entity_id == eid
+    assert "pxr" not in sys.modules, "ephemeral / MockUsdTarget path must not require pxr"
+
+
+def test_empty_query_returns_empty_not_error():
+    with mr.make_ephemeral(embedding_dim=8) as m:
+        assert m.query([0.0] * 8, limit=5) == []  # well-defined on an empty store
+
+
+def test_uri_lock_releases_on_close():
+    # Two sequential ephemeral handles must each acquire + release cleanly;
+    # a leaked URI lock would surface as MonetaResourceLockedError.
+    with mr.make_ephemeral(embedding_dim=4) as m1:
+        m1.deposit("first", [1.0, 0.0, 0.0, 0.0])
+    with mr.make_ephemeral(embedding_dim=4) as m2:
+        m2.deposit("second", [0.0, 1.0, 0.0, 0.0])
+        assert m2.ecs.n == 1  # fresh handle, not the previous one's state

--- a/tests/test_moneta_store.py
+++ b/tests/test_moneta_store.py
@@ -1,0 +1,176 @@
+"""Mile 4 — MonetaBackedStore contract + parity (L1).
+
+Runs wherever Moneta is importable; skips cleanly otherwise. Pins:
+  * the five-op contract (add/count/search/get_recent/get_by_type) round-trips,
+  * search ranking is identical to the JSONL MemoryStore on the same inputs
+    (parity preview of AP5 — fix-forward if it diverges, never weaken),
+  * importance -> protected_floor mapping,
+  * append/consolidate ops (update/delete/clear) raise loudly, not silently.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "python"))
+
+from synapse.memory import moneta_runtime as mr  # noqa: E402
+from synapse.memory.embedding import HashEmbedder  # noqa: E402
+from synapse.memory.models import (  # noqa: E402
+    Memory, MemoryQuery, MemoryType, MemoryTier,
+)
+from synapse.memory.store import MemoryStore  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not mr.moneta_available(),
+    reason=f"Moneta not importable (set $MONETA_SRC). Last error: {mr.import_error()}",
+)
+
+DIM = 256
+
+
+def _store():
+    from synapse.memory.moneta_store import MonetaBackedStore
+    handle = mr.make_ephemeral(embedding_dim=DIM)
+    return MonetaBackedStore(handle, HashEmbedder(dim=DIM))
+
+
+def _corpus():
+    """A small fixed corpus exercising types, tags, keywords, recency."""
+    return [
+        Memory(content="render the karma beauty pass tonight",
+               memory_type=MemoryType.ACTION, tags=["render", "karma"],
+               keywords=["karma", "beauty"], created_at="2026-01-01T00:00:00Z"),
+        Memory(content="Decision: use assemble_chain to wire the Solaris graph",
+               memory_type=MemoryType.DECISION, tags=["ai_decision"],
+               keywords=["assemble_chain", "solaris"], created_at="2026-01-02T00:00:00Z"),
+        Memory(content="material binding failed on the hero asset",
+               memory_type=MemoryType.ERROR, tags=["error", "material"],
+               keywords=["material", "binding"], created_at="2026-01-03T00:00:00Z"),
+        Memory(content="note about karma denoiser settings for the render",
+               memory_type=MemoryType.NOTE, tags=["render"],
+               keywords=["karma", "denoiser"], created_at="2026-01-04T00:00:00Z"),
+    ]
+
+
+def test_add_and_count():
+    s = _store()
+    for m in _corpus():
+        assert s.add(m) == m.id
+    assert s.count() == 4
+
+
+def test_payload_round_trips_full_memory():
+    s = _store()
+    original = _corpus()[1]  # the decision, with tags + keywords
+    s.add(original)
+    got = s.get(original.id)
+    assert got is not None
+    assert got.content == original.content
+    assert got.memory_type == MemoryType.DECISION
+    assert got.tags == original.tags
+    assert got.keywords == original.keywords
+
+
+def test_get_recent_orders_by_created_at_desc():
+    s = _store()
+    for m in _corpus():
+        s.add(m)
+    recent = s.get_recent(limit=2)
+    assert [m.created_at for m in recent] == ["2026-01-04T00:00:00Z", "2026-01-03T00:00:00Z"]
+
+
+def test_get_by_type_is_the_decisions_path():
+    s = _store()
+    for m in _corpus():
+        s.add(m)
+    decisions = s.get_by_type(MemoryType.DECISION)
+    assert len(decisions) == 1
+    assert decisions[0].memory_type == MemoryType.DECISION
+
+
+@pytest.mark.parametrize("query", [
+    MemoryQuery(text="karma"),
+    MemoryQuery(text="render", limit=2),
+    MemoryQuery(tags=["render"]),
+    MemoryQuery(keywords=["karma"]),
+    MemoryQuery(memory_types=[MemoryType.DECISION]),
+    MemoryQuery(text="material", tags=["error"]),
+    MemoryQuery(text="nothing matches this string xyzzy"),
+])
+def test_search_ranking_parity_with_jsonl_store(tmp_path, query):
+    corpus = _corpus()
+    moneta = _store()
+    jsonl = MemoryStore(tmp_path / ".synapse")
+    for m in corpus:
+        moneta.add(m)
+        jsonl.add(m)
+
+    def rank(results):
+        return [(r.memory.id, round(r.score, 9)) for r in results]
+
+    assert rank(moneta.search(query)) == rank(jsonl.search(query))
+
+
+def test_protected_floor_mapping():
+    from synapse.memory.moneta_store import MonetaBackedStore
+    handle = mr.make_ephemeral(embedding_dim=DIM)
+    s = MonetaBackedStore(handle, HashEmbedder(dim=DIM))
+    note = Memory(content="routine note", memory_type=MemoryType.NOTE)
+    decision = Memory(content="big call", memory_type=MemoryType.DECISION)
+    s.add(note)
+    s.add(decision)
+    floors = {Memory.from_json(r.payload).memory_type: r.protected_floor
+              for r in handle.ecs.iter_rows()}
+    assert floors[MemoryType.NOTE] == 0.0
+    assert floors[MemoryType.DECISION] > 0.0
+
+
+def test_show_tier_and_gate_source_are_protected():
+    from synapse.memory.moneta_store import MonetaBackedStore
+    handle = mr.make_ephemeral(embedding_dim=DIM)
+    s = MonetaBackedStore(handle, HashEmbedder(dim=DIM))
+    s.add(Memory(content="show-wide convention", memory_type=MemoryType.NOTE,
+                 tier=MemoryTier.SHOW))
+    s.add(Memory(content="human-approved", memory_type=MemoryType.NOTE, source="gate"))
+    assert all(r.protected_floor > 0.0 for r in handle.ecs.iter_rows())
+
+
+def test_mutation_ops_raise_loudly():
+    from synapse.memory.moneta_store import MonetaUpdateNotSupported
+    s = _store()
+    m = _corpus()[0]
+    s.add(m)
+    with pytest.raises(MonetaUpdateNotSupported):
+        s.update(m)
+    with pytest.raises(MonetaUpdateNotSupported):
+        s.delete(m.id)
+    with pytest.raises(MonetaUpdateNotSupported):
+        s.clear()
+
+
+def test_flag_wires_synapse_memory_to_moneta(tmp_path, monkeypatch):
+    monkeypatch.setenv("SYNAPSE_MEMORY_BACKEND", "moneta")
+    from synapse.memory.store import SynapseMemory
+    from synapse.memory.moneta_store import MonetaBackedStore
+
+    sm = SynapseMemory(project_path=str(tmp_path / "proj"))
+    try:
+        assert isinstance(sm.store, MonetaBackedStore)
+        # Facade methods must work unchanged through the new backend.
+        sm.add(content="a decision", memory_type=MemoryType.DECISION, tags=["x"])
+        sm.add(content="a note", memory_type=MemoryType.NOTE)
+        assert sm.store.count() == 2
+        assert len(sm.get_decisions()) == 1
+        assert len(sm.get_recent(10)) == 2
+    finally:
+        sm.store.close()
+
+
+def test_flag_falls_back_to_jsonl_when_backend_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("SYNAPSE_MEMORY_BACKEND", raising=False)
+    from synapse.memory.store import SynapseMemory
+    sm = SynapseMemory(project_path=str(tmp_path / "proj2"))
+    assert isinstance(sm.store, MemoryStore)

--- a/tests/test_shadow_store.py
+++ b/tests/test_shadow_store.py
@@ -1,0 +1,127 @@
+"""Mile 5 — shadow dual-write + parity diff harness.
+
+Pins: writes hit both stores, reads come from the primary, the parity report
+reflects real agreement, and a failing shadow can NEVER break the caller or
+the primary. Because the Moneta adapter's search is parity-by-construction
+(Mile 4), the report should read 1.0 over a representative query set -- the
+evidence that justifies cutover (AP5 / FC3).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "python"))
+
+from synapse.memory import moneta_runtime as mr  # noqa: E402
+from synapse.memory.embedding import HashEmbedder  # noqa: E402
+from synapse.memory.models import Memory, MemoryQuery, MemoryType  # noqa: E402
+from synapse.memory.store import MemoryStore  # noqa: E402
+from synapse.memory.shadow_store import ShadowMemoryStore, ParityReport  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not mr.moneta_available(),
+    reason=f"Moneta not importable (set $MONETA_SRC). Last error: {mr.import_error()}",
+)
+
+DIM = 256
+
+
+def _corpus():
+    return [
+        Memory(content="render the karma beauty pass tonight",
+               memory_type=MemoryType.ACTION, tags=["render", "karma"],
+               keywords=["karma"], created_at="2026-01-01T00:00:00Z"),
+        Memory(content="Decision: use assemble_chain to wire Solaris",
+               memory_type=MemoryType.DECISION, tags=["ai_decision"],
+               keywords=["assemble_chain"], created_at="2026-01-02T00:00:00Z"),
+        Memory(content="material binding failed on hero asset",
+               memory_type=MemoryType.ERROR, tags=["error"],
+               keywords=["material"], created_at="2026-01-03T00:00:00Z"),
+        Memory(content="karma denoiser note for the render",
+               memory_type=MemoryType.NOTE, tags=["render"],
+               keywords=["denoiser"], created_at="2026-01-04T00:00:00Z"),
+    ]
+
+
+def _shadow(tmp_path):
+    from synapse.memory.moneta_store import MonetaBackedStore
+    primary = MemoryStore(tmp_path / ".synapse")
+    shadow = MonetaBackedStore(mr.make_ephemeral(embedding_dim=DIM), HashEmbedder(dim=DIM))
+    return ShadowMemoryStore(primary, shadow)
+
+
+def test_dual_write_and_reads_serve_primary(tmp_path):
+    s = _shadow(tmp_path)
+    for m in _corpus():
+        s.add(m)
+    assert s.count() == 4
+    assert s.primary.count() == 4
+    assert s.shadow.count() == 4
+    # reads come from primary
+    assert [m.id for m in s.get_recent(2)] == [m.id for m in s.primary.get_recent(2)]
+
+
+def test_parity_report_is_perfect_over_query_set(tmp_path):
+    s = _shadow(tmp_path)
+    for m in _corpus():
+        s.add(m)
+    queries = [
+        MemoryQuery(text="karma"),
+        MemoryQuery(text="render", limit=2),
+        MemoryQuery(tags=["render"]),
+        MemoryQuery(memory_types=[MemoryType.DECISION]),
+        MemoryQuery(text="material", tags=["error"]),
+    ]
+    s.count()
+    s.get_recent(10)
+    s.get_by_type(MemoryType.DECISION)
+    for q in queries:
+        s.search(q)
+
+    rep = s.report
+    assert rep.comparisons >= len(queries) + 3
+    assert rep.parity_ratio == 1.0, rep.mismatches
+    assert rep.write_errors == []
+
+
+def test_shadow_write_failure_is_isolated(tmp_path):
+    # A shadow that raises on every write must not disturb the primary path.
+    class Boom:
+        def add(self, memory):
+            raise RuntimeError("shadow exploded")
+        def save(self):
+            raise RuntimeError("shadow exploded")
+
+    primary = MemoryStore(tmp_path / ".synapse")
+    s = ShadowMemoryStore(primary, Boom())
+    rid = s.add(_corpus()[0])  # must succeed despite shadow blowing up
+    assert rid is not None
+    assert s.primary.count() == 1
+    assert len(s.report.write_errors) >= 1
+
+
+def test_shadow_read_failure_is_isolated(tmp_path):
+    class HalfBroken:
+        def add(self, memory):
+            return memory.id
+        def count(self):
+            raise RuntimeError("shadow count broke")
+
+    primary = MemoryStore(tmp_path / ".synapse")
+    s = ShadowMemoryStore(primary, HalfBroken())
+    s.add(_corpus()[0])
+    assert s.count() == 1  # primary answer still returned
+    assert len(s.report.write_errors) >= 1
+
+
+def test_parity_report_records_real_mismatch():
+    rep = ParityReport()
+    rep.record("count", 5, 5)
+    rep.record("count", 5, 4)
+    assert rep.comparisons == 2
+    assert rep.matches == 1
+    assert rep.parity_ratio == 0.5
+    assert rep.mismatches == [("count", 5, 4)]


### PR DESCRIPTION
## Moneta ↔ SYNAPSE integration — Miles 3–8

Makes Moneta available as SYNAPSE's memory substrate behind the unchanged `MemoryStore` interface — the *"Replace done right"* the Contract-1 diagnostic pointed at. The two-store divergence, the dead gauge, the empty stubs, and the read/write path divergence become **structurally impossible** (one store; `count()` = engine's live entity count). Delivered **shadow-first, flag-gated, default-off.** Follows PR #13 (Mile 2 embedder, merged).

### Miles
- **3 — pxr/CI path** (`moneta_runtime.py`): import-guarded Moneta access; `ephemeral()` is pxr-free; round-trip proven with no OpenUSD (AP9, clean subprocess).
- **4 — `MonetaBackedStore`** (`moneta_store.py`, `store.py`): full `Memory` serialized to the deposit payload; content embedded; decision/SHOW/gate → `protected_floor`. Reads enumerate via `ecs.iter_rows`. **Search ranking is bit-identical to the JSONL store** across every query shape (AP3 + AP5-by-construction). `SYNAPSE_MEMORY_BACKEND` flag: `jsonl`(default)|`moneta`|`shadow`, safe fallback.
- **5 — shadow + parity** (`shadow_store.py`): dual-write, read-from-primary, per-read diff → `ParityReport` (1.0 over the query set). Shadow failures isolated from the caller.
- **6 — integration**: facade E2E, gauge invariant (AP4), replay determinism (AP7), single-owner URI lock + durable reload (FC4 seam).
- **7 — CRUCIBLE L4** (4-agent adversarial fan-out): **two real defects fixed** — protected-quota silent demotion (quota raised) and corrupt-snapshot startup-killer (now quarantined, not fatal). 30 adversarial pins.
- **8 — ship**: count-agnostic backfill (backup-first, reversible, verified; dry-run validated on the live store); `evolution.py` deprecated; ship report.

### Acceptance / falsifiers
AP1✅ AP2✅ AP3✅ AP4✅ AP5✅(1.0) AP6⚠️(honest: memory store has no gate today — adapter adds no bypass) AP7✅ AP8✅ AP9✅. FC1–FC3 cleared; **FC4 (async-server serialization/deadlock) is the one live-gated item** — verified-by-design (single-writer, no bg daemon) but the production default-on flip needs the running FastMCP server and is **not** flipped here.

### Cutover (staged, NOT auto-flipped)
Flag stays default `jsonl`. Sequence in the ship report: run `shadow` live → verify parity + serialization under the async server → `backfill --execute` → flip default → remove `evolution.py`. See `docs/MONETA_SYNAPSE_SHIP_REPORT.md`.

### Tests
New: embedding(25, in #13), moneta_runtime(5), moneta_store(16), shadow_store(6), moneta_integration(5), moneta_crucible(30), backfill(5). Full suite: **3013 passed**; 15 pre-existing pxr-env failures in untouched files; **zero new regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Moneta-based memory storage backend with flag-gated selection via `SYNAPSE_MEMORY_BACKEND` environment variable; defaults to existing JSON storage.
  * Added memory migration tool to transition existing data to new backend.
  * Added shadow dual-write capability for verification and parity testing during gradual rollout.

* **Documentation**
  * Updated README with project test status and Moneta backend description.
  * Added integration and handoff documentation for backend implementation and acceptance criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->