### PR TITLE
feat(houdini): ship the Houdini package in-repo (artists get the panel on install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,20 +179,25 @@ cd C:\Users\%USERNAME%\SYNAPSE
 
 ### 2. Register the package with Houdini
 
-Create `%USERPROFILE%\houdini21.0\packages\Synapse.json`:
+The Houdini package ships **in the repo** at [`packages/synapse.json`](packages/synapse.json) — so the SYNAPSE panel, shelves, and `synapse` Python package load on launch. Two ways to register it:
 
-```json
-{
-    "env": [
-        { "PYTHONPATH": "C:/Users/YOUR_USERNAME/SYNAPSE/python" }
-    ]
-}
+**Recommended — run the installer** (resolves absolute paths + a sibling `Moneta/` checkout, writes a `synapse.json` into your Houdini prefs):
+
+```powershell
+python scripts/install_synapse_package.py            # auto-detects your houdini21.0 prefs
+python scripts/install_synapse_package.py --dry-run  # preview without writing
 ```
 
-Replace `YOUR_USERNAME` with your actual Windows username (forward slashes in the path, not backslashes).
+**Portable alternative — no install.** Add the repo's `packages/` dir to Houdini's package search path (the shipped `packages/synapse.json` derives every path from `$HOUDINI_PACKAGE_PATH`, so nothing is hard-coded). In your `houdini.env`:
+
+```
+HOUDINI_PACKAGE_DIR = "$HOUDINI_PACKAGE_DIR;C:/path/to/Synapse/packages"
+```
+
+Either way, **restart Houdini** afterward — packages and env vars load at launch (and a running session caches Python modules until restart). The optional `MONETA_SRC` var (set automatically by the installer when a sibling `../Moneta` exists) enables the Moneta memory backend; without it SYNAPSE uses the default JSONL store.
 
 **You're good if:** launching Houdini and running `import synapse; print(synapse.__version__)` in the Python Shell prints a version string.
-**If you see** `ModuleNotFoundError: No module named 'synapse'`: double-check the `PYTHONPATH` value in the `.json` points at the `python/` directory, not the repo root.
+**If you see** `ModuleNotFoundError: No module named 'synapse'`: confirm the package's `PYTHONPATH` resolves to the repo's `python/` directory (the installer prints the resolved path), and that you restarted Houdini.
 
 ### 3. Set the API key
 

--- a/packages/synapse.json
+++ b/packages/synapse.json
@@ -1,0 +1,21 @@
+{
+    "name": "synapse",
+    "enable": true,
+    "comment": "SYNAPSE Houdini package. Portable: paths derive from $HOUDINI_PACKAGE_PATH (the dir of THIS file = <repo>/packages), so nothing is hard-coded per user. Install by adding <repo>/packages to HOUDINI_PACKAGE_DIR, or run scripts/install_synapse_package.py to deploy a resolved copy into your Houdini prefs. See README 'Install'.",
+    "env": [
+        {
+            "var": "SYNAPSE_ROOT",
+            "value": "$HOUDINI_PACKAGE_PATH/.."
+        },
+        {
+            "var": "PYTHONPATH",
+            "value": "$SYNAPSE_ROOT/python",
+            "method": "prepend"
+        },
+        {
+            "var": "MONETA_SRC",
+            "value": "$SYNAPSE_ROOT/../Moneta/src"
+        }
+    ],
+    "path": "$SYNAPSE_ROOT/houdini"
+}

--- a/scripts/install_synapse_package.py
+++ b/scripts/install_synapse_package.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+"""Install the SYNAPSE Houdini package into your Houdini user prefs.
+
+Writes a resolved ``<pref>/packages/synapse.json`` that points at THIS repo, so
+the SYNAPSE panel + shelves load on Houdini launch. Uses absolute paths (no
+reliance on Houdini package-var resolution) and auto-detects a sibling Moneta
+checkout for the optional memory backend.
+
+Usage:
+    python scripts/install_synapse_package.py             # auto-detect prefs, install
+    python scripts/install_synapse_package.py --dry-run   # show, do not write
+    python scripts/install_synapse_package.py --pref-dir "C:/Users/me/Documents/houdini21.0"
+
+Portable alternative (no install): add ``<repo>/packages`` to
+``HOUDINI_PACKAGE_DIR`` and Houdini loads the version-controlled package
+(packages/synapse.json) directly.
+
+This lives in scripts/ (outside python/synapse/), so print() is fine here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def resolve_repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def moneta_src_for(repo_root: Path) -> str | None:
+    """A sibling ``../Moneta/src`` checkout, if present (else None)."""
+    cand = repo_root.parent / "Moneta" / "src"
+    return cand.as_posix() if cand.is_dir() else None
+
+
+def build_package(repo_root: Path) -> dict:
+    """The resolved (absolute-path) package dict. Pure — easy to test."""
+    env = [
+        {"var": "SYNAPSE_ROOT", "value": repo_root.as_posix()},
+        {"var": "PYTHONPATH", "value": (repo_root / "python").as_posix(), "method": "prepend"},
+    ]
+    moneta = moneta_src_for(repo_root)
+    if moneta:
+        env.append({"var": "MONETA_SRC", "value": moneta})
+    return {
+        "name": "synapse",
+        "enable": True,
+        "env": env,
+        "path": (repo_root / "houdini").as_posix(),
+    }
+
+
+def candidate_pref_dirs() -> list[Path]:
+    """Houdini user pref dirs to install into. $HOUDINI_USER_PREF_DIR wins,
+    then any ``houdini2*`` under the home dir and (Windows) ~/Documents."""
+    found: list[Path] = []
+    env = os.environ.get("HOUDINI_USER_PREF_DIR")
+    if env:
+        found.append(Path(env))
+    home = Path.home()
+    for root in (home, home / "Documents"):
+        if root.is_dir():
+            found.extend(sorted(root.glob("houdini2*"), reverse=True))
+    seen: set = set()
+    uniq: list[Path] = []
+    for p in found:
+        if not p.is_dir():
+            continue
+        rp = p.resolve()
+        if rp not in seen:
+            seen.add(rp)
+            uniq.append(p)
+    return uniq
+
+
+def deploy(pref_dir: Path, package: dict, dry_run: bool) -> Path:
+    """Write <pref_dir>/packages/synapse.json. Returns the target path."""
+    target = pref_dir / "packages" / "synapse.json"
+    if not dry_run:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(package, indent=4) + "\n", encoding="utf-8")
+    return target
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Install the SYNAPSE Houdini package.")
+    ap.add_argument("--pref-dir", help="Houdini user pref dir (e.g. .../houdini21.0). Default: auto-detect.")
+    ap.add_argument("--dry-run", action="store_true", help="Show what would be written without writing.")
+    args = ap.parse_args(argv)
+
+    repo_root = resolve_repo_root()
+    package = build_package(repo_root)
+
+    prefs = [Path(args.pref_dir)] if args.pref_dir else candidate_pref_dirs()
+    if not prefs:
+        print("No Houdini user pref dir found. Pass --pref-dir explicitly "
+              "(e.g. your Documents/houdini21.0).", file=sys.stderr)
+        return 1
+
+    print(f"SYNAPSE repo : {repo_root.as_posix()}")
+    print(f"package      : {json.dumps(package)}")
+    for pref in prefs:
+        target = deploy(pref, package, args.dry_run)
+        print(f"  {'would write' if args.dry_run else 'wrote'}: {target.as_posix()}")
+    if args.dry_run:
+        print("(dry run -- re-run without --dry-run to install)")
+    else:
+        print("Done. Restart Houdini to load the SYNAPSE package + panel.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_install_package.py
+++ b/tests/test_install_package.py
@@ -1,0 +1,98 @@
+"""Tests for scripts/install_synapse_package.py — the Houdini package installer.
+
+Standalone, no Houdini. Exercises the pure path-resolution + json-build logic and
+the deploy/dry-run behavior against tmp dirs only (never the real prefs).
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_installer():
+    path = _ROOT / "scripts" / "install_synapse_package.py"
+    spec = importlib.util.spec_from_file_location("install_synapse_package", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+inst = _load_installer()
+
+
+def test_build_package_uses_absolute_repo_paths(tmp_path):
+    repo = tmp_path / "Synapse"
+    (repo / "python").mkdir(parents=True)
+    (repo / "houdini").mkdir()
+    pkg = inst.build_package(repo)
+    assert pkg["name"] == "synapse"
+    assert pkg["enable"] is True
+    env = {e["var"]: e for e in pkg["env"]}
+    assert env["SYNAPSE_ROOT"]["value"] == repo.as_posix()
+    assert env["PYTHONPATH"]["value"] == (repo / "python").as_posix()
+    assert env["PYTHONPATH"]["method"] == "prepend"
+    assert pkg["path"] == (repo / "houdini").as_posix()
+
+
+def test_moneta_src_included_only_when_sibling_exists(tmp_path):
+    repo = tmp_path / "Synapse"
+    repo.mkdir()
+    # No sibling Moneta -> no MONETA_SRC entry.
+    pkg = inst.build_package(repo)
+    assert "MONETA_SRC" not in {e["var"] for e in pkg["env"]}
+    # Create sibling ../Moneta/src -> MONETA_SRC appears, pointing at it.
+    (tmp_path / "Moneta" / "src").mkdir(parents=True)
+    pkg2 = inst.build_package(repo)
+    env = {e["var"]: e["value"] for e in pkg2["env"]}
+    assert env["MONETA_SRC"] == (tmp_path / "Moneta" / "src").as_posix()
+
+
+def test_deploy_dry_run_writes_nothing(tmp_path):
+    pref = tmp_path / "houdini21.0"
+    target = inst.deploy(pref, {"name": "synapse"}, dry_run=True)
+    assert target == pref / "packages" / "synapse.json"
+    assert not target.exists()  # dry run wrote nothing
+
+
+def test_deploy_writes_valid_json(tmp_path):
+    pref = tmp_path / "houdini21.0"
+    repo = tmp_path / "Synapse"
+    (repo / "python").mkdir(parents=True)
+    pkg = inst.build_package(repo)
+    target = inst.deploy(pref, pkg, dry_run=False)
+    assert target.exists()
+    loaded = json.loads(target.read_text(encoding="utf-8"))
+    assert loaded["name"] == "synapse"
+    assert any(e["var"] == "PYTHONPATH" for e in loaded["env"])
+
+
+def test_pref_dir_detection_honors_env(tmp_path, monkeypatch):
+    pref = tmp_path / "houdini21.0"
+    pref.mkdir()
+    monkeypatch.setenv("HOUDINI_USER_PREF_DIR", str(pref))
+    cands = inst.candidate_pref_dirs()
+    assert pref.resolve() in [c.resolve() for c in cands]
+
+
+def test_main_dry_run_against_explicit_pref(tmp_path, capsys):
+    pref = tmp_path / "houdini21.0"
+    pref.mkdir()
+    rc = inst.main(["--pref-dir", str(pref), "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "would write" in out
+    assert not (pref / "packages" / "synapse.json").exists()
+
+
+def test_repo_synced_package_json_is_valid_and_portable():
+    # The version-controlled packages/synapse.json must be valid JSON and use
+    # the portable $HOUDINI_PACKAGE_PATH derivation (no hard-coded user paths).
+    repo_pkg = _ROOT / "packages" / "synapse.json"
+    data = json.loads(repo_pkg.read_text(encoding="utf-8"))
+    assert data["name"] == "synapse"
+    blob = json.dumps(data)
+    assert "$HOUDINI_PACKAGE_PATH" in blob
+    assert "C:/Users" not in blob and "/home/" not in blob  # no user-specific paths


### PR DESCRIPTION
**Problem:** `synapse.json` (the Houdini package that loads the SYNAPSE panel, shelves, and `synapse` Python package) lived only as a per-machine **prefs file with hard-coded user paths** — not version-controlled. A fresh clone gave artists no panel.

**Fix:** the package now ships **in the repo**.

- **`packages/synapse.json`** — the version-controlled package, **fully portable**: every path derives from `$HOUDINI_PACKAGE_PATH` (the dir of the file), so there are *zero* hard-coded user paths. (Verified pattern — `JLTools` uses the same Houdini variable.) Sets `SYNAPSE_ROOT`, `PYTHONPATH`→`python/`, `MONETA_SRC`→sibling `../Moneta/src`, `path`→`houdini/` (panel + shelves).
- **`scripts/install_synapse_package.py`** — one-command installer: resolves absolute repo paths, auto-detects a sibling Moneta checkout, and writes a resolved `synapse.json` into the artist's Houdini prefs. `--dry-run`, `--pref-dir`, auto-detects `houdini2*` prefs. Bulletproof (no reliance on Houdini var resolution).
- **README** install section rewritten — installer (recommended) + `HOUDINI_PACKAGE_DIR` portable alternative + restart/MONETA_SRC notes.

**Two install paths for artists:**
```
python scripts/install_synapse_package.py        # writes resolved json to your houdini21.0 prefs
# or, portable: add <repo>/packages to HOUDINI_PACKAGE_DIR
```

**Tests:** `tests/test_install_package.py` (7) — absolute-path build, sibling-Moneta gating, dry-run safety, valid-json deploy, pref detection, and that the shipped `packages/synapse.json` is valid + contains no user-specific paths. Full suite **3106 passed**, zero new regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)