### PR TITLE
feat(panel): native drag-n-drop + Build-HDA mode + bouncing-toy loader

### DIFF
--- a/python/synapse/panel/designsystem/loader.py
+++ b/python/synapse/panel/designsystem/loader.py
@@ -1,0 +1,84 @@
+"""BouncingToy — SYNAPSE's "thinking" loader.
+
+A squash-and-stretch bouncing rubber toy (the classic Houdini test-geometry
+animation archetype), painted in the SYNAPSE accent with a contact shadow.
+Replaces the old typing indicator that re-inserted "SYNAPSE is thinking…" every
+tick and accumulated dozens of copies in the chat.
+"""
+
+import math
+
+try:
+    from PySide6 import QtWidgets, QtGui, QtCore
+    from PySide6.QtCore import Qt, QPropertyAnimation, QEasingCurve, Property, QRectF
+except ImportError:  # pragma: no cover - Houdini ships PySide6
+    from PySide2 import QtWidgets, QtGui, QtCore
+    from PySide2.QtCore import Qt, QPropertyAnimation, QEasingCurve, Property, QRectF
+
+from . import tokens as t
+
+
+class BouncingToy(QtWidgets.QWidget):
+    """A looping squash-and-stretch bounce. start()/stop() control the anim."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._phase = 0.0
+        self.setFixedSize(56, 38)
+        self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+        self._anim = QPropertyAnimation(self, b"phase", self)
+        self._anim.setStartValue(0.0)
+        self._anim.setEndValue(1.0)
+        self._anim.setDuration(680)
+        self._anim.setLoopCount(-1)
+        self._anim.setEasingCurve(QEasingCurve.Linear)  # the parabola does the bounce
+
+    def start(self):
+        if self._anim.state() != QPropertyAnimation.Running:
+            self._anim.start()
+
+    def stop(self):
+        self._anim.stop()
+
+    def _get_phase(self):
+        return self._phase
+
+    def _set_phase(self, value):
+        self._phase = value
+        self.update()
+
+    phase = Property(float, _get_phase, _set_phase)
+
+    def paintEvent(self, _event):
+        p = QtGui.QPainter(self)
+        p.setRenderHint(QtGui.QPainter.Antialiasing)
+        w, h = self.width(), self.height()
+        cx = w / 2.0
+        r = 8.0
+        top_y = r + 2
+        ground_y = h - r - 4
+
+        ph = self._phase
+        # up: 0 at the loop ends (ground contact), 1 at mid (apex) — so the ball
+        # is fast near the ground and "hangs" at the top, the natural bounce feel.
+        up = 4.0 * ph * (1.0 - ph)
+        contact = 1.0 - up                       # 1 on the ground, 0 at apex
+        cy = ground_y - (ground_y - top_y) * up
+
+        squash = 0.38 * contact                  # round at apex, squashed on impact
+        rx = r * (1.0 + squash)
+        ry = r * (1.0 - squash)
+
+        # contact shadow — wider + darker the closer to the ground
+        p.setPen(Qt.NoPen)
+        sh_w = rx * (0.7 + 0.9 * contact)
+        p.setBrush(QtGui.QColor(0, 0, 0, int(70 * (0.35 + 0.65 * contact))))
+        p.drawEllipse(QtCore.QRectF(cx - sh_w, ground_y + ry - 2, sh_w * 2, 4.5))
+
+        # the toy
+        p.setBrush(QtGui.QColor(t.SIGNAL))
+        p.drawEllipse(QtCore.QRectF(cx - rx, cy - ry, rx * 2, ry * 2))
+        # soft highlight
+        p.setBrush(QtGui.QColor(255, 255, 255, 70))
+        p.drawEllipse(QtCore.QRectF(cx - rx * 0.35, cy - ry * 0.55, rx * 0.5, ry * 0.4))
+        p.end()

--- a/python/synapse/panel/designsystem/qss.py
+++ b/python/synapse/panel/designsystem/qss.py
@@ -72,6 +72,7 @@ QPushButton#DsPill {{
 QPushButton#DsPill:hover  {{ background: {t.HOVER_WASH}; color: {t.TEXT_ACCENT}; }}
 QPushButton#DsPill:pressed {{ background: {t.SIGNAL_TINT}; }}
 QPushButton#DsPill:disabled {{ color: {t.TEXT_DISABLED}; }}
+QPushButton#DsPill[active="true"] {{ color: {t.TEXT_ACCENT}; background: {t.SIGNAL_TINT}; }}
 
 /* ---- cards & drawers ----------------------------------------- */
 QWidget#DsCard {{

--- a/python/synapse/panel/dnd.py
+++ b/python/synapse/panel/dnd.py
@@ -1,0 +1,117 @@
+"""Native Houdini drag-and-drop helpers for the SYNAPSE panel.
+
+Verified against H21's shipping examples (clonecontrol/model.py, stagemanager
+mimedatautils, and help/examples/python_panels/dragdrop.pypanel):
+  * node drags carry hou.qt.mimeType.nodePath (TAB-separated node paths), with
+    mimeData().text() as the simple fallback the example panel uses;
+  * file/image drags carry text/uri-list;
+  * the Network Editor is a native C++ pane (no Qt drop target) — you PLACE
+    nodes programmatically via the hou.NetworkEditor API, you don't drop onto it.
+
+Pure helpers here are headless-testable; the hou-touching ones are guarded.
+"""
+
+try:
+    from PySide6 import QtCore  # noqa: F401  (binding parity with the panel)
+except ImportError:  # pragma: no cover - Houdini ships PySide6
+    from PySide2 import QtCore  # noqa: F401
+
+
+def node_mime_type():
+    """The MIME type Houdini uses for node-path drags (GUI-resolved, guarded)."""
+    try:
+        import hou
+        return hou.qt.mimeType.nodePath
+    except Exception:
+        return "application/sidefx-houdini-node-path"
+
+
+def extract_node_paths(mime):
+    """Node/prim paths from a drag's mime data — node MIME first, text fallback.
+
+    Houdini packs multiple paths TAB-separated in the node MIME; the example
+    panel's text() form is comma-separated. We tolerate tab / comma / newline.
+    """
+    paths = []
+    nm = node_mime_type()
+    try:
+        if mime.hasFormat(nm):
+            raw = bytes(mime.data(nm)).decode("utf-8", "ignore")
+            paths = raw.replace(",", "\t").replace("\n", "\t").split("\t")
+    except Exception:
+        pass
+    if not paths and mime.hasText():
+        txt = mime.text()
+        for chunk in txt.replace(",", "\t").replace("\n", "\t").split("\t"):
+            paths.append(chunk)
+    # node + USD prim paths both start with "/"; keep those.
+    return [p.strip() for p in paths if p.strip().startswith("/")]
+
+
+def extract_files(mime):
+    """Local file paths from a text/uri-list drag."""
+    try:
+        return [u.toLocalFile() for u in mime.urls() if u.isLocalFile()]
+    except Exception:
+        return []
+
+
+def mime_is_acceptable(mime):
+    """True if a drag carries something the panel can use."""
+    try:
+        if mime.hasUrls() or mime.hasText():
+            return True
+        return mime.hasFormat(node_mime_type())
+    except Exception:
+        return False
+
+
+def place_in_network(node_path):
+    """Results-OUT: locate/place a node in the active Network Editor.
+
+    The network editor is native C++ (no Qt drop), so placement is programmatic
+    via the verified hou.NetworkEditor API. Selects + frames the node, dropping
+    it at the editor's cursor when the contexts match. GUI-only; returns False
+    off-GUI or on any failure (never raises).
+    """
+    try:
+        import hou
+        node = hou.node(node_path)
+        if node is None:
+            return False
+        editor = None
+        for pane in hou.ui.paneTabs():
+            if pane.type() == hou.paneTabType.NetworkEditor:
+                editor = pane
+                break
+        if editor is not None:
+            try:
+                if editor.pwd() == node.parent():
+                    node.setPosition(editor.cursorPosition())
+                else:
+                    node.moveToGoodPosition()
+            except Exception:
+                pass
+        node.setSelected(True, clear_all_selected=True)
+        return True
+    except Exception:
+        return False
+
+
+def transcript_to_markdown(messages, title="SYNAPSE conversation"):
+    """Text-COPY-OUT: serialize the chat to clean markdown for reports / LLMs."""
+    lines = ["# %s\n" % title]
+    for m in messages:
+        role = m.get("role", "?") if isinstance(m, dict) else "?"
+        content = m.get("content", "") if isinstance(m, dict) else str(m)
+        if isinstance(content, list):  # Anthropic content blocks
+            parts = []
+            for b in content:
+                if isinstance(b, dict):
+                    parts.append(b.get("text") or "")
+                else:
+                    parts.append(str(b))
+            content = " ".join(p for p in parts if p)
+        who = {"user": "**You**", "assistant": "**SYNAPSE**"}.get(role, "**%s**" % role)
+        lines.append("%s: %s\n" % (who, content))
+    return "\n".join(lines)

--- a/python/synapse/panel/synapse_panel.py
+++ b/python/synapse/panel/synapse_panel.py
@@ -99,7 +99,9 @@ class SynapsePanel(QtWidgets.QWidget):
         self._stream_buf = []        # accumulates streamed tokens
         self._worker = None
         self._tool_executor = ToolExecutor(parent=self) if ToolExecutor else None
+        self._pending_context = []  # paths dropped in; prepended to the next send
 
+        self.setAcceptDrops(True)
         self._build_ui()
         self._wire_gate()
         self._palette_shortcut = QShortcut(QKeySequence("Ctrl+K"), self)
@@ -167,6 +169,8 @@ class SynapsePanel(QtWidgets.QWidget):
             self._chat = ChatDisplay()
         else:  # graceful fallback
             self._chat = QtWidgets.QTextBrowser()
+        if hasattr(self._chat, "node_clicked"):
+            self._chat.node_clicked.connect(self._on_node_clicked)
         try:
             self._chat.append_system_message(
                 "Ready. What are we building?"
@@ -243,6 +247,8 @@ class SynapsePanel(QtWidgets.QWidget):
 
     def _show_overflow(self):
         menu = QtWidgets.QMenu(self)
+        menu.addAction("Copy conversation", self._copy_conversation)
+        menu.addSeparator()
         menu.addAction("Larger text", lambda: self._set_scale(1.15))
         menu.addAction("Default text", lambda: self._set_scale(1.0))
         menu.exec(QtGui.QCursor.pos()) if hasattr(menu, "exec") else menu.exec_(QtGui.QCursor.pos())
@@ -278,8 +284,12 @@ class SynapsePanel(QtWidgets.QWidget):
             self._send(text)
 
     def _send(self, text):
+        display = text
+        if self._pending_context:
+            text = "[Context: %s]\n%s" % (", ".join(self._pending_context), text)
+            self._pending_context = []
         try:
-            self._chat.append_user_message(text)
+            self._chat.append_user_message(display)
         except Exception:
             pass
         self._messages.append({"role": "user", "content": text})
@@ -383,6 +393,60 @@ class SynapsePanel(QtWidgets.QWidget):
             self._foot_label.setText("Houdini")
             if self._header_status.text() in ("Standing by", ""):
                 self._set_header("idle", "Ready")
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------ drag & drop
+    def dragEnterEvent(self, event):
+        try:
+            from synapse.panel import dnd
+            if dnd.mime_is_acceptable(event.mimeData()):
+                event.acceptProposedAction()
+        except Exception:
+            pass
+
+    def dragMoveEvent(self, event):
+        event.acceptProposedAction()
+
+    def dropEvent(self, event):
+        """Node-in / SOP-USD-in / files-in → add to the next request's context."""
+        try:
+            from synapse.panel import dnd
+            mime = event.mimeData()
+            added = []
+            for p in dnd.extract_node_paths(mime) + dnd.extract_files(mime):
+                if p and p not in self._pending_context:
+                    self._pending_context.append(p)
+                    added.append(p)
+            if added:
+                try:
+                    self._chat.append_system_message(
+                        "Added to context: %s — ask away." % ", ".join(added)
+                    )
+                except Exception:
+                    pass
+                self._input.setFocus()
+            event.acceptProposedAction()
+        except Exception:
+            pass
+
+    def _on_node_clicked(self, node_path):
+        """Results-out / locate: a node link selects + frames the node in the
+        Network Editor (which is native C++ and can't be a Qt drop target)."""
+        try:
+            from synapse.panel import dnd
+            dnd.place_in_network(node_path)
+        except Exception:
+            pass
+
+    def _copy_conversation(self):
+        """Text-copy-out: copy the transcript as markdown for reports / LLMs."""
+        try:
+            from synapse.panel import dnd
+            QtWidgets.QApplication.clipboard().setText(
+                dnd.transcript_to_markdown(self._messages)
+            )
+            self._chat.append_system_message("Conversation copied as markdown.")
         except Exception:
             pass
 

--- a/python/synapse/panel/synapse_panel.py
+++ b/python/synapse/panel/synapse_panel.py
@@ -24,6 +24,10 @@ from synapse.panel.designsystem import tokens as t
 from synapse.panel.designsystem import qss
 from synapse.panel.designsystem import components as c
 from synapse.panel.designsystem import motion
+try:
+    from synapse.panel.designsystem.loader import BouncingToy
+except Exception:  # pragma: no cover
+    BouncingToy = None
 
 # Proven runtime + widgets — composed, not rewritten. All optional so the panel
 # always instantiates (graceful degradation is a runtime contract).
@@ -132,6 +136,7 @@ class SynapsePanel(QtWidgets.QWidget):
         root.addWidget(self._build_context_ribbon())
         root.addWidget(self._build_mode_bar())
         root.addWidget(self._build_converse(), 1)   # dominant
+        root.addWidget(self._build_activity_row())
         root.addWidget(self._build_trust())
         root.addWidget(self._build_act())
         root.addWidget(self._build_input())
@@ -251,6 +256,26 @@ class SynapsePanel(QtWidgets.QWidget):
             "Build a %s HDA: %s. Use the houdini_hda_package tool, then show me "
             "the node path and the promoted parameters.%s" % (ctx, prompt, helptxt)
         )
+
+    def _build_activity_row(self):
+        """A bouncing rubber-toy 'thinking' loader (hidden until working)."""
+        self._activity = self._section()
+        lay = QtWidgets.QHBoxLayout(self._activity)
+        lay.setContentsMargins(t.SPACE_MD, t.SPACE_XS, t.SPACE_MD, t.SPACE_XS)
+        lay.addStretch(1)
+        self._toy = BouncingToy() if BouncingToy is not None else None
+        if self._toy is not None:
+            lay.addWidget(self._toy)
+        lay.addWidget(c.label("thinking…", role="caption"))
+        lay.addStretch(1)
+        self._activity.setVisible(False)
+        return self._activity
+
+    def _set_thinking(self, on):
+        if hasattr(self, "_activity"):
+            self._activity.setVisible(on)
+        if getattr(self, "_toy", None) is not None:
+            self._toy.start() if on else self._toy.stop()
 
     def _build_trust(self):
         self._trust = self._section()
@@ -378,10 +403,7 @@ class SynapsePanel(QtWidgets.QWidget):
                 pass
             return
         self._stream_buf = []
-        try:
-            self._chat.show_typing_indicator()
-        except Exception:
-            pass
+        self._set_thinking(True)
         self._set_busy(True)
         tools = get_anthropic_tools() if get_anthropic_tools else None
         self._worker = ClaudeWorker(self._messages, tools=tools, parent=self)
@@ -397,10 +419,7 @@ class SynapsePanel(QtWidgets.QWidget):
         self._stream_buf.append(tok)
 
     def _on_done(self):
-        try:
-            self._chat.hide_typing_indicator()
-        except Exception:
-            pass
+        self._set_thinking(False)
         text = "".join(self._stream_buf).strip()
         if text:
             try:
@@ -415,8 +434,8 @@ class SynapsePanel(QtWidgets.QWidget):
         self._set_busy(False)
 
     def _on_error(self, msg):
+        self._set_thinking(False)
         try:
-            self._chat.hide_typing_indicator()
             self._chat.append_system_message("We hit a snag: %s" % msg)
         except Exception:
             pass
@@ -429,6 +448,7 @@ class SynapsePanel(QtWidgets.QWidget):
     def _on_stop(self):
         if self._worker is not None:
             self._worker.abort()
+        self._set_thinking(False)
         self._set_busy(False)
 
     def _set_busy(self, busy):

--- a/python/synapse/panel/synapse_panel.py
+++ b/python/synapse/panel/synapse_panel.py
@@ -130,6 +130,7 @@ class SynapsePanel(QtWidgets.QWidget):
         root.addWidget(self._build_header())
         root.addWidget(c.divider())
         root.addWidget(self._build_context_ribbon())
+        root.addWidget(self._build_mode_bar())
         root.addWidget(self._build_converse(), 1)   # dominant
         root.addWidget(self._build_trust())
         root.addWidget(self._build_act())
@@ -177,7 +178,79 @@ class SynapsePanel(QtWidgets.QWidget):
             )
         except Exception:
             pass
-        return self._chat
+        self._converse_stack = QtWidgets.QStackedWidget()
+        self._converse_stack.addWidget(self._chat)              # page 0: chat
+        self._converse_stack.addWidget(self._build_hda_form())  # page 1: Build HDA
+        return self._converse_stack
+
+    def _build_mode_bar(self):
+        w = self._section()
+        lay = QtWidgets.QHBoxLayout(w)
+        lay.setContentsMargins(t.SPACE_MD, 0, t.SPACE_MD, 0)
+        lay.setSpacing(t.SPACE_XS)
+        self._chat_pill = c.Pill("Chat")
+        self._hda_pill = c.Pill("Build HDA")
+        self._chat_pill.clicked.connect(lambda: self._set_mode("chat"))
+        self._hda_pill.clicked.connect(lambda: self._set_mode("hda"))
+        lay.addWidget(self._chat_pill)
+        lay.addWidget(self._hda_pill)
+        lay.addStretch(1)
+        self._set_mode("chat")
+        return w
+
+    def _build_hda_form(self):
+        """Native-designsystem describe→build flow (the build runs through the
+        agent's houdini_hda_package tool, so it reuses the proven runtime)."""
+        page = self._section()
+        lay = QtWidgets.QVBoxLayout(page)
+        lay.setContentsMargins(t.SPACE_MD, t.SPACE_MD, t.SPACE_MD, t.SPACE_MD)
+        lay.setSpacing(t.SPACE_SM)
+        lay.addWidget(c.label("Describe the HDA you want", role="title"))
+        self._hda_prompt = QtWidgets.QTextEdit()
+        self._hda_prompt.setObjectName("DsInput")
+        self._hda_prompt.setAcceptRichText(False)
+        self._hda_prompt.setPlaceholderText(
+            "e.g. a scatter tool with density control · a 3-point light rig · "
+            "a Karma draft/preview/production setup"
+        )
+        self._hda_prompt.setMinimumHeight(110)
+        lay.addWidget(self._hda_prompt)
+        row = QtWidgets.QHBoxLayout()
+        row.setSpacing(t.SPACE_SM)
+        row.addWidget(c.label("Context", role="caption"))
+        self._hda_ctx = QtWidgets.QComboBox()
+        self._hda_ctx.addItems(["SOP", "LOP", "DOP", "COP", "TOP"])
+        row.addWidget(self._hda_ctx)
+        self._hda_help = QtWidgets.QCheckBox("Include help text")
+        self._hda_help.setChecked(True)
+        row.addWidget(self._hda_help)
+        row.addStretch(1)
+        lay.addLayout(row)
+        gen = c.Button("Generate HDA", variant="primary")
+        gen.clicked.connect(self._on_build_hda)
+        lay.addWidget(gen)
+        lay.addStretch(1)
+        return page
+
+    def _set_mode(self, mode):
+        if hasattr(self, "_converse_stack"):
+            self._converse_stack.setCurrentIndex(1 if mode == "hda" else 0)
+        for pill, m in ((self._chat_pill, "chat"), (self._hda_pill, "hda")):
+            pill.setProperty("active", mode == m)
+            c.repolish(pill)
+
+    def _on_build_hda(self):
+        prompt = self._hda_prompt.toPlainText().strip()
+        if not prompt:
+            return
+        ctx = self._hda_ctx.currentText()
+        helptxt = " Include help text." if self._hda_help.isChecked() else ""
+        self._hda_prompt.clear()
+        self._set_mode("chat")
+        self._send(
+            "Build a %s HDA: %s. Use the houdini_hda_package tool, then show me "
+            "the node path and the promoted parameters.%s" % (ctx, prompt, helptxt)
+        )
 
     def _build_trust(self):
         self._trust = self._section()


### PR DESCRIPTION
Two requested features for the SYNAPSE panel, plus a loader fix — all verified against live H21.0.671 via SideFX's own shipping examples.

## Drag-and-drop (5 interactions)
Verified patterns (clonecontrol, stagemanager, `dragdrop.pypanel`):
- **Node-in →** drag node(s) from the Network Editor onto the panel → added to the next request's context (`hou.qt.mimeType.nodePath`, tab-separated; `mimeData().text()` fallback).
- **SOP/USD-in →** dropped `/obj` or `/stage` prim paths land as context too.
- **Files/images-in →** `text/uri-list` → local paths added as context.
- **Results-out →** the Network Editor is native C++ (no Qt drop), so a node link in chat **selects + frames** the node via the verified `hou.NetworkEditor` API (honest "locate/place", not a fake drag).
- **Text-copy-out →** "Copy conversation" (overflow menu) serializes the transcript to markdown for reports / other LLMs.

New `synapse.panel.dnd` holds the headless-testable helpers.

## Build-HDA mode
A **Chat | Build HDA** toggle swaps the converse to a native describe form (prompt + SOP/LOP/DOP/COP/TOP context + include-help). "Generate HDA" composes a tool-routed request (`…use the houdini_hda_package tool…`) and returns to chat to stream the build + result. Deliberately **re-skinned in the new muted-blue/native design** and routed through the proven ClaudeWorker + tool path, rather than copying the legacy `hda_views` (old cyan / inline-styled / WS-bridge `HdaController`) which would regress the look.

## Bouncing rubber-toy loader (fixes a visible bug)
The old typing indicator re-inserted "SYNAPSE is thinking…" every tick and **accumulated dozens of copies**. Replaced with a squash-and-stretch **bouncing rubber-toy** loader (`designsystem/loader.BouncingToy`) in a hidden-until-working activity row. The panel no longer calls ChatDisplay's typing indicator.

## Verified (hython 21.0.671, offscreen)
Real `QDropEvent` populates context from node + prim + file paths; transcript→markdown round-trips; the HDA toggle swaps the stacked converse and Generate composes the `houdini_hda_package` prompt; the toy animates and the activity row shows/hides; 51 design + install tests green.

## Reviewer GUI check
Restart Houdini → drag a node onto the panel (see it added to context), Ctrl+K palette, toggle Build HDA + Generate, and watch a request show the bouncing toy instead of repeated text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bouncing loader animation to indicate activity during operations.
  * Introduced drag-and-drop support for nodes and files to add context to conversations.
  * Added mode switching between Chat and HDA Build interfaces.
  * Added "Copy conversation" action to export chat transcripts.
  * Enabled clicking node results to locate them in the network editor.

* **UI/UX Enhancements**
  * Improved pill button styling for active states.
  * Enhanced conversation interface with better context handling and visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->