### PR TITLE
ci: FU-3 — run Moneta-gated tests when MONETA_DEPLOY_KEY is set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,39 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.14"]
+    env:
+      # Mapped from the secret so steps can gate on its presence — the `secrets`
+      # context is not usable directly in `if:`. Empty string when the
+      # MONETA_DEPLOY_KEY secret is not configured, in which case the Moneta
+      # backend steps below skip and the ~70 Moneta-gated tests skip as before
+      # (CI stays green). Add the secret to activate them. See docs/MONETA_FOLLOWUPS.md (FU-3).
+      MONETA_DEPLOY_KEY: ${{ secrets.MONETA_DEPLOY_KEY }}
     steps:
       - uses: actions/checkout@v5
+
+      - name: Check out private Moneta backend (when key is configured)
+        if: ${{ env.MONETA_DEPLOY_KEY != '' }}
+        uses: actions/checkout@v5
+        with:
+          repository: JosephOIbrahim/Moneta
+          ref: main
+          ssh-key: ${{ secrets.MONETA_DEPLOY_KEY }}
+          path: _moneta
+
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
+
       - run: pip install -e ".[dev,websocket,mcp]"
+
+      - name: Install Moneta backend (zero-dep, pxr-free; when key is configured)
+        if: ${{ env.MONETA_DEPLOY_KEY != '' }}
+        run: pip install -e ./_moneta
+
+      - name: Assert Moneta backend is active (no silent skip)
+        if: ${{ env.MONETA_DEPLOY_KEY != '' }}
+        run: |
+          python -c "import sys; from synapse.memory import moneta_runtime as m; ok = m.moneta_available(); print('Moneta available:', ok, '| import_error:', m.import_error()); sys.exit(0 if ok else 1)"
+
       - run: python -m pytest tests/ -v --tb=short

--- a/docs/MONETA_FOLLOWUPS.md
+++ b/docs/MONETA_FOLLOWUPS.md
@@ -115,9 +115,20 @@ same-owner (`JosephOIbrahim/Moneta`).
      run: python -c "import sys; from synapse.memory import moneta_runtime as m; sys.exit(0 if m.moneta_available() else 1)"
    ```
 
-**Blocked on:** the `MONETA_DEPLOY_KEY` secret (Joe must create it — I cannot).
-Until then the tests run locally and skip on CI. Do **not** add the checkout
-step before the secret exists — it would fail CI.
+**Status: IMPLEMENTED (conditional).** `ci.yml` now wires the Moneta checkout +
+`pip install -e ./_moneta` + the no-silent-skip tripwire, each **gated on the
+secret being present** (`if: ${{ env.MONETA_DEPLOY_KEY != '' }}`, the secret
+mapped to a job env var since `secrets` isn't usable in `if:`). With no secret,
+those steps skip and CI stays green (Moneta tests skip as before). **The only
+remaining step is Joe creating the secret**, which activates everything:
+1. `ssh-keygen -t ed25519 -f moneta_ci -N ""` (no passphrase).
+2. Add `moneta_ci.pub` as a **read-only Deploy Key** on `JosephOIbrahim/Moneta`
+   (Settings → Deploy keys).
+3. Add the private key `moneta_ci` as secret **`MONETA_DEPLOY_KEY`** on
+   `JosephOIbrahim/Synapse` (Settings → Secrets → Actions). `gh secret set
+   MONETA_DEPLOY_KEY -R JosephOIbrahim/Synapse < moneta_ci`.
+4. Delete the local keypair. Next CI run installs Moneta and runs the ~70 tests;
+   the tripwire fails loudly if the checkout/install ever breaks.
 
 ---
 
@@ -126,4 +137,4 @@ step before the secret exists — it would fail CI.
 |---|---|---|---|
 | FU-1 Memory.id | Low | — | focused PR (invert tripwire) |
 | FU-2 AP6 gating | Low–mod | — (wire when a tool calls it) | PR when sleep_pass is exposed |
-| FU-3 CI Moneta | Low | `MONETA_DEPLOY_KEY` secret | PR after Joe adds the secret |
+| FU-3 CI Moneta | Low | `MONETA_DEPLOY_KEY` secret (workflow already wired conditionally) | DONE — activates on the secret |


### PR DESCRIPTION
Closes the last Moneta follow-up (FU-3 from \`docs/MONETA_FOLLOWUPS.md\`): the ~70 Moneta-backend tests are \`skipif not moneta_available()\` and currently **skip on CI** (the private \`moneta\` package isn't installed there).

## What this does
When the \`MONETA_DEPLOY_KEY\` secret is configured, CI:
1. checks out \`JosephOIbrahim/Moneta\` (zero-dep, pxr-free) via the deploy key,
2. \`pip install -e ./_moneta\`,
3. asserts \`moneta_available()\` (no-silent-skip tripwire — fails loudly if the checkout/install breaks),
4. so the ~70 Moneta tests actually run on both 3.11 and 3.14, making **AP9** ("CI runs the memory path with no pxr") genuinely true.

## Safe to merge now (secret-gated)
The secret is mapped to a job env var (the \`secrets\` context isn't usable in \`if:\`), and each Moneta step is \`if: \${{ env.MONETA_DEPLOY_KEY != '' }}\`. **With no secret, those steps skip and CI is identical to today (green; Moneta tests skip).** No risk of a red build before the key exists.

## To activate (your step — I can't create secrets)
1. \`ssh-keygen -t ed25519 -f moneta_ci -N ""\`
2. Add \`moneta_ci.pub\` as a **read-only Deploy Key** on \`JosephOIbrahim/Moneta\`.
3. \`gh secret set MONETA_DEPLOY_KEY -R JosephOIbrahim/Synapse < moneta_ci\`
4. Delete the local keypair. Next run installs Moneta + runs the tests.

This PR's own CI run validates the workflow (green, with the steps skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)