### PR TITLE
feat(science): nodetype probe kind — fix node-type false-negative (find->fix->reverify)

### DIFF
--- a/python/synapse/science/apex_probes.py
+++ b/python/synapse/science/apex_probes.py
@@ -28,7 +28,9 @@ Provenance — every claim below is derived from existing code, not invented:
 
 These are seeds, not exhaustive coverage. ``kind`` distinguishes a plain
 attribute lookup (``"attr"``) from something we expect to be invoked
-(``"call"``) or a graph constructed (``"construct"``). ``expect`` records the
+(``"call"``), a graph constructed (``"construct"``), or a Houdini node type
+looked up by NAME in a catalog (``"nodetype"`` — required because type names
+contain "::" and are not getattr-resolvable). ``expect`` records the
 codebase's prior belief; the loop's job is to confirm or falsify it.
 """
 
@@ -37,13 +39,15 @@ from __future__ import annotations
 from .probe import ProbeSpec
 
 # NOTE on surface convention:
-#   For node-type assumptions the surface is the SOP/APEX type STRING the
-#   recipes feed to houdini_create_node. The probe namespace is expected to
-#   expose a node-type catalog (e.g. injected as namespace["nodetypes"], a dict
-#   keyed by type name) so a dotted lookup like "nodetypes.apex::rig::fkfull"
-#   resolves to a truthy entry when the type exists in this Houdini build.
-#   For pure Python APEX-module assumptions the surface is a dotted attribute
-#   path against namespace["apex"].
+#   For node-type assumptions (kind="nodetype") the surface is the SOP/APEX
+#   type STRING the recipes feed to houdini_create_node, carrying a
+#   "nodetypes." routing prefix. The probe namespace is expected to expose a
+#   node-type catalog as namespace["nodetypes"] — a dict (or any __contains__
+#   object) keyed by full type name. probe() strips the prefix and does a
+#   MEMBERSHIP test ("apex::rig::fkfull" in catalog), NOT getattr — because
+#   "::"-bearing names are not getattr-resolvable attributes.
+#   For pure Python APEX-module assumptions (kind="attr"/"call") the surface is
+#   a dotted attribute path against namespace["apex"].
 
 APEX_SEED: list[ProbeSpec] = [
     # --- Python-level APEX module surface (highest value: gates everything) ---
@@ -73,7 +77,7 @@ APEX_SEED: list[ProbeSpec] = [
     # --- Node-type catalog assumptions from apex_recipes.py ---
     ProbeSpec(
         surface="nodetypes.apex::rig::fkfull",
-        kind="attr",
+        kind="nodetype",
         expect="present",
         rationale=(
             "fk_chain / fk_ik_blend / control_shapes recipes all build "
@@ -83,7 +87,7 @@ APEX_SEED: list[ProbeSpec] = [
     ),
     ProbeSpec(
         surface="nodetypes.apex::rig::ikfull",
-        kind="attr",
+        kind="nodetype",
         expect="present",
         rationale=(
             "ik_chain / fk_ik_blend recipes build apex::rig::ikfull for the "
@@ -93,7 +97,7 @@ APEX_SEED: list[ProbeSpec] = [
     ),
     ProbeSpec(
         surface="nodetypes.apex::rig::blendtransform",
-        kind="attr",
+        kind="nodetype",
         expect="present",
         rationale=(
             "fk_ik_blend recipe blends FK/IK via apex::rig::blendtransform; "
@@ -103,7 +107,7 @@ APEX_SEED: list[ProbeSpec] = [
     ),
     ProbeSpec(
         surface="nodetypes.apex::autorig::build",
-        kind="attr",
+        kind="nodetype",
         expect="unknown",
         rationale=(
             "autorig_biped recipe assumes apex::autorig::build generates a "
@@ -114,7 +118,7 @@ APEX_SEED: list[ProbeSpec] = [
     ),
     ProbeSpec(
         surface="nodetypes.apex::sop::graphdefaults",
-        kind="attr",
+        kind="nodetype",
         expect="present",
         rationale=(
             "simple_deformer recipe + its tips explicitly prefer "
@@ -125,7 +129,7 @@ APEX_SEED: list[ProbeSpec] = [
     ),
     ProbeSpec(
         surface="nodetypes.apex::sop::fromkinefx",
-        kind="attr",
+        kind="nodetype",
         expect="present",
         rationale=(
             "kinefx_to_apex recipe + migration guide assume "
@@ -136,7 +140,7 @@ APEX_SEED: list[ProbeSpec] = [
     ),
     ProbeSpec(
         surface="nodetypes.apex::sop::invoke",
-        kind="attr",
+        kind="nodetype",
         expect="unknown",
         rationale=(
             "apex_explainer maps 'invoke' to both bare 'invoke' and "
@@ -148,7 +152,7 @@ APEX_SEED: list[ProbeSpec] = [
     ),
     ProbeSpec(
         surface="nodetypes.rig_doctor",
-        kind="attr",
+        kind="nodetype",
         expect="present",
         rationale=(
             "Multiple recipes (fk_chain, autorig_biped, kinefx_to_apex) and "
@@ -160,7 +164,7 @@ APEX_SEED: list[ProbeSpec] = [
     # --- Autorig building-block SOPs assumed by apex_explainer patterns ---
     ProbeSpec(
         surface="nodetypes.apex::sop::transformobject",
-        kind="attr",
+        kind="nodetype",
         expect="unknown",
         rationale=(
             "_APEX_TYPE_PATTERNS lists apex::sop::transformobject as an "
@@ -171,7 +175,7 @@ APEX_SEED: list[ProbeSpec] = [
     ),
     ProbeSpec(
         surface="nodetypes.apex::sop::apexedit",
-        kind="attr",
+        kind="nodetype",
         expect="unknown",
         rationale=(
             "apex_explainer classifies apex::sop::apexedit / apexedit as the "

--- a/python/synapse/science/probe.py
+++ b/python/synapse/science/probe.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class ProbeSpec:
     surface: str            # dotted path, e.g. "apex.Graph.addNode"
-    kind: str = "attr"      # one of: "attr" | "call" | "construct"
+    kind: str = "attr"      # one of: "attr" | "call" | "construct" | "nodetype"
     expect: str = "unknown"  # one of: "present" | "absent" | "unknown"
     rationale: str = ""
     rank: int = 0
@@ -23,6 +23,62 @@ class ProbeResult:
     error: str | None = None
 
 
+def _probe_nodetype(namespace: dict, spec: ProbeSpec) -> ProbeResult:
+    """Resolve a node-type surface by NAME membership in a catalog.
+
+    Houdini node-type names contain "::" and are not getattr-resolvable; they
+    live keyed by name in a catalog (dict / set / any __contains__ object). The
+    surface carries a "nodetypes." prefix only as a routing label, e.g.
+    "nodetypes.apex::sop::invoke" -> catalog membership test on
+    "apex::sop::invoke".
+
+    A node type def is not a callable, so present results report
+    is_callable=False, signature=None. Cleanly absent names report present=False
+    with error=None (a true dead_end). Only a missing catalog is an error.
+
+    Never raises.
+    """
+    if "nodetypes" not in namespace:
+        return ProbeResult(
+            surface=spec.surface,
+            kind=spec.kind,
+            present=False,
+            error=repr(KeyError("nodetypes")),
+        )
+
+    catalog = namespace["nodetypes"]
+    if catalog is None:
+        # Key present but explicitly None: no usable catalog. Report a truthful
+        # error (the key exists, so don't fabricate a KeyError) — never raise.
+        return ProbeResult(
+            surface=spec.surface,
+            kind=spec.kind,
+            present=False,
+            error=repr(TypeError("nodetypes catalog is None")),
+        )
+
+    name = spec.surface.split(".", 1)[1] if "." in spec.surface else spec.surface
+
+    try:
+        present = name in catalog  # membership, NOT getattr
+    except Exception as exc:  # noqa: BLE001 - capture, never raise
+        return ProbeResult(
+            surface=spec.surface,
+            kind=spec.kind,
+            present=False,
+            error=repr(exc),
+        )
+
+    return ProbeResult(
+        surface=spec.surface,
+        kind=spec.kind,
+        present=present,
+        is_callable=False,   # a node type def is not a callable
+        signature=None,
+        error=None,          # present True OR cleanly-absent both have no error
+    )
+
+
 def probe(namespace: dict, spec: ProbeSpec) -> ProbeResult:
     """Resolve spec.surface as a dotted path against namespace.
 
@@ -32,7 +88,15 @@ def probe(namespace: dict, spec: ProbeSpec) -> ProbeResult:
     key is missing or any getattr fails, returns present=False with the error
     captured (never raises). On success, reports callability and a best-effort
     signature string.
+
+    For ``spec.kind == "nodetype"`` the surface is NOT getattr-resolvable:
+    Houdini node-type names contain "::" (e.g. "apex::sop::invoke"), which are
+    looked up by NAME in a node-type catalog, not as attributes. The branch
+    below resolves them via membership against ``namespace["nodetypes"]``.
     """
+    if spec.kind == "nodetype":
+        return _probe_nodetype(namespace, spec)
+
     parts = spec.surface.split(".")
     root_key = parts[0]
 

--- a/scripts/run_apex_verify.py
+++ b/scripts/run_apex_verify.py
@@ -52,37 +52,21 @@ def _build_namespace() -> dict:
         namespace["apex"] = apex
 
     # Best-effort node-type catalog so "nodetypes.<typename>" surfaces resolve.
+    # A plain {name: node_type} dict — probe() does a MEMBERSHIP test on the
+    # full "namespace::name" string (not getattr), so no wrapper is needed.
     try:
         import hou  # type: ignore
 
-        catalog = {}
+        catalog: dict = {}
         for category in hou.nodeTypeCategories().values():
             for type_name, node_type in category.nodeTypes().items():
                 catalog[type_name] = node_type
         if catalog:
-            # Wrap in an object so dotted getattr works for names with "::".
-            namespace["nodetypes"] = _Catalog(catalog)
+            namespace["nodetypes"] = catalog
     except Exception:  # noqa: BLE001 — hou is a soft dependency
         pass
 
     return namespace
-
-
-class _Catalog:
-    """Attribute-access wrapper over a {type_name: node_type} dict.
-
-    ``probe`` resolves ``"nodetypes.apex::rig::fkfull"`` via getattr, so the
-    catalog must answer getattr for type names that contain ``::``.
-    """
-
-    def __init__(self, mapping: dict) -> None:
-        self._mapping = mapping
-
-    def __getattr__(self, name: str):
-        try:
-            return self._mapping[name]
-        except KeyError as exc:
-            raise AttributeError(name) from exc
 
 
 def main(argv: list[str]) -> int:

--- a/tests/test_science_harness.py
+++ b/tests/test_science_harness.py
@@ -155,6 +155,105 @@ def test_probe_single_segment_present():
 
 
 # ===========================================================================
+# probe() — kind == "nodetype" (membership lookup, NOT getattr)
+#
+# Houdini node-type names contain "::" (e.g. "apex::sop::invoke") and are NOT
+# getattr-resolvable. The nodetype branch resolves them by NAME against a
+# catalog injected as namespace["nodetypes"]. These tests pin that mechanism
+# with zero Houdini / zero hou.
+# ===========================================================================
+
+def test_probe_nodetype_present_via_membership():
+    # A "::"-bearing name that getattr could never resolve — must resolve via
+    # membership in the injected catalog.
+    ns = {"nodetypes": {"apex::sop::invoke": object()}}
+    spec = ProbeSpec(surface="nodetypes.apex::sop::invoke", kind="nodetype")
+    res = probe(ns, spec)
+    assert res.present is True
+    # A node-type def is not a callable, and has no signature.
+    assert res.is_callable is False
+    assert res.signature is None
+    assert res.error is None
+    assert res.kind == "nodetype"
+    assert res.surface == "nodetypes.apex::sop::invoke"
+
+
+def test_probe_nodetype_cleanly_absent_no_error():
+    ns = {"nodetypes": {"apex::sop::invoke": object()}}
+    spec = ProbeSpec(surface="nodetypes.apex::missing", kind="nodetype")
+    res = probe(ns, spec)
+    assert res.present is False
+    # Cleanly absent — a true dead_end for that name, NOT an error condition.
+    assert res.error is None
+    assert res.is_callable is False
+
+
+def test_probe_nodetype_missing_catalog_is_error():
+    # No "nodetypes" catalog at all -> present False WITH an error.
+    spec = ProbeSpec(surface="nodetypes.apex::sop::invoke", kind="nodetype")
+    res = probe({}, spec)
+    assert res.present is False
+    assert res.error is not None
+    assert "nodetypes" in res.error
+
+
+def test_probe_nodetype_accepts_set_catalog():
+    # Catalog need only support membership (__contains__): a set works too.
+    ns = {"nodetypes": {"apex::rig::fkfull"}}
+    present = probe(ns, ProbeSpec(surface="nodetypes.apex::rig::fkfull", kind="nodetype"))
+    absent = probe(ns, ProbeSpec(surface="nodetypes.apex::rig::nope", kind="nodetype"))
+    assert present.present is True
+    assert absent.present is False
+    assert absent.error is None
+
+
+def test_probe_nodetype_bare_name_without_prefix():
+    # If the surface has no ".", the whole surface is the lookup name.
+    ns = {"nodetypes": {"rig_doctor": object()}}
+    res = probe(ns, ProbeSpec(surface="rig_doctor", kind="nodetype"))
+    assert res.present is True
+
+
+def test_probe_nodetype_hostile_catalog_never_raises():
+    # A catalog whose __contains__ explodes must be captured, not raised.
+    class _Hostile:
+        def __contains__(self, item):
+            raise RuntimeError("boom")
+
+    ns = {"nodetypes": _Hostile()}
+    res = probe(ns, ProbeSpec(surface="nodetypes.apex::sop::invoke", kind="nodetype"))
+    assert res.present is False
+    assert res.error is not None
+
+
+def test_probe_nodetype_does_not_use_getattr_path():
+    # REGRESSION GUARD: a catalog that ANSWERS getattr but has the name only as
+    # a dict key proves the nodetype branch uses membership, not getattr. (A
+    # dict's getattr would AttributeError on "apex::sop::invoke" anyway, but
+    # this also confirms a "::" name resolves at all.)
+    ns = {"nodetypes": {"apex::sop::invoke": object()}}
+    res = probe(ns, ProbeSpec(surface="nodetypes.apex::sop::invoke", kind="nodetype"))
+    assert res.present is True
+
+
+def test_probe_attr_path_unaffected_by_nodetype_branch(namespace):
+    # REGRESSION: existing getattr dotted-path behavior is unchanged for attr/call.
+    res = probe(namespace, ProbeSpec(surface="apex.Graph.addNode", kind="call"))
+    assert res.present is True
+    assert res.is_callable is True
+    assert res.signature is not None
+
+    res2 = probe(namespace, ProbeSpec(surface="apex.Graph", kind="attr"))
+    assert res2.present is True
+    assert res2.is_callable is True
+
+    # And a missing attr still errors via the getattr path (not the nodetype path).
+    res3 = probe(namespace, ProbeSpec(surface="apex.DoesNotExist", kind="attr"))
+    assert res3.present is False
+    assert res3.error is not None
+
+
+# ===========================================================================
 # Registry
 # ===========================================================================
 
@@ -390,9 +489,44 @@ def test_apex_seed_has_at_least_six_specs():
 def test_apex_seed_specs_are_well_formed():
     for s in APEX_SEED:
         assert s.surface
-        assert s.kind in {"attr", "call", "construct"}
+        assert s.kind in {"attr", "call", "construct", "nodetype"}
         assert s.expect in {"present", "absent", "unknown"}
         assert isinstance(s.rank, int)
+
+
+def test_apex_seed_nodetype_seeds_are_reclassified():
+    # Every seed whose surface starts "nodetypes." MUST be kind=="nodetype"
+    # (the probe-shape fix: "::" names are membership lookups, not getattr).
+    node_seeds = [s for s in APEX_SEED if s.surface.startswith("nodetypes.")]
+    assert node_seeds, "expected node-type seeds in APEX_SEED"
+    assert all(s.kind == "nodetype" for s in node_seeds), [
+        (s.surface, s.kind) for s in node_seeds if s.kind != "nodetype"
+    ]
+    # And there are the ~10 we expect (the apex::rig/sop/autorig + rig_doctor set).
+    assert len(node_seeds) >= 10
+
+
+def test_apex_seed_graph_champions_stay_attr_and_call():
+    # The real champions are pure Python-API surfaces — NOT node types.
+    by_surface = {s.surface: s for s in APEX_SEED}
+    assert by_surface["apex.Graph"].kind == "attr"
+    assert by_surface["apex.Graph.addNode"].kind == "call"
+    # Neither carries the nodetypes. prefix.
+    assert not by_surface["apex.Graph"].surface.startswith("nodetypes.")
+
+
+def test_apex_seed_nodetype_resolves_against_catalog_standalone():
+    # End-to-end standalone: inject a catalog containing one of the seed names
+    # and confirm the loop records it as a champion (no Houdini, no hou).
+    target = "apex::sop::invoke"
+    seed = next(
+        s for s in APEX_SEED if s.surface == f"nodetypes.{target}"
+    )
+    assert seed.kind == "nodetype"
+    ns = {"nodetypes": {target: object()}}
+    res = probe(ns, seed)
+    assert res.present is True
+    assert res.error is None
 
 
 def test_apex_seed_drives_run_search_standalone():
@@ -638,3 +772,236 @@ def test_crucible_persistence_dedup_is_keyed_on_surface_and_kind(tmp_path):
     assert reg2.known("apex.Graph", "attr").status == "champion"
     assert reg2.known("apex.Graph", "call").status == "dead_end"
     assert len(reg2.all()) == 2
+
+
+# ===========================================================================
+# CRUCIBLE — nodetype probe (membership branch) adversarial invariants
+#
+# The nodetype branch is a SEPARATE code path from getattr resolution. These
+# attack its boundaries head-on:
+#   * catalog shape polymorphism  — set / dict / arbitrary __contains__ object
+#   * dotted node-type NAMES       — split(".",1) must keep "foo.bar::baz" whole
+#   * missing vs None vs hostile catalog — present=False with error, NEVER raise
+#   * bare surface (no dot)        — whole surface is the lookup name, no crash
+#   * REGRESSION: attr/call/construct getattr path is byte-for-byte unchanged
+# ===========================================================================
+
+
+def test_crucible_nodetype_catalog_shape_set_dict_and_custom_contains():
+    """Membership must work for a set, a dict, AND a custom __contains__ object."""
+    target = "apex::sop::invoke"
+    miss = "apex::sop::absent"
+
+    # 1. set
+    set_ns = {"nodetypes": {target}}
+    assert probe(set_ns, ProbeSpec(surface=f"nodetypes.{target}", kind="nodetype")).present is True
+    set_absent = probe(set_ns, ProbeSpec(surface=f"nodetypes.{miss}", kind="nodetype"))
+    assert set_absent.present is False
+    assert set_absent.error is None  # cleanly absent, not an error
+
+    # 2. dict (keyed by name)
+    dict_ns = {"nodetypes": {target: object()}}
+    assert probe(dict_ns, ProbeSpec(surface=f"nodetypes.{target}", kind="nodetype")).present is True
+    assert probe(dict_ns, ProbeSpec(surface=f"nodetypes.{miss}", kind="nodetype")).present is False
+
+    # 3. custom object whose ONLY membership contract is __contains__ (no len,
+    #    no iter, not a builtin container) — the duck-typed catalog Houdini-side.
+    class _CustomCatalog:
+        def __init__(self, names):
+            self._names = set(names)
+
+        def __contains__(self, item):  # the ONLY protocol method
+            return item in self._names
+
+    custom_ns = {"nodetypes": _CustomCatalog({target})}
+    hit = probe(custom_ns, ProbeSpec(surface=f"nodetypes.{target}", kind="nodetype"))
+    miss_res = probe(custom_ns, ProbeSpec(surface=f"nodetypes.{miss}", kind="nodetype"))
+    assert hit.present is True
+    assert hit.is_callable is False  # a node-type def is never reported callable
+    assert hit.signature is None
+    assert hit.error is None
+    assert miss_res.present is False
+    assert miss_res.error is None
+
+
+def test_crucible_nodetype_falsy_but_valid_catalog_is_not_missing():
+    """An EMPTY catalog is a real (empty) catalog, NOT a missing one.
+
+    Guards against a future `if not catalog:` regression — emptiness must yield
+    a clean absent (present=False, error=None), never the missing-catalog error.
+    """
+    for empty in ({}, set()):
+        res = probe({"nodetypes": empty}, ProbeSpec(surface="nodetypes.anything", kind="nodetype"))
+        assert res.present is False
+        assert res.error is None  # empty != missing
+
+    # A custom catalog that is falsy (len 0) but answers membership True for a
+    # hit must still resolve present — truthiness must not gate the lookup.
+    class _FalsyCatalog:
+        def __len__(self):
+            return 0
+
+        def __contains__(self, item):
+            return item == "hit::me"
+
+    res = probe({"nodetypes": _FalsyCatalog()}, ProbeSpec(surface="nodetypes.hit::me", kind="nodetype"))
+    assert res.present is True
+    assert res.error is None
+
+
+def test_crucible_nodetype_dotted_name_kept_intact_by_split():
+    """A node-type name CONTAINING a dot must survive split(".",1) whole.
+
+    surface "nodetypes.foo.bar::baz" -> only the FIRST dot is the prefix
+    separator; the lookup name is "foo.bar::baz", dot and all.
+    """
+    name = "foo.bar::baz"
+    # The catalog is keyed by the FULL dotted name. If the probe split on every
+    # dot (or the last dot) the lookup would miss.
+    ns = {"nodetypes": {name: object()}}
+    res = probe(ns, ProbeSpec(surface=f"nodetypes.{name}", kind="nodetype"))
+    assert res.present is True
+    assert res.error is None
+
+    # And a near-miss: the catalog has only the prefix-stripped-too-far variant
+    # ("bar::baz"); the correct full name must NOT match it -> cleanly absent.
+    ns_wrong = {"nodetypes": {"bar::baz": object()}}
+    res_wrong = probe(ns_wrong, ProbeSpec(surface=f"nodetypes.{name}", kind="nodetype"))
+    assert res_wrong.present is False
+    assert res_wrong.error is None
+
+
+def test_crucible_nodetype_missing_catalog_never_raises_only_errors():
+    """No 'nodetypes' key at all -> present=False WITH error, NEVER an exception."""
+    # Several mis-shaped namespaces, none containing 'nodetypes'.
+    for ns in ({}, {"apex": object()}, {"NODETYPES": {"x"}}, {"nodetype": {"x"}}):
+        res = probe(ns, ProbeSpec(surface="nodetypes.apex::sop::invoke", kind="nodetype"))
+        assert res.present is False
+        assert res.error is not None
+        assert "nodetypes" in res.error  # names the missing routing key
+
+
+def test_crucible_nodetype_none_catalog_is_truthful_error_not_fabricated_keyerror():
+    """A present-but-None catalog must error WITHOUT lying about a missing key.
+
+    The 'nodetypes' key EXISTS (it's None), so a KeyError('nodetypes') would be
+    a fabrication. The branch reports a truthful TypeError and never raises.
+    """
+    res = probe({"nodetypes": None}, ProbeSpec(surface="nodetypes.x", kind="nodetype"))
+    assert res.present is False
+    assert res.error is not None
+    # It must NOT claim the key is missing.
+    assert "KeyError" not in res.error
+    assert "None" in res.error
+
+
+def test_crucible_nodetype_non_container_catalog_never_raises():
+    """A catalog with no membership protocol (int) is captured, not raised."""
+    for junk in (123, 4.5, True):
+        res = probe({"nodetypes": junk}, ProbeSpec(surface="nodetypes.x", kind="nodetype"))
+        assert res.present is False
+        assert res.error is not None  # TypeError captured into the result
+
+
+def test_crucible_nodetype_hostile_contains_is_captured():
+    """A catalog whose __contains__ raises is captured into error, never raised."""
+
+    class _Bomb:
+        def __contains__(self, item):
+            raise RuntimeError("kaboom")
+
+    res = probe({"nodetypes": _Bomb()}, ProbeSpec(surface="nodetypes.x::y", kind="nodetype"))
+    assert res.present is False
+    assert res.error is not None
+    assert "kaboom" in res.error or "RuntimeError" in res.error
+
+
+def test_crucible_nodetype_bare_surface_no_dot_uses_whole_surface_as_name():
+    """A 'nodetype' surface with NO dot ("nodetypes") -> name is the whole surface.
+
+    split(".",1) only strips a prefix when a dot exists; with no dot the entire
+    surface is the lookup name. Must not crash and must not strip anything.
+    """
+    # The catalog literally contains the bare string "nodetypes" as a type name.
+    ns = {"nodetypes": {"nodetypes": object()}}
+    res = probe(ns, ProbeSpec(surface="nodetypes", kind="nodetype"))
+    assert res.present is True
+    assert res.error is None
+
+    # A different dot-free name not in the catalog -> cleanly absent, no crash.
+    ns2 = {"nodetypes": {"rig_doctor"}}
+    present = probe(ns2, ProbeSpec(surface="rig_doctor", kind="nodetype"))
+    absent = probe(ns2, ProbeSpec(surface="not_there", kind="nodetype"))
+    assert present.present is True
+    assert absent.present is False
+    assert absent.error is None
+
+
+def test_crucible_nodetype_routing_is_by_kind_not_by_surface_prefix():
+    """REGRESSION GUARD: the membership branch is gated on kind, NOT on the
+    'nodetypes.' surface prefix.
+
+    A 'nodetypes.'-prefixed surface with kind='attr' MUST take the getattr path
+    (and error, since a dict has no such attribute) — proving the nodetype
+    branch cannot be reached by surface shape alone.
+    """
+    ns = {"nodetypes": {"apex::sop::invoke": object()}}
+    # kind='attr' on a 'nodetypes.'-prefixed surface -> getattr path, not membership.
+    res = probe(ns, ProbeSpec(surface="nodetypes.foo", kind="attr"))
+    assert res.present is False
+    assert res.error is not None
+    assert "AttributeError" in res.error  # getattr failed, NOT a membership miss
+
+
+def test_crucible_attr_call_construct_getattr_path_byte_for_byte_unchanged(namespace):
+    """REGRESSION GUARD: attr / call / construct behavior is the legacy getattr
+    path, fully unaffected by the nodetype branch. Prove it across all three.
+    """
+    # attr — present non-callable
+    a = probe(namespace, ProbeSpec(surface="apex.Graph.not_callable", kind="attr"))
+    assert a.present is True
+    assert a.is_callable is False
+    assert a.signature is None
+    assert a.error is None
+
+    # call — present callable WITH a signature (getattr + inspect.signature)
+    c = probe(namespace, ProbeSpec(surface="apex.Graph.addNode", kind="call"))
+    assert c.present is True
+    assert c.is_callable is True
+    assert c.signature is not None
+    assert "name" in c.signature
+    assert c.error is None
+
+    # construct — a class resolves via getattr; classes are callable.
+    k = probe(namespace, ProbeSpec(surface="apex.Graph", kind="construct"))
+    assert k.present is True
+    assert k.is_callable is True
+    assert k.error is None
+
+    # missing attr still errors via getattr (KeyError/AttributeError), NOT the
+    # nodetype membership path.
+    miss = probe(namespace, ProbeSpec(surface="apex.DoesNotExist", kind="attr"))
+    assert miss.present is False
+    assert miss.error is not None
+    assert "DoesNotExist" in miss.error or "attribute" in miss.error.lower()
+
+
+def test_crucible_no_double_colon_seed_left_as_attr():
+    """Every APEX_SEED surface containing '::' MUST be kind='nodetype'.
+
+    A '::' name is not getattr-resolvable; if any such seed were left as
+    kind='attr'/'call'/'construct' it would always falsely probe absent. This
+    is the seed-side guarantee that the reclassification is complete.
+    """
+    misrouted = [
+        (s.surface, s.kind) for s in APEX_SEED if "::" in s.surface and s.kind != "nodetype"
+    ]
+    assert misrouted == [], f"'::'-bearing seeds wrongly classified: {misrouted}"
+
+    # And the inverse: every kind='nodetype' seed actually targets the catalog
+    # (carries the 'nodetypes.' routing prefix OR is a bare dot-free SOP name).
+    for s in APEX_SEED:
+        if s.kind == "nodetype":
+            assert s.surface.startswith("nodetypes.") or "." not in s.surface, (
+                f"nodetype seed {s.surface!r} is neither prefixed nor a bare name"
+            )


### PR DESCRIPTION
Harness **find → fix → re-verify** cycle on the finding the scaffold's first run surfaced.

**Find:** the first APEX run reported 10 `apex::…` node-type probes as `dead_end` via `getattr` dotted-path walking — but `::`-bearing node-type names aren't `getattr`-resolvable attributes. A probe-shape **false negative**.

**Fix:** a `nodetype` probe kind in `probe.py` that resolves by NAME via membership lookup against an injected catalog (`name in catalog`). Stays pure (zero `hou` imports), never raises. CRUCIBLE caught + fixed a real defect (present-but-`None` catalog was conflated with a missing key → fabricated `KeyError`; now a truthful `TypeError`). The `attr`/`call`/`construct` getattr path is byte-for-byte unchanged (routing gated on `kind`, not surface prefix — proven). Seeds reclassified; `run_apex_verify.py` builds a real `{nodetype.name(): nodetype}` catalog.

**Re-verify (hython 21.0.671):** catalog now `present`, probes route as `[nodetype]`. `apex.Graph` + `apex.Graph.addNode` confirmed (champions). The 10 names now come back `dead_end` **truthfully** — the getattr artifact is gone; the assumed names are genuinely absent as-spelled in the H21 catalog → **next cycle: discover the real APEX node-type names.**

**Tests:** 57 (was 35; +22 nodetype + hostile). Full suite **3099 passed**, zero new regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)