### PR TITLE
feat(panel): panel-redesign dev harness + network-nav-bar toggle

### DIFF
--- a/docs/SYNAPSE_PANEL_REDESIGN_HARNESS.md
+++ b/docs/SYNAPSE_PANEL_REDESIGN_HARNESS.md
@@ -1,0 +1,131 @@
+# SYNAPSE PANEL — BUILD HARNESS · the Pentagram pass
+
+> **Race:** translate the locked v3 design (rail + three faces, the work as hero) into the live Qt panel.
+> **Distance:** ~7 spikes after the start line. **Start line is already crossed** — the harness runner boots and loads the full panel (verified).
+> **One truth, taped to the mirror:** *the work is the product; the panel's only job is to make it trustworthy enough to walk away from.*
+
+---
+
+## 0 · What this is (and is not)
+
+This is a **re-layout**, not a rewrite. Every widget already exists — `ChatDisplay`, `GateWidget`, `ClaudeWorker`, `ToolExecutor`, `HealthInfographic`, the design system. The work is rewriting `synapse_panel.py`'s `_build_ui` order, adding a **state→face controller**, and three design moves: the **mark-as-status**, **speaker-by-type** chat, and the **render-as-hero** Review.
+
+**Panel-layer only.** Nothing here touches USD substrate conventions. **Michael Gold's zones stay untouched — no RFC needed for any of this.** If a spike ever wants to reach into substrate, that's a halt (see §5).
+
+---
+
+## 1 · Hard invariants (the constitution)
+
+1. **Compose, don't rewrite.** Reuse the proven runtime. The legacy 3032-line monolith is dead; do not resurrect inline widgets that already exist as modules.
+2. **PySide6, PySide2 fallback.** Every widget import stays optional and wrapped — *graceful degradation is a runtime contract.* The panel must instantiate even when a dependency is absent.
+3. **The six properties stay visible.** termination · observability · bounded cost (the **rail**) · durability · provenance · reversibility (the **faces**). A spike that hides one fails its gate.
+4. **Two verification gates, both required before a spike is "done":**
+   - **G1 — harness:** `python harness/run_panel.py --smoke` exits 0, and the face renders correctly in the window.
+   - **G2 — Houdini 21.0.671:** the panel loads via the `.pypanel` hot-reload and renders in the real host. *Live verification supersedes "looks right in Qt."*
+5. **Design fidelity gate.** Each face is checked side-by-side against `synapse_panel_pentagram_v3.html`. Drift is a defect.
+6. **Atomic commits, one per spike.** Marathon-marker messages (`mile N/7 — <what landed>`). Race-safe push: fetch + rebase, max 3 attempts, **halt on merge conflict.**
+7. **No phantom APIs.** If a Qt/`hou` call isn't confirmed present on the build, probe it (`dir()`/`hasattr`) before relying on it. Confirmed-absent → quarantine, don't re-litigate.
+
+---
+
+## 2 · Roles (sequential, one session — MOE)
+
+- **ARCHITECT** — *design is locked.* The comps + this harness are the spec. ARCHITECT only re-opens if a spike exposes a real design gap → **halt + surface to Joe**, don't improvise a new direction.
+- **FORGE** — implements the current spike. Carries momentum down the spike list; no scope expansion mid-spike.
+- **CRUCIBLE** — adversarial verification against both gates. **Fix-forward only. Never weakens a test to make it pass.**
+
+---
+
+## 3 · The runner (Spike 0 — DONE, verified)
+
+```
+python harness/run_panel.py            # open the panel in a window
+python harness/run_panel.py --smoke    # offscreen build + verify, exits 0/1
+```
+
+- Edit any `synapse.panel.*` module → **press F5** in the window → hot-reload. No Houdini restart.
+- `harness/hou_stub.py` feeds fake scene state (`/stage · 1 selected · f1`) so the panel renders alive.
+- **Build every spike against this loop.** Drop into Houdini only at each spike's G2.
+- Confirmed at start: all eight optional components load; the full layout renders. Chat needs a key; live telemetry needs the bridge — neither blocks design work.
+
+---
+
+## 4 · The spikes (the marathon)
+
+> Each spike: **goal · files · gate · commit.** Continuous flow — only stop at a gate or a halt trigger.
+
+**Mile 1 — The rail.** *You are here after Spike 0.*
+- **Goal:** collapse header + footer + observability into one persistent top strip. Move `Stop` up into it. Condense `HealthInfographic` to a quiet meter + mono numerics + cost.
+- **Files:** `synapse_panel.py` (`_build_header`/`_build_footer` → `_build_rail`), `designsystem/components.py` (new **MarkDot** — the ◖ that fills by state), `tokens.py` (mark + muted-semantic stops).
+- **Gate:** G1 — rail renders, mark animates on `working`, `Stop` reachable. G2 — same in Houdini.
+- **Commit:** `mile 1/7 — persistent rail + mark-as-status`
+
+**Mile 2 — Faces + switcher.**
+- **Goal:** extend the existing `Pill` + `QStackedWidget` (today `[Chat][Build HDA]`) to `[Direct][Work][Review]`. Add the **state→face controller**: idle→Direct, working→Work, gate-raised/done→Review. Pills are manual override. **Never yank away from Direct while the input has focus.** Build HDA demotes into Direct / ⌘K.
+- **Files:** `synapse_panel.py` (`_build_mode_bar`, `_set_mode` → `_set_face`, wire to `_set_busy`/`_on_tool_status`/gate signals).
+- **Gate:** G1 — switches manually + auto on simulated state changes. G2.
+- **Commit:** `mile 2/7 — three faces + state-driven switching`
+
+**Mile 3 — Direct, recomposed.**
+- **Goal:** **kill the chat bubbles.** Speakers told apart by type + a single hairline rule on the human voice. Agent results appear as **artifact chips** (node refs as things, not sentences). Verb actions become type-set, not pills. Taut, goal-framed microcopy.
+- **Files:** `chat_display.py`, `message_formatter.py`, `synapse_panel.py` (`_build_act`, `_build_input`).
+- **Gate:** G1 — a scripted conversation renders correctly. G2.
+- **Commit:** `mile 3/7 — speaker-by-type chat, results as artifacts`
+
+**Mile 4 — Work face.**
+- **Goal:** promote activity + `HealthInfographic` + live tool status (`_on_tool_status`) + a **cook preview** (bucket grid) + plan-with-progress. Reuse `routing_log` / `network_trace`.
+- **Files:** new `panel/face_work.py`, wired into the stack.
+- **Gate:** G1 — a simulated `working` state shows Work alive. G2.
+- **Commit:** `mile 4/7 — Work face (the walk-away glance)`
+
+**Mile 5 — Review face (the payoff).**
+- **Goal:** **the render is the hero** (the work supplies the color). Taut benefit verdict. **Credit/provenance block** (named authorship — `apex_trace`/`routing_log`). `GateWidget` with the graduated `GATE_LEVELS` (`INFORM/REVIEW` flow, `APPROVE/CRITICAL` block + timeout). Quality flags via `render_preflight`/`scene_doctor` — **BL-007 / BL-008 detection lands here.** Diff + accept/revert.
+- **Files:** new `panel/face_review.py`, a render-thumbnail surface, wire `gate_widget` + preflight.
+- **Gate:** G1 — simulated `done` shows render + credit + gate + flags. G2.
+- **Commit:** `mile 5/7 — Review face: render-hero, provenance, gated commit`
+
+**Mile 6 — ⌘K on two axes.**
+- **Goal:** reorganize the palette on **verb × context** (build/fix/explain/optimize/render × SOP/LOP/COP/Karma/USD) — self-identify two ways.
+- **Files:** `tool_palette.py`, `command_palette.py`, `tool_filter.py`.
+- **Gate:** G1 — palette opens, both axes navigable. G2.
+- **Commit:** `mile 6/7 — two-axis command palette`
+
+**Mile 7 — Design pass (the finish line).**
+- **Goal:** recede the chrome, apply muted-semantic tokens, set the type roles, tune the negative-space rhythm, final QSS. Production type decision (Söhne / Diatype / GT America) vs the comp's Space Grotesk/Mono.
+- **Files:** `designsystem/qss.py`, `tokens.py`, `styles.py`.
+- **Gate:** G1 + G2 + **fidelity gate** against the v3 comp, all three faces.
+- **Commit:** `mile 7/7 — design pass, fidelity locked`
+
+---
+
+## 5 · Halt and surface (stop, tell Joe, don't improvise)
+
+- A spike exposes a **design gap** the comps don't answer.
+- A Qt/`hou` API needed for a spike is **absent on 21.0.671** (quarantine it; surface the workaround choice).
+- A change would touch **USD substrate** → Michael Gold's RFC zone.
+- A gate **can't pass fix-forward** without weakening a test.
+- **PySide6 vs PySide2 divergence** changes behavior between gates.
+- Merge conflict on push.
+
+---
+
+## 6 · Definition of done
+
+Per spike: **G1 green · G2 green · matches comp · six properties intact · tests added or green.**
+Overall: the three faces live in Houdini 21.0.671, the rail never leaves the screen, and a walk-away → come-back cycle reads as trustworthy without you touching the transcript.
+
+---
+
+## 7 · Capsule (paste-forward for the next session)
+
+```
++== PANEL REDESIGN — BUILD ==============================+
+| WHERE WE ARE:        Spike 0 done — runner verified    |
+| MILE MARKER:         0 of 7 (start line crossed)       |
+| WHAT I WAS THINKING: v3 design locked; re-layout only  |
+| NEXT ACTION:         Mile 1 — rail + mark-as-status    |
+| BLOCKERS:            none                              |
+| ENERGY REQUIRED:     coding (3) — momentum from design |
+| IDEAS PARKED:        production type (Söhne/Diatype/GT) |
++========================================================+
+```

--- a/houdini/python_panels/synapse_panel.pypanel
+++ b/houdini/python_panels/synapse_panel.pypanel
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pythonPanelDocument>
-  <interface name="synapse_panel"
-             label="Synapse"
-             icon="MISC_python"
-             help_url="">
+  <!-- This file contains definitions of Python interfaces and the
+ interfaces menu.  It should not be hand-edited when it is being
+ used by the application.  Note, that two definitions of the
+ same interface or of the interfaces menu are not allowed
+ in a single file. -->
+  <interface name="synapse_panel" label="Synapse" icon="MISC_python" showNetworkNavigationBar="false" help_url="">
     <script><![CDATA[
 # Thin loader for the redesigned, modular SYNAPSE panel.
 # The panel itself lives in synapse.panel.synapse_panel (testable, design-system
@@ -22,7 +24,7 @@ if os.path.isdir(_py) and _py not in sys.path:
 # shared/ (the Lossless bridge, advisor, constants) lives at the REPO ROOT, not
 # under python/. SynapseHandler -> handlers_render imports `from shared...`, so
 # the repo root itself MUST be importable or the whole handler surface (and the
-# bridge + observability) silently fails to load — which surfaced to the artist
+# bridge + observability) silently fails to load  which surfaced to the artist
 # as a misleading "hou isn't responding". Root cause of the "processes but no
 # nodes" bug: only <root>/python was on the path, never <root>.
 if os.path.isdir(_root) and _root not in sys.path:
@@ -43,7 +45,7 @@ def onCreateInterface():
         from synapse.panel.synapse_panel import onCreateInterface as _build
         return _build()
     except Exception:
-        # Never crash Houdini's panel system — surface the error in-panel.
+        # Never crash Houdini's panel system  surface the error in-panel.
         import traceback
         try:
             from PySide6 import QtWidgets
@@ -55,8 +57,10 @@ def onCreateInterface():
         return view
 
 
-# Some Houdini code paths / older docs use createInterface — alias for safety.
+# Some Houdini code paths / older docs use createInterface  alias for safety.
 createInterface = onCreateInterface
 ]]></script>
+    <includeInToolbarMenu menu_position="0" create_separator="false"/>
+    <help><![CDATA[]]></help>
   </interface>
 </pythonPanelDocument>

--- a/run_panel.py
+++ b/run_panel.py
@@ -1,0 +1,170 @@
+"""SYNAPSE panel harness — one file, drop it anywhere in your SYNAPSE folder.
+
+    python run_panel.py            # open the panel in a window
+    python run_panel.py --smoke    # build it offscreen, print OK/FAIL, exit
+
+Press F5 in the window to hot-reload after editing any synapse.panel.* module.
+
+It finds the repo by looking for python/synapse/panel/synapse_panel.py, walking up
+from wherever this file lives (and from where you ran it), so it works in the
+SYNAPSE root, in a subfolder, or run from anywhere inside the tree.
+"""
+
+import os
+import sys
+import traceback
+
+
+# ----- find the SYNAPSE repo root, robustly --------------------------------
+def _find_root(start):
+    d = os.path.abspath(start)
+    for _ in range(10):
+        if os.path.isfile(os.path.join(d, "python", "synapse", "panel", "synapse_panel.py")):
+            return d
+        parent = os.path.dirname(d)
+        if parent == d:
+            return None
+        d = parent
+    return None
+
+
+_ROOT = _find_root(os.path.dirname(os.path.abspath(__file__))) or _find_root(os.getcwd())
+
+if not _ROOT:
+    print("Couldn't find the SYNAPSE code (python/synapse/panel/synapse_panel.py).")
+    print("Put this file inside your SYNAPSE folder, then run it again.")
+    sys.exit(1)
+
+for _p in (_ROOT, os.path.join(_ROOT, "python")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+# ----- tiny hou stub so the panel renders 'alive' outside Houdini ----------
+class _Node:
+    def __init__(self, path, parent_path=None):
+        self._path, self._parent_path = path, parent_path
+
+    def path(self):
+        return self._path
+
+    def parent(self):
+        return _Node(self._parent_path) if self._parent_path else None
+
+
+class _Hou:
+    class _HipFile:
+        def basename(self):
+            return "untitled.hip"
+
+    class _PaneTab:
+        def pwd(self):
+            return _Node("/stage")
+
+    class _UI:
+        def paneTabOfType(self, *_a, **_k):
+            return _Hou._PaneTab()
+
+        def displayMessage(self, msg, *_a, **_k):
+            print("[hou.ui]", msg)
+
+    class _PaneTabType:
+        NetworkEditor = "NetworkEditor"
+
+    class _SeverityType:
+        Message = "Message"
+        Warning = "Warning"
+        Error = "Error"
+
+    hipFile = _HipFile()
+    ui = _UI()
+    paneTabType = _PaneTabType()
+    severityType = _SeverityType()
+    _selected = [_Node("/stage/crystal_glass", parent_path="/stage")]
+
+    @staticmethod
+    def frame():
+        return 1
+
+    @staticmethod
+    def selectedNodes():
+        return list(_Hou._selected)
+
+
+sys.modules["hou"] = _Hou
+
+
+# ----- Qt (Houdini ships PySide6); guide the user if it's missing ----------
+_SMOKE = "--smoke" in sys.argv
+if _SMOKE:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PySide6 import QtWidgets
+    from PySide6.QtGui import QShortcut, QKeySequence
+except ImportError:
+    try:
+        from PySide2 import QtWidgets
+        from PySide2.QtWidgets import QShortcut
+        from PySide2.QtGui import QKeySequence
+    except ImportError:
+        print("PySide6 isn't available in this Python (%s)." % sys.executable)
+        print("The panel needs Houdini's Python, which already includes it. Try:")
+        print('  & "C:\\Program Files\\Side Effects Software\\Houdini 21.0.671\\bin\\hython.exe" run_panel.py')
+        print("(or: pip install PySide6  — if there's a wheel for your Python version)")
+        sys.exit(1)
+
+_PANEL_BG = "#2B2B2B"  # Houdini pane grey, so the frame doesn't lie about the fit
+
+
+def _flush_synapse():
+    for name in sorted(k for k in sys.modules if k.startswith("synapse.")):
+        del sys.modules[name]
+    sys.modules.pop("synapse", None)
+
+
+def build_panel():
+    _flush_synapse()
+    from synapse.panel.synapse_panel import createInterface
+    return createInterface()
+
+
+class Harness(QtWidgets.QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("SYNAPSE — panel harness  ·  F5 to reload")
+        self.resize(380, 940)
+        self.setStyleSheet("QMainWindow{background:%s;}" % _PANEL_BG)
+        self._mount()
+        QShortcut(QKeySequence("F5"), self).activated.connect(self._reload)
+
+    def _mount(self):
+        self.setCentralWidget(build_panel())
+
+    def _reload(self):
+        old = self.centralWidget()
+        if old is not None:
+            old.setParent(None)
+            old.deleteLater()
+        self._mount()
+        print("[harness] reloaded")
+
+
+def main():
+    app = QtWidgets.QApplication(sys.argv)
+    if _SMOKE:
+        try:
+            w = build_panel()
+            app.processEvents()
+        except Exception:
+            print("SMOKE FAIL:\n")
+            traceback.print_exc()
+            return 1
+        print("SMOKE OK — %s instantiated" % type(w).__name__)
+        return 0
+    Harness().show()
+    return app.exec() if hasattr(app, "exec") else app.exec_()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds the panel-redesign dev harness and a small panel tweak.

- **run_panel.py** — standalone harness: `python run_panel.py` opens the panel in a window, `--smoke` builds it offscreen (OK/FAIL), F5 hot-reloads `synapse.panel.*`. Stubs `hou` so it runs outside Houdini.
- **docs/SYNAPSE_PANEL_REDESIGN_HARNESS.md** — the build-harness spec (the redesign re-layout plan).
- **synapse_panel.pypanel** — Houdini re-save: showNetworkNavigationBar=false (Houdini's serializer also stripped em-dashes from the comments — cosmetic).

**Verified:** `hython run_panel.py --smoke` -> `SMOKE OK — SynapsePanel instantiated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)