### PR TITLE
panel: the Pentagram pass — three faces + state→face controller (7 miles)

### DIFF
--- a/.claude/agents/panel-relay/ASSAYER.md
+++ b/.claude/agents/panel-relay/ASSAYER.md
@@ -1,0 +1,39 @@
+---
+name: panel-relay-assayer
+description: Leg 3 of the PANEL RELAY — through the live bridge, reload modules in the manifest's order, re-instantiate the panel, and dir()/hasattr-probe every new hou.* call against live Houdini 21.0.671. Execute + probe only; no design decisions.
+tools: Read, Grep, Glob, Bash
+---
+
+# ASSAYER — Leg 3: reload + re-instantiate + probe
+
+Execute and verify. **No design decisions.** Houdini's import cache is the enemy —
+an "update" is edit → invalidate → re-bind → verify, without bouncing the session.
+
+## Do, in order
+1. **Ping the bridge first** (`ws://localhost:9999`). The SessionStart "connected"
+   hook can be stale — confirm live before trusting it.
+2. **Reload modules in the manifest's bottom-up order** (`importlib.reload`), so a
+   module never re-binds against a stale dependency.
+3. **Close/reopen the panel** so it binds the reloaded classes. Confirm it actually
+   re-instantiated — not merely that reload returned.
+4. **dir() / hasattr gate:** every new `hou.*` call is probed in live 671 BEFORE it
+   is trusted. Phantom APIs are the #1 failure class; this hurdle is non-negotiable.
+   Known-absent (do not re-litigate): `hou.pdg.*`, `hou.secure`,
+   `hou.lopNetworks()`, `hou.updateGraphTick()`.
+
+## WebSocket transport caveats (hard-won)
+- `execute_python` chokes on multi-line dict literals → **sequential single-line calls**.
+- Multi-line class defs → Source Editor or `exec()`.
+
+## Failure
+Bridge unreachable → fall back to hython, and **flag the 21.0.631 headless vs
+21.0.671 graphical build mismatch**. UI checks still require the GUI session.
+
+## Baton out
+```
+probe_report {
+  reinstantiated:        bool
+  new_hou_calls_verified: [names confirmed present in live 671]
+  exceptions:            [any raised on reload/open]
+}
+```

--- a/.claude/agents/panel-relay/CARTOGRAPHER.md
+++ b/.claude/agents/panel-relay/CARTOGRAPHER.md
@@ -1,0 +1,35 @@
+---
+name: panel-relay-cartographer
+description: Leg 1 of the PANEL RELAY — classify the change's tier, map it to exact files in the symlinked tree, and compute the dependency-bottom-up reload order. Read + classify only; never edits.
+tools: Read, Grep, Glob, Bash
+---
+
+# CARTOGRAPHER — Leg 1: classify + map
+
+Read-only. **No edits, ever.** You produce the map the whole relay runs on.
+
+## Do
+1. **Classify the tier** (the rubric is the contract):
+   - RELOAD — code inside the symlinked tree (no registration, no shared/daemon).
+   - HARNESS — touches registration: `.pypanel`, shelf XML, icon registry, or a NEW
+     top-level file the installer must register.
+   - RESTART — new vendored dependency, OR shared/ or daemon code.
+2. **Map the change** to exact files in the symlinked tree.
+3. **Compute the reload order** — always dependency-bottom-up:
+   `tokens → styles/qss → widgets → faces → panel`. A module reloads only after
+   everything it imports has reloaded.
+4. Note whether **registration is touched** (decides HARNESS vs RELOAD).
+
+## Hard rules
+- The tier rubric is the contract. Reload order is always bottom-up.
+- Ambiguous tier → default to the **higher** (safer) tier and flag for Joe.
+
+## Baton out (typed)
+```
+manifest {
+  tier:                RELOAD | HARNESS | RESTART
+  files:               [exact paths in the symlinked tree]
+  reload_order:        [module names, bottom-up]
+  touches_registration: bool
+}
+```

--- a/.claude/agents/panel-relay/CRUCIBLE.md
+++ b/.claude/agents/panel-relay/CRUCIBLE.md
@@ -1,0 +1,35 @@
+---
+name: panel-relay-crucible
+description: Leg 4 of the PANEL RELAY — adversarial verification. Tries to break the reloaded panel (reload desync, missing module, malformed state, daemon-shared-code case). Fixes forward; never weakens a test to make it pass.
+tools: Read, Grep, Glob, Edit, Bash
+---
+
+# CRUCIBLE — Leg 4: adversarial, fix-forward
+
+Try to break what FORGE built and ASSAYER reloaded. Then harden it.
+
+## Attack surface
+- Reload desync (a module re-bound against a stale dependency).
+- A missing / unimportable module in the chain.
+- Malformed panel state on reopen.
+- The daemon-shared-code case (should have been caught at tier classification —
+  verify it wasn't silently crossed).
+
+## Hard rules
+- **Never weaken a test to make it pass. Fix-forward only.**
+- Commandment 7 — **property requirements over pattern paraphrase.** Don't
+  cargo-cult a safety pattern FORGE correctly omitted; assert the behavior, not the
+  incantation.
+- Test count strictly holds or rises.
+
+## Failure
+Can't harden in 3 attempts → hand to ORCHESTRATOR for escalation. Do **not** lower
+the bar.
+
+## Baton out
+```
+hardened {
+  test_delta:   >= 0
+  cases_covered: [adversarial cases handled]
+}
+```

--- a/.claude/agents/panel-relay/FORGE.md
+++ b/.claude/agents/panel-relay/FORGE.md
@@ -1,0 +1,30 @@
+---
+name: panel-relay-forge
+description: Leg 2 of the PANEL RELAY — implement the change, bound by the invariants, touching only files named in the CARTOGRAPHER manifest. Stops and re-flags the tier rather than silently crossing a tier boundary.
+tools: Read, Grep, Glob, Edit, Write, Bash
+---
+
+# FORGE — Leg 2: implement
+
+Implement the change inside the manifest's files. Nothing else.
+
+## Invariants (the constitution)
+- All tool calls route through the **Dispatcher**. Preserve the **`AgentToolError`
+  envelope shape** — do not reshape it.
+- **No new dependencies** beyond the vendored anthropic SDK. No new imports that
+  weren't already in the touched files.
+- **Design tokens come from `tokens.py` / `styles.py` — never hardcode greys.** The
+  palette is `UIDark.hcs`-derived; the render stays the only chromatic event.
+- **Match the comp.** Compose, don't rewrite — reuse the proven runtime/widgets.
+- PySide6 with PySide2 fallback; every optional import wrapped (graceful degradation
+  is a runtime contract).
+
+## Hard stop
+If the change turns out to need **registration** (→ HARNESS) or **shared/daemon
+code** (→ RESTART), **STOP and re-flag the tier** to the ORCHESTRATOR. Do NOT cross
+the boundary silently.
+
+## Baton out
+```
+diff — confined to the manifest's files; no new imports; tokens not hardcoded.
+```

--- a/.claude/agents/panel-relay/ORCHESTRATOR.md
+++ b/.claude/agents/panel-relay/ORCHESTRATOR.md
@@ -1,0 +1,57 @@
+---
+name: panel-relay-orchestrator
+description: Conductor of the PANEL RELAY. Owns the state machine, the tier call, escalation, and rollback. Runs nothing itself except sequencing — dispatches CARTOGRAPHER → FORGE → ASSAYER → CRUCIBLE, then halts at the human anchor.
+tools: Read, Grep, Glob, Bash, Agent
+---
+
+# ORCHESTRATOR — the conductor
+
+You own the relay; you do not do the legs. You hold the stick between legs and
+advance only when a baton is in hand and its exit criterion is genuinely met.
+
+## First decision, every run: the tier
+```
+RELOAD-tier    code inside the symlinked tree              → fast loop, no restart
+HARNESS-tier   registration (.pypanel / shelf / icon / new → re-run installer's register step
+               top-level file)
+RESTART-tier   new vendored dep, OR shared/daemon code      → bounce Houdini (mind 671/631 split)
+```
+Misclassify and you waste a restart or ship a stale panel. Ambiguous → take the
+HIGHER tier and flag Joe.
+
+## The relay
+`Leg 1 CARTOGRAPHER → Leg 2 FORGE → Leg 3 ASSAYER → Leg 4 CRUCIBLE → ⚑ ANCHOR (Joe)`
+Each leg meets its exit criterion and hands a typed baton. No leg starts until the
+prior baton is in hand.
+
+## Two run modes
+- **Supervised** (first runs, low trust): halt + report at EVERY leg boundary; wait
+  for an explicit "go" before dispatching the next. Watch the relay walk.
+- **Walk-away** (earned): advance machine gates automatically; halt only at the
+  anchor and on escalation.
+- **Start supervised; drop to walk-away once Leg 3 has proven out.**
+
+## Laws
+- Never advance a gate whose exit criterion wasn't met. A soft pass is a fail.
+- Bounded failure: 3 retries/leg → re-route once (e.g. re-classify tier) → still
+  failing → escalate to Joe with a capsule.
+- **Strangler Fig:** the old registration and the daemon stay live through the whole
+  relay. The panel is never left unloadable.
+- **Commit discipline:** test count strictly holds or rises — never regresses.
+  Marathon-marker commit messages, test count recorded.
+- **Live-session mutation (Leg 3 reload) is outward-facing** — in supervised mode it
+  needs an explicit "go"; never reload Joe's running Houdini on inference alone.
+
+## Must escalate — never decide alone
+- Any new `hou.*` that fails ASSAYER's dir() probe → quarantine. Do NOT re-litigate
+  the known-absent set: `hou.pdg.*`, `hou.secure`, `hou.lopNetworks()`, `hou.updateGraphTick()`.
+- Any change that reaches shared/daemon code → flag RESTART-tier, hand to Joe.
+- The visual accept — always the anchor, always human.
+
+## Rollback
+Brick at any point → installer's uninstall / re-register. Daemon never touched.
+A UI-only reload never justifies bouncing the agent; only RESTART-tier does (Joe's call).
+
+## Escalation capsule (standard format)
+WHERE WE ARE / MILE MARKER / WHAT I WAS THINKING / NEXT ACTION / BLOCKERS /
+ENERGY REQUIRED / IDEAS PARKED

--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ SYNAPSE's whole point is to be *used*. The payoff is a docked **SYNAPSE panel**:
 ```mermaid
 %%{init: {'theme':'base', 'themeVariables': {'primaryColor':'#1e293b','primaryTextColor':'#f1f5f9','primaryBorderColor':'#0f172a','lineColor':'#f59e0b','secondaryColor':'#334155','tertiaryColor':'#475569'}}}%%
 flowchart LR
-    ART["Artist<br/>'make a box'"]:::artist --> PANEL["SYNAPSE panel<br/>docked, in-process"]:::panel
+    ART["Artist<br/>'make a box'"]:::artist --> PANEL["SYNAPSE panel<br/>rail + 3 faces, in-process"]:::panel
     PANEL --> LOOP["Agent loop<br/>streams Claude + 110 tools"]:::panel
     LOOP -->|"tool_use<br/>(e.g. execute_python)"| EXEC["Tool executor<br/>main thread"]:::panel
     EXEC --> BR["LosslessExecutionBridge<br/>consent &middot; undo &middot; thread-safe &middot; integrity"]:::bridge
     BR -->|in-process call| HOU[("hou.*<br/>node created")]:::hou
-    BR -.->|telemetry| OBS["Trust zone<br/>per-agent health &middot; self-tuning loop"]:::obs
+    LOOP -.->|state| FACE["state&rarr;face controller<br/>idle&middot;Direct / working&middot;Work / done&middot;Review"]:::obs
+    BR -.->|telemetry &middot; provenance| FACE
+    FACE -.->|surfaces the right face| PANEL
     classDef artist fill:#334155,stroke:#f59e0b,color:#f1f5f9
     classDef panel fill:#1e293b,stroke:#3b82f6,color:#f1f5f9
     classDef bridge fill:#1e293b,stroke:#f59e0b,color:#f1f5f9
@@ -38,7 +40,7 @@ flowchart LR
     classDef obs fill:#1e293b,stroke:#8b5cf6,color:#f1f5f9
 ```
 
-The panel was rebuilt from first principles over a thin `.pypanel` loader: one vendored design system (native Houdini 21 greys, a cool/warm dual accent), a Ctrl+K command palette across all 110 registry tools, live token streaming, and a Trust zone. Every mutation the agent makes is routed through the **`LosslessExecutionBridge`** — undo-wrapped, thread-safe, integrity-verified — so the agent's hands stay structurally reversible. Consent is **non-blocking for artist-initiated work** (your chat request *is* the consent; autonomous / external-MCP operations still gate through `HumanGate`); the gate previously polled the GUI thread and dead-locked Houdini until that was root-caused live and fixed. The Trust zone also surfaces a **recursive-observability** readout — per-agent success rates plus a recommendation history that persists across restarts and escalates if the same issue recurs.
+The panel was rebuilt from first principles ("the Pentagram pass") over a thin `.pypanel` loader: one vendored design system (native Houdini 21 greys, a cool/warm dual accent, the signal blue `#8FB3D9` kept as the *one* chromatic event). A persistent **rail** keeps termination, live state, and bounded cost on screen; the surface itself is **three faces driven by a state→face controller** — **Direct** (speaker-by-type chat, agent results as artifact chips), **Work** (the walk-away glance: a cook preview, plan-with-progress, and per-agent health), and **Review** (the render is the hero — a taut verdict, credited provenance, quality flags, and a gated commit). A **Ctrl+K palette lets you self-identify two ways** — by verb (build / fix / explain / optimize / render) × context (SOP / LOP / COP / Karma / USD). Every mutation the agent makes is routed through the **`LosslessExecutionBridge`** — undo-wrapped, thread-safe, integrity-verified — so the agent's hands stay structurally reversible. Consent is **non-blocking for artist-initiated work** (your chat request *is* the consent; autonomous / external-MCP operations still gate through `HumanGate`); the gate previously polled the GUI thread and dead-locked Houdini until that was root-caused live and fixed. The Work and Review faces surface a **recursive-observability** readout — per-agent success rates plus a recommendation history that persists across restarts and escalates if the same issue recurs.
 
 ---
 
@@ -544,12 +546,14 @@ python/synapse/
 │   ├── backfill.py             # one-time JSONL → Moneta backfill (backup-first)
 │   └── store.py                # SynapseMemory + SYNAPSE_MEMORY_BACKEND selector
 ├── panel/                      # artist-facing copilot panel (Qt / PySide6)
-│   ├── synapse_panel.py        # the docked panel (Converse / Act / Trust zones)
+│   ├── synapse_panel.py        # the docked panel — rail + 3 faces, state→face controller
+│   ├── face_work.py            # Work face — cook-preview bucket grid + plan-with-progress + health
+│   ├── face_review.py          # Review face — render-hero + verdict + credit/provenance + flags + gated commit
 │   ├── claude_worker.py        # background QThread — streams Claude + tool loop
 │   ├── tool_executor.py        # main-thread tool dispatch (→ SynapseHandler)
 │   ├── bridge_adapter.py       # routes every mutation through LosslessExecutionBridge
-│   ├── tool_palette.py         # Ctrl+K command palette over the tool registry
-│   ├── health_infographic.py   # Trust-zone observability (per-agent health + self-tuning loop)
+│   ├── tool_palette.py         # Ctrl+K palette — two axes (verb × context) over the tool registry
+│   ├── health_infographic.py   # observability (per-agent health + self-tuning loop), embedded in the Work face
 │   └── designsystem/           # vendored tokens / qss / components (one source)
 ├── _vendor/                    # anthropic + deps, CP311 win_amd64
 └── ...                         # Sprint 2 Week 1 + prior subsystems

--- a/audit_panel.py
+++ b/audit_panel.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+audit_panel.py  --  the THIRD gate (G3) for the SYNAPSE panel harness.
+
+  G1 (run_panel.py --smoke) proves it BOOTS.
+  G2 (Houdini 21.0.671)      proves it loads in the real host.
+  G3 (this)                  proves it is READABLE and USABLE.
+
+Two layers:
+  A. TOKEN AUDIT  -- deterministic, no host. Contrast matrix + type-scale floors.
+                     Reads your real designsystem/tokens.py, so it audits the
+                     SYSTEM, not a screenshot.
+  B. LIVE AUDIT   -- offscreen Qt build. Interactive target sizes + face presence.
+
+Usage:
+  python audit_panel.py            # full human report
+  python audit_panel.py --strict   # exit 1 on any FAIL  (use this as the gate)
+"""
+import os, sys, math
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+# ---- repo path (same discovery as run_panel) ----
+def _find_root(start):
+    p = os.path.abspath(start)
+    while p != os.path.dirname(p):
+        if os.path.isdir(os.path.join(p, "python", "synapse")):
+            return p
+        p = os.path.dirname(p)
+    return os.path.abspath(start)
+
+ROOT  = _find_root(__file__)
+PYDIR = os.path.join(ROOT, "python")
+if PYDIR not in sys.path:
+    sys.path.insert(0, PYDIR)
+
+from synapse.panel.designsystem import tokens as t
+
+# ---------------- WCAG contrast ----------------
+def _lin(c):
+    c = c / 255.0
+    return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+def _lum(hx):
+    h = hx.lstrip("#")
+    r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+    return 0.2126 * _lin(r) + 0.7152 * _lin(g) + 0.0722 * _lin(b)
+
+def contrast(fg, bg):
+    a, b = _lum(fg), _lum(bg)
+    return (max(a, b) + 0.05) / (min(a, b) + 0.05)
+
+# ---------------- floors ----------------
+AA_BODY    = 4.5    # WCAG AA, normal text
+AA_LARGE   = 3.0    # WCAG AA, large/bold text
+PRAGMATIC  = 3.0    # dark-DCC line we will not cross for ANY essential text
+BODY_FLOOR = 13     # px @ scale 1.0  (the v3 comp sets chat body to 13.5)
+TARGET_FLOOR = 26   # px, comfortable click/tap height for pills + buttons
+
+FAILS, WARNS = [], []
+def tag(ok, warnable=False, cr=None):
+    if ok:
+        return "[ ok ]"
+    if warnable:
+        WARNS.append(1); return "[WARN]"
+    FAILS.append(1);  return "[FAIL]"
+
+print("=" * 70)
+print("  SYNAPSE PANEL  ·  G3 READABILITY + USABILITY AUDIT")
+print("=" * 70)
+
+# ---------- A1 · contrast matrix ----------
+print("\n-- READABILITY · text on surface (WCAG contrast) " + "-" * 19)
+text_roles = {
+    "PRIMARY  (body)":  (t.TEXT_PRIMARY,   "body"),
+    "SECONDARY(meta)":  (t.TEXT_SECONDARY, "essential"),
+    "TERTIARY (hint)":  (t.TEXT_TERTIARY,  "essential"),
+    "BRIGHT   (head)":  (t.TEXT_BRIGHT,    "large"),
+    "ACCENT   (link)":  (t.TEXT_ACCENT,    "large"),
+}
+surfaces = {"PANEL": t.PANEL, "GROUND": t.GROUND, "SURFACE": t.SURFACE}
+hdr = "  " + " " * 16 + "".join(f"{s:>16}" for s in surfaces)
+print(hdr)
+for name, (fg, kind) in text_roles.items():
+    row = f"  {name:<16}"
+    for sname, sbg in surfaces.items():
+        cr = contrast(fg, sbg)
+        floor = AA_BODY if kind == "body" else (AA_LARGE if kind == "large" else PRAGMATIC)
+        ok = cr >= floor
+        warnable = (kind != "body")  # body is non-negotiable; others can warn
+        row += f"  {cr:4.1f}:1 {tag(ok, warnable)}"
+    print(row)
+print(f"  floors:  body >= {AA_BODY}:1   head/link >= {AA_LARGE}:1   any essential >= {PRAGMATIC}:1")
+
+# ---------- A2 · type scale ----------
+print("\n-- READABILITY · type scale (px @ scale " + f"{t.FONT_SCALE_DEFAULT}) " + "-" * 22)
+sizes = [("HERO", t.SIZE_HERO), ("TITLE", t.SIZE_TITLE), ("UI", t.SIZE_UI),
+         ("SMALL", t.SIZE_SMALL), ("MICRO", t.SIZE_MICRO), ("BODY", t.SIZE_BODY)]
+for n, s in sizes:
+    eff = t.scaled(s, t.FONT_SCALE_DEFAULT)
+    note = ""
+    if n == "BODY":
+        note = "  " + tag(eff >= BODY_FLOOR) + f"  chat body — floor {BODY_FLOOR}px"
+    print(f"   {n:<6} {eff:>3}px{note}")
+distinct = len({s for _, s in sizes})
+print(f"   hierarchy: {distinct} distinct steps  " + tag(distinct >= 4, warnable=True))
+
+# ---------- B · live build ----------
+print("\n-- USABILITY · live offscreen build " + "-" * 31)
+try:
+    import run_panel  # registers hou stub + path
+    try:
+        from PySide6 import QtWidgets
+    except ImportError:
+        from PySide2 import QtWidgets
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    panel = run_panel.build_panel()
+    app.processEvents()
+
+    btns = panel.findChildren(QtWidgets.QAbstractButton)
+    under = [b for b in btns if 0 < b.sizeHint().height() < TARGET_FLOOR]
+    print(f"   interactive targets : {len(btns):>3} found, "
+          f"{len(under)} under {TARGET_FLOOR}px  " + tag(not under, warnable=True))
+
+    texts = [b.text() for b in btns if b.text()]
+    faces = [f for f in ("Direct", "Work", "Review") if f in texts]
+    print(f"   faces present       : {faces}  " + tag(len(faces) == 3))
+
+    labels = panel.findChildren(QtWidgets.QLabel)
+    print(f"   labels rendered     : {len(labels):>3}")
+except Exception as e:
+    WARNS.append(1)
+    print(f"   [skip] live build unavailable here: {type(e).__name__}: {e}")
+    print("          (run this one inside hython for the real G3 — fonts differ)")
+
+# ---------- verdict ----------
+print("\n" + "=" * 70)
+n_fail, n_warn = len(FAILS), len(WARNS)
+if n_fail:
+    print(f"  G3 RESULT:  {n_fail} FAIL · {n_warn} WARN  —  not readable/usable yet.")
+else:
+    print(f"  G3 RESULT:  pass  ·  {n_warn} WARN")
+print("=" * 70)
+
+if "--strict" in sys.argv:
+    sys.exit(1 if n_fail else 0)

--- a/python/synapse/panel/command_palette.py
+++ b/python/synapse/panel/command_palette.py
@@ -69,6 +69,12 @@ except ImportError:
 # 1. PaletteEntry dataclass
 # ===================================================================
 
+try:
+    from synapse.panel.tool_filter import classify_tool
+except Exception:  # pragma: no cover
+    classify_tool = None
+
+
 @dataclass
 class PaletteEntry:
     """Single searchable entry in the command palette."""
@@ -78,6 +84,8 @@ class PaletteEntry:
     category: str        # "command", "recipe", "apex", "vex", "recent"
     description: str     # brief description
     score: float = 0.0   # fuzzy match score (higher = better match)
+    verb: str = "build"          # two-axis (Mile 6): what the artist wants done
+    context: Optional[str] = None  # two-axis (Mile 6): where they are
 
 
 # ===================================================================
@@ -185,6 +193,14 @@ def build_palette_entries(*, force_rebuild: bool = False) -> list[PaletteEntry]:
             ))
     except (ImportError, AttributeError):
         pass
+
+    # Tag every entry on the two axes (verb × context) for ⌘K navigation.
+    if classify_tool is not None:
+        for e in entries:
+            try:
+                e.verb, e.context = classify_tool(e.command, e.label, e.description)
+            except Exception:
+                pass
 
     _cached_entries = entries
     return entries

--- a/python/synapse/panel/designsystem/components.py
+++ b/python/synapse/panel/designsystem/components.py
@@ -9,16 +9,16 @@ QFrame) — uses QWidget + WA_StyledBackground.
 """
 
 try:
-    from PySide6 import QtWidgets, QtGui
+    from PySide6 import QtWidgets, QtGui, QtCore
     from PySide6.QtCore import Qt
 except ImportError:  # pragma: no cover - Houdini ships PySide6
-    from PySide2 import QtWidgets, QtGui
+    from PySide2 import QtWidgets, QtGui, QtCore
     from PySide2.QtCore import Qt
 
 from . import tokens as t
 
 __all__ = [
-    "Button", "Pill", "Card", "Badge", "StatusDot", "ProgressBar",
+    "Button", "Pill", "Card", "Badge", "StatusDot", "MarkDot", "ProgressBar",
     "label", "divider", "apply_font_role", "repolish",
 ]
 
@@ -122,6 +122,74 @@ class StatusDot(QtWidgets.QWidget):
         p.setPen(Qt.NoPen)
         p.setBrush(QtGui.QColor(self._color))
         p.drawEllipse(1, 1, self._d, self._d)
+        p.end()
+
+
+class MarkDot(QtWidgets.QWidget):
+    """The SYNAPSE mark IS the status light.
+
+    A ring at rest, a sweeping half-disc while working, a full disc when done —
+    always in the one warm note (WARM). Identity and live state collapse into a
+    single element, and because it never borrows Houdini's own orange, SYNAPSE
+    keeps a distinct presence in the host. (Pentagram pass.)
+    """
+
+    _RESTING = {"idle", "ready", "connected", "disconnected", "warning", "error", ""}
+
+    def __init__(self, state="idle", diameter=16, parent=None):
+        super().__init__(parent)
+        self._d = diameter
+        self._state = state or "idle"
+        self._angle = 0
+        self._spin = QtCore.QTimer(self)
+        self._spin.setInterval(33)  # ~30 fps; only runs while working
+        self._spin.timeout.connect(self._tick)
+        self.setFixedSize(diameter + 4, diameter + 4)
+        self._sync_timer()
+
+    def set_state(self, state):
+        state = state or "idle"
+        if state == self._state:
+            return
+        self._state = state
+        self._sync_timer()
+        self.update()
+
+    def _sync_timer(self):
+        if self._state == "working":
+            if not self._spin.isActive():
+                self._spin.start()
+        elif self._spin.isActive():
+            self._spin.stop()
+
+    def _tick(self):
+        self._angle = (self._angle + 6) % 360
+        self.update()
+
+    def paintEvent(self, _event):
+        p = QtGui.QPainter(self)
+        p.setRenderHint(QtGui.QPainter.Antialiasing)
+        col = QtGui.QColor(t.WARM)
+        m = 2
+        rect = QtCore.QRectF(m, m, self._d, self._d)
+        if self._state == "working":
+            faint = QtGui.QColor(t.WARM)
+            faint.setAlphaF(0.22)
+            p.setPen(Qt.NoPen)
+            p.setBrush(faint)
+            p.drawEllipse(rect)                       # faint full ring behind
+            p.setBrush(col)
+            p.drawPie(rect, int(self._angle * 16), 180 * 16)  # sweeping half
+        elif self._state == "done":
+            p.setPen(Qt.NoPen)
+            p.setBrush(col)
+            p.drawEllipse(rect)                       # full disc
+        else:  # resting → ring
+            pen = QtGui.QPen(col)
+            pen.setWidthF(2.0)
+            p.setPen(pen)
+            p.setBrush(Qt.NoBrush)
+            p.drawEllipse(QtCore.QRectF(m + 1, m + 1, self._d - 2, self._d - 2))
         p.end()
 
 

--- a/python/synapse/panel/designsystem/qss.py
+++ b/python/synapse/panel/designsystem/qss.py
@@ -79,6 +79,35 @@ QPushButton#DsPill:pressed {{ background: {t.SIGNAL_TINT}; }}
 QPushButton#DsPill:disabled {{ color: {t.TEXT_DISABLED}; }}
 QPushButton#DsPill[active="true"] {{ color: {t.TEXT_ACCENT}; background: {t.SIGNAL_TINT}; }}
 
+/* ---- type-set verbs (Direct act bar + Review actions) — Mile 7 --- */
+/* Verbs read as type, not buttons: flat, mono, the chrome recedes. */
+QPushButton#DsVerb {{
+    background: transparent; border: none; padding: 2px 0;
+    color: {t.TEXT_SECONDARY}; font-family: {t.FONT_MONO_CSS};
+    font-size: {s(11)}px;
+}}
+QPushButton#DsVerb:hover {{ color: {t.TEXT_ACCENT}; }}
+QPushButton#DsVerb[tone="ok"]     {{ color: {t.GROW}; }}
+QPushButton#DsVerb[tone="hot"]    {{ color: {t.WARM}; }}
+QPushButton#DsVerb[tone="accent"] {{ color: {t.TEXT_ACCENT}; }}
+
+/* ---- two-axis palette chips (⌘K · DO × WHERE) ---------------- */
+QPushButton#DsChip {{
+    background: transparent; color: {t.TEXT_TERTIARY};
+    border: none; border-radius: {t.RADIUS_SM}px; padding: 3px 8px;
+    font-family: {t.FONT_MONO_CSS}; font-size: {s(10)}px;
+}}
+QPushButton#DsChip:hover {{ color: {t.TEXT_SECONDARY}; }}
+QPushButton#DsChip[active="true"] {{ background: {t.SIGNAL_TINT}; color: {t.TEXT_ACCENT}; }}
+
+/* ---- command-palette list ------------------------------------ */
+QListWidget#DsList {{
+    background: transparent; color: {t.TEXT_PRIMARY};
+    border: none; outline: none;
+}}
+QListWidget#DsList::item {{ padding: {t.SPACE_XS}px {t.SPACE_SM}px; border-radius: {t.RADIUS_SM}px; }}
+QListWidget#DsList::item:selected {{ background: {t.SIGNAL_TINT}; color: {t.TEXT_ACCENT}; }}
+
 /* ---- cards & drawers ----------------------------------------- */
 QWidget#DsCard {{
     background: {t.SURFACE}; border: 1px solid {t.BORDER};

--- a/python/synapse/panel/designsystem/qss.py
+++ b/python/synapse/panel/designsystem/qss.py
@@ -72,7 +72,7 @@ QPushButton#DsPill {{
     background: none; color: {t.TEXT_SECONDARY};
     border: none; border-radius: {t.RADIUS_SM}px;
     padding: {t.SPACE_XS}px {t.SPACE_MD}px;
-    font-size: {s(t.SIZE_UI)}px; font-weight: 500;
+    font-size: {s(t.SIZE_UI + 2)}px; font-weight: 500;
 }}
 QPushButton#DsPill:hover  {{ background: {t.HOVER_WASH}; color: {t.TEXT_ACCENT}; }}
 QPushButton#DsPill:pressed {{ background: {t.SIGNAL_TINT}; }}

--- a/python/synapse/panel/designsystem/tokens.py
+++ b/python/synapse/panel/designsystem/tokens.py
@@ -242,9 +242,14 @@ PALETTE = {
 
 
 if __name__ == "__main__":
-    print("SYNAPSE design tokens (vendored, single source)")
-    print(f"  elevation: {ELEVATION}")
-    print(f"  type roles: {list(TYPE_ROLES)}")
-    print(f"  status: {list(STATUS)}  gates: {list(GATE_LEVELS)}")
-    print(f"  space: {SPACE_XS}/{SPACE_SM}/{SPACE_MD}/{SPACE_LG}/{SPACE_XL}"
-          f"  motion: {DUR_FAST}/{DUR_BASE}/{DUR_SLOW}ms {EASE}")
+    # stdout.write, not print() — the project bans bare print() in source
+    # (tests/test_v5_features.py::test_no_print_in_source enforces it).
+    import sys as _sys
+    _sys.stdout.write("SYNAPSE design tokens (vendored, single source)\n")
+    _sys.stdout.write(f"  elevation: {ELEVATION}\n")
+    _sys.stdout.write(f"  type roles: {list(TYPE_ROLES)}\n")
+    _sys.stdout.write(f"  status: {list(STATUS)}  gates: {list(GATE_LEVELS)}\n")
+    _sys.stdout.write(
+        f"  space: {SPACE_XS}/{SPACE_SM}/{SPACE_MD}/{SPACE_LG}/{SPACE_XL}"
+        f"  motion: {DUR_FAST}/{DUR_BASE}/{DUR_SLOW}ms {EASE}\n"
+    )

--- a/python/synapse/panel/designsystem/tokens.py
+++ b/python/synapse/panel/designsystem/tokens.py
@@ -63,8 +63,8 @@ ELEVATION = {  # role -> bg color, for components to read by name
 # multiplied ×0.85: CC→AD, 80→6D, 6E→5E, E6→C4, 6A→5A. Brand/semantic accents
 # (SIGNAL/WARM/status) are left at full strength — "fonts" = the readable ramp.
 TEXT_PRIMARY   = "#ADADAD"  # body — 85% of CC (Houdini TEXT, GREY .8)
-TEXT_SECONDARY = "#6D6D6D"  # secondary — 85% of 80 (Houdini SecondaryText)
-TEXT_TERTIARY  = "#5E5E5E"  # captions / hints — 85% of 6E
+TEXT_SECONDARY = "#8A8A8A"  # secondary — 85% of 80 (Houdini SecondaryText)
+TEXT_TERTIARY  = "#7E7E7E"  # captions / hints — 85% of 6E
 TEXT_BRIGHT    = "#C4C4C4"  # emphasis / headings — 85% of E6
 TEXT_ACCENT    = SIGNAL     # links, accent labels (NOT body — see WCAG note)
 TEXT_DISABLED  = "#5A5A5A"  # 85% of 6A
@@ -110,18 +110,12 @@ STATE_TINTS = {  # status-hue washes for cards/badges
 # 5. TYPOGRAPHY — families, sizes, and ROLES
 # ─────────────────────────────────────────────────────────────
 
-# Production type decision (Mile 7): prefer the ship faces (Söhne · Diatype ·
-# GT America), fall through the comp faces (Space Grotesk · Space Mono), then to
-# ever-more-common system fonts. Graceful by construction — body text inherits
-# Houdini's native UI font (apply_font_role), so these chiefly drive the mono
-# surfaces (paths, verbs, chips); an absent face falls back silently, never
-# breaks. Same install-risk class as the prior JetBrains-Mono primary.
-FONT_MONO = "Diatype Mono"
-FONT_MONO_FALLBACKS = ("Space Mono", "JetBrains Mono", "IBM Plex Mono", "Consolas", "monospace")
+FONT_MONO = "JetBrains Mono"
+FONT_MONO_FALLBACKS = ("IBM Plex Mono", "Consolas", "monospace")
 FONT_MONO_CSS = ", ".join(f'"{f}"' for f in (FONT_MONO,) + FONT_MONO_FALLBACKS)
 
-FONT_SANS = "Söhne"
-FONT_SANS_FALLBACKS = ("GT America", "Space Grotesk", "Inter", "DM Sans", "Segoe UI", "sans-serif")
+FONT_SANS = "DM Sans"
+FONT_SANS_FALLBACKS = ("Instrument Sans", "Segoe UI", "sans-serif")
 FONT_SANS_CSS = ", ".join(f'"{f}"' for f in (FONT_SANS,) + FONT_SANS_FALLBACKS)
 
 # px scale (Qt). Calibrated to the panel's true rendering DPI (the canonical
@@ -129,7 +123,7 @@ FONT_SANS_CSS = ", ".join(f'"{f}"' for f in (FONT_SANS,) + FONT_SANS_FALLBACKS)
 SIZE_MICRO  = 13   # tiny labels / numbers
 SIZE_SMALL  = 14   # captions, metadata
 SIZE_UI     = 20   # buttons, pills, menu items, labels — two sizes up; scalable via Aa
-SIZE_BODY   = 12   # chat body — KEEP ("Ready…" is the correct reference size)
+SIZE_BODY   = 13   # chat body — KEEP ("Ready…" is the correct reference size)
 SIZE_TITLE  = 22   # section headers
 SIZE_HERO   = 30   # panel title
 
@@ -248,12 +242,9 @@ PALETTE = {
 
 
 if __name__ == "__main__":
-    import sys as _sys
-    _sys.stdout.write("SYNAPSE design tokens (vendored, single source)\n")
-    _sys.stdout.write(f"  elevation: {ELEVATION}\n")
-    _sys.stdout.write(f"  type roles: {list(TYPE_ROLES)}\n")
-    _sys.stdout.write(f"  status: {list(STATUS)}  gates: {list(GATE_LEVELS)}\n")
-    _sys.stdout.write(
-        f"  space: {SPACE_XS}/{SPACE_SM}/{SPACE_MD}/{SPACE_LG}/{SPACE_XL}"
-        f"  motion: {DUR_FAST}/{DUR_BASE}/{DUR_SLOW}ms {EASE}\n"
-    )
+    print("SYNAPSE design tokens (vendored, single source)")
+    print(f"  elevation: {ELEVATION}")
+    print(f"  type roles: {list(TYPE_ROLES)}")
+    print(f"  status: {list(STATUS)}  gates: {list(GATE_LEVELS)}")
+    print(f"  space: {SPACE_XS}/{SPACE_SM}/{SPACE_MD}/{SPACE_LG}/{SPACE_XL}"
+          f"  motion: {DUR_FAST}/{DUR_BASE}/{DUR_SLOW}ms {EASE}")

--- a/python/synapse/panel/designsystem/tokens.py
+++ b/python/synapse/panel/designsystem/tokens.py
@@ -110,12 +110,18 @@ STATE_TINTS = {  # status-hue washes for cards/badges
 # 5. TYPOGRAPHY — families, sizes, and ROLES
 # ─────────────────────────────────────────────────────────────
 
-FONT_MONO = "JetBrains Mono"
-FONT_MONO_FALLBACKS = ("IBM Plex Mono", "Consolas", "monospace")
+# Production type decision (Mile 7): prefer the ship faces (Söhne · Diatype ·
+# GT America), fall through the comp faces (Space Grotesk · Space Mono), then to
+# ever-more-common system fonts. Graceful by construction — body text inherits
+# Houdini's native UI font (apply_font_role), so these chiefly drive the mono
+# surfaces (paths, verbs, chips); an absent face falls back silently, never
+# breaks. Same install-risk class as the prior JetBrains-Mono primary.
+FONT_MONO = "Diatype Mono"
+FONT_MONO_FALLBACKS = ("Space Mono", "JetBrains Mono", "IBM Plex Mono", "Consolas", "monospace")
 FONT_MONO_CSS = ", ".join(f'"{f}"' for f in (FONT_MONO,) + FONT_MONO_FALLBACKS)
 
-FONT_SANS = "DM Sans"
-FONT_SANS_FALLBACKS = ("Instrument Sans", "Segoe UI", "sans-serif")
+FONT_SANS = "Söhne"
+FONT_SANS_FALLBACKS = ("GT America", "Space Grotesk", "Inter", "DM Sans", "Segoe UI", "sans-serif")
 FONT_SANS_CSS = ", ".join(f'"{f}"' for f in (FONT_SANS,) + FONT_SANS_FALLBACKS)
 
 # px scale (Qt). Calibrated to the panel's true rendering DPI (the canonical

--- a/python/synapse/panel/face_review.py
+++ b/python/synapse/panel/face_review.py
@@ -1,0 +1,355 @@
+"""FaceReview — the Review face: *the payoff* (Pentagram pass, Mile 5).
+
+When the work lands, this is the surface that has to be trustworthy enough to
+walk away from. It makes the **render the hero** (the only chromatic event),
+states a taut benefit **verdict**, credits the **authorship/provenance** like a
+named partner (apex_trace / routing_log), surfaces **quality flags** — including
+the BL-007 (silent no-output) and BL-008 (silent material-binding loss)
+detections — embeds the graduated **GateWidget** for consent, and offers
+**accept / revert / commit** as the close.
+
+Panel-layer only: ``Commit to /stage`` *raises a gate*, it never writes the USD
+substrate itself. Every dependency is optional so the face always instantiates.
+"""
+
+import os
+
+try:
+    from PySide6 import QtWidgets, QtGui, QtCore
+    from PySide6.QtCore import Qt, Signal
+except ImportError:  # pragma: no cover - Houdini ships PySide6
+    from PySide2 import QtWidgets, QtGui, QtCore
+    from PySide2.QtCore import Qt, Signal
+
+from synapse.panel.designsystem import tokens as t
+from synapse.panel.designsystem import components as c
+
+try:
+    from synapse.panel.gate_widget import GateWidget
+except Exception:  # pragma: no cover
+    GateWidget = None
+try:
+    from synapse.panel.routing_log import get_routing_log
+except Exception:  # pragma: no cover
+    get_routing_log = None
+try:
+    from synapse.panel.render_preflight import run_preflight
+except Exception:  # pragma: no cover
+    run_preflight = None
+
+# render-hero placeholder palette — the abstract "work" when no real frame is
+# in hand yet. Cool dark ground + the brand's two accents. Mile-7-tunable.
+_HERO_BG0, _HERO_BG1, _HERO_BG2 = "#2D3742", "#1A1F26", "#101317"
+
+# quality-flag status → dot color
+_FLAG_COLOR = {
+    "ok": t.GROW, "pass": t.GROW,
+    "warn": t.WARN,
+    "fail": t.ERROR, "no": t.ERROR,
+}
+
+
+def bl007_flag(output_path):
+    """BL-007 (silent no-output): a render is only real if a file landed at the
+    configured path with size > 0. Pure os check — no hou, so it is testable
+    standalone and honest about the husk-no-op-on-Indie failure mode."""
+    try:
+        if output_path and os.path.isfile(output_path) and os.path.getsize(output_path) > 0:
+            return ("ok", "output written")
+    except Exception:
+        pass
+    return ("fail", "EXR not written — BL-007")
+
+
+def detect_render_flags(render_node="", output_path=""):
+    """Best-effort live quality flags for the Review face. Combines the render
+    preflight report with the BL-007 output-on-disk check. Returns a list of
+    (status, text). Degrades to a single BL-007 row outside Houdini."""
+    flags = []
+    if run_preflight is not None:
+        try:
+            report = run_preflight(render_node)
+            flags.append(("ok" if report.ready else "fail",
+                          "render ready" if report.ready else "render not ready"))
+            for chk in report.checks:
+                if chk.status in ("fail", "warn"):
+                    text = chk.message
+                    # surface BL-008 framing on the material-binding check
+                    if chk.name == "materials":
+                        text += " — BL-008"
+                    flags.append((chk.status, text))
+        except Exception:
+            pass
+    flags.append(bl007_flag(output_path))
+    return flags
+
+
+def _verb(text, on_click, color=None):
+    """Type-set action — mono, letter-spaced, no pill chrome (matches Direct's
+    act bar). Inline-styled so it doesn't depend on the Mile-7 QSS pass."""
+    btn = QtWidgets.QPushButton(text)
+    btn.setObjectName("DsVerb")
+    btn.setCursor(Qt.PointingHandCursor)
+    btn.setFlat(True)
+    rest = color or t.TEXT_SECONDARY
+    btn.setStyleSheet(
+        "QPushButton#DsVerb{background:transparent; border:none; padding:2px 0;"
+        " color:%s; font-family:%s; font-size:11px; letter-spacing:1.4px;}"
+        "QPushButton#DsVerb:hover{color:%s;}"
+        % (rest, t.FONT_MONO, t.TEXT_ACCENT)
+    )
+    btn.clicked.connect(on_click)
+    return btn
+
+
+class RenderHero(QtWidgets.QWidget):
+    """The render, made the hero — the one chromatic event on the surface.
+
+    Shows the actual frame (a QPixmap) if a path is given; otherwise paints the
+    abstract gradient + shards placeholder from the v3 comp so the surface still
+    reads 'a result landed here'."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("DsSection")
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self._pix = None
+        self._meta = ""
+        self.setMinimumHeight(168)
+
+    def sizeHint(self):
+        return QtCore.QSize(340, 191)   # 16:9
+
+    def heightForWidth(self, w):
+        return int(w * 9 / 16)
+
+    def set_image(self, path):
+        pix = None
+        try:
+            if path and os.path.isfile(path):
+                pix = QtGui.QPixmap(path)
+                if pix.isNull():
+                    pix = None
+        except Exception:
+            pix = None
+        self._pix = pix
+        self.update()
+
+    def set_meta(self, text):
+        self._meta = text or ""
+        self.update()
+
+    def paintEvent(self, _event):
+        p = QtGui.QPainter(self)
+        p.setRenderHint(QtGui.QPainter.Antialiasing)
+        r = QtCore.QRectF(self.rect())
+        if self._pix is not None:
+            scaled = self._pix.scaled(
+                self.size(), Qt.KeepAspectRatioByExpanding, Qt.SmoothTransformation)
+            x = (scaled.width() - self.width()) / 2.0
+            y = (scaled.height() - self.height()) / 2.0
+            p.drawPixmap(QtCore.QPointF(-x, -y), scaled)
+        else:
+            self._paint_placeholder(p, r)
+        self._paint_vignette(p, r)
+        if self._meta:
+            self._paint_meta(p, r)
+        p.end()
+
+    def _paint_placeholder(self, p, r):
+        bg = QtGui.QRadialGradient(r.width() * 0.32, r.height() * 0.22,
+                                   max(r.width(), r.height()) * 1.1)
+        bg.setColorAt(0.0, QtGui.QColor(_HERO_BG0))
+        bg.setColorAt(0.55, QtGui.QColor(_HERO_BG1))
+        bg.setColorAt(1.0, QtGui.QColor(_HERO_BG2))
+        p.fillRect(r, QtGui.QBrush(bg))
+        # three angled shards, lit by the brand's two accents
+        self._shard(p, r, 0.24, 0.14, 0.34, 0.74, t.SIGNAL, t.WARM, 0.42)
+        self._shard(p, r, 0.48, 0.30, 0.30, 0.60, t.WARM, t.SIGNAL, 0.30)
+        self._shard(p, r, 0.14, 0.42, 0.22, 0.46, t.SIGNAL, t.SIGNAL, 0.24)
+
+    def _shard(self, p, r, fx, fy, fw, fh, c0, c1, a):
+        x, y = r.width() * fx, r.height() * fy
+        w, h = r.width() * fw, r.height() * fh
+        path = QtGui.QPainterPath()
+        path.moveTo(x + w * 0.38, y)
+        path.lineTo(x + w, y + h * 0.24)
+        path.lineTo(x + w * 0.72, y + h)
+        path.lineTo(x, y + h * 0.70)
+        path.closeSubpath()
+        grad = QtGui.QLinearGradient(x, y, x + w, y + h)
+        col0 = QtGui.QColor(c0); col0.setAlphaF(a)
+        col1 = QtGui.QColor(c1); col1.setAlphaF(a * 0.35)
+        grad.setColorAt(0.0, col0)
+        grad.setColorAt(1.0, col1)
+        p.setPen(Qt.NoPen)
+        p.setBrush(QtGui.QBrush(grad))
+        p.drawPath(path)
+
+    def _paint_vignette(self, p, r):
+        vig = QtGui.QRadialGradient(r.center(), max(r.width(), r.height()) * 0.62)
+        vig.setColorAt(0.55, QtGui.QColor(0, 0, 0, 0))
+        vig.setColorAt(1.0, QtGui.QColor(0, 0, 0, 115))
+        p.fillRect(r, QtGui.QBrush(vig))
+
+    def _paint_meta(self, p, r):
+        f = QtGui.QFont()
+        f.setPixelSize(10)
+        f.setFamily("monospace")
+        p.setFont(f)
+        p.setPen(QtGui.QColor("#97A3AD"))
+        p.drawText(QtCore.QRectF(r.left() + 10, r.bottom() - 20, r.width() - 20, 16),
+                   int(Qt.AlignLeft | Qt.AlignVCenter), self._meta)
+
+
+class FaceReview(QtWidgets.QWidget):
+    """The Review face content surface. The panel switches here on 'done' and
+    feeds it via ``show_result`` / the individual setters."""
+
+    accepted = Signal()
+    reverted = Signal()
+    committed = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("DsSection")
+        self.setAttribute(Qt.WA_StyledBackground, True)
+
+        col = QtWidgets.QVBoxLayout(self)
+        col.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_MD)
+        col.setSpacing(t.SPACE_SM)
+
+        # — the render, the hero —
+        self._hero = RenderHero()
+        col.addWidget(self._hero)
+
+        # — taut benefit verdict —
+        self._verdict = c.label("", role="title")
+        self._verdict.setWordWrap(True)
+        self._verdict.setStyleSheet("color:%s; font-size:15px;" % t.TEXT_BRIGHT)
+        col.addWidget(self._verdict)
+
+        # — credit / provenance (named authorship) —
+        self._credit_box = QtWidgets.QVBoxLayout()
+        self._credit_box.setSpacing(1)
+        col.addLayout(self._credit_box)
+
+        # — quality flags (preflight + BL-007 / BL-008) —
+        self._flags_box = QtWidgets.QVBoxLayout()
+        self._flags_box.setSpacing(1)
+        col.addLayout(self._flags_box)
+
+        # — touched paths —
+        self._paths = c.label("", role="code")
+        self._paths.setWordWrap(True)
+        self._paths.setStyleSheet("color:%s; font-size:10px;" % t.TEXT_TERTIARY)
+        self._paths.setVisible(False)
+        col.addWidget(self._paths)
+
+        # — consent gate (graduated GATE_LEVELS, embedded here) —
+        if GateWidget is not None:
+            self.gate = GateWidget(parent=self)
+            col.addWidget(self.gate)
+        else:
+            self.gate = None
+
+        # — the close: accept / revert / commit —
+        acts = QtWidgets.QHBoxLayout()
+        acts.setSpacing(t.SPACE_MD)
+        acts.addWidget(_verb("ACCEPT", lambda _=False: self.accepted.emit(), color=t.GROW))
+        acts.addWidget(_verb("↶ REVERT", lambda _=False: self.reverted.emit()))
+        acts.addStretch(1)
+        acts.addWidget(_verb("COMMIT TO /STAGE", lambda _=False: self.committed.emit(),
+                             color=t.WARM))
+        col.addLayout(acts)
+        col.addStretch(1)
+
+        self._verdict.setText("Standing by for the next result.")
+
+    # -- setters ---------------------------------------------------------
+    def set_render(self, path=None, meta=None):
+        self._hero.set_image(path)
+        if meta is not None:
+            self._hero.set_meta(meta)
+
+    def set_verdict(self, text):
+        self._verdict.setText(text or "")
+
+    def set_credit(self, items):
+        """items: list of (label, value, note)."""
+        self._clear(self._credit_box)
+        for label, value, note in items or []:
+            row = QtWidgets.QLabel()
+            row.setTextFormat(Qt.RichText)
+            row.setWordWrap(True)
+            row.setText(
+                '<span style="color:%s; font-family:%s; letter-spacing:1px;">%s </span>'
+                '<span style="color:%s;">%s</span>'
+                '<span style="color:%s;">%s</span>' % (
+                    t.TEXT_TERTIARY, t.FONT_MONO, label,
+                    t.SIGNAL, value,
+                    t.TEXT_SECONDARY, ("  — " + note) if note else "",
+                )
+            )
+            self._credit_box.addWidget(row)
+
+    def set_flags(self, flags):
+        """flags: list of (status, text). status in ok/pass/warn/fail/no."""
+        self._clear(self._flags_box)
+        for status, text in flags or []:
+            color = _FLAG_COLOR.get(status, t.TEXT_SECONDARY)
+            row = QtWidgets.QLabel()
+            row.setTextFormat(Qt.RichText)
+            row.setWordWrap(True)
+            row.setText(
+                '<span style="color:%s;">&#9679;</span> '
+                '<span style="color:%s;">%s</span>' % (color, t.TEXT_PRIMARY, text)
+            )
+            self._flags_box.addWidget(row)
+
+    def set_paths(self, paths):
+        if paths:
+            self._paths.setText("\n".join("~ %s" % p for p in paths))
+            self._paths.setVisible(True)
+        else:
+            self._paths.setVisible(False)
+
+    def show_result(self, verdict=None, credit=None, flags=None, paths=None,
+                    render=None, meta=None):
+        """Populate the whole surface for a landed result (one call)."""
+        if render is not None or meta is not None:
+            self.set_render(render, meta)
+        if verdict is not None:
+            self.set_verdict(verdict)
+        if credit is not None:
+            self.set_credit(credit)
+        if flags is not None:
+            self.set_flags(flags)
+        if paths is not None:
+            self.set_paths(paths)
+
+    def refresh_provenance(self):
+        """Best-effort credit row from the MOE routing_log (named authorship)."""
+        if get_routing_log is None:
+            return
+        try:
+            decisions = get_routing_log().to_dict().get("decisions", [])
+        except Exception:
+            return
+        if not decisions:
+            return
+        last = decisions[-1]
+        pair = last.get("primary", "?")
+        adv = last.get("advisory", "none")
+        if adv and adv != "none":
+            pair += " + " + adv
+        self.set_credit([("ROUTED", pair, last.get("method", ""))])
+
+    # -- helpers ---------------------------------------------------------
+    def _clear(self, box):
+        while box.count():
+            item = box.takeAt(0)
+            w = item.widget()
+            if w is not None:
+                w.setParent(None)
+                w.deleteLater()

--- a/python/synapse/panel/face_review.py
+++ b/python/synapse/panel/face_review.py
@@ -84,20 +84,15 @@ def detect_render_flags(render_node="", output_path=""):
     return flags
 
 
-def _verb(text, on_click, color=None):
-    """Type-set action — mono, letter-spaced, no pill chrome (matches Direct's
-    act bar). Inline-styled so it doesn't depend on the Mile-7 QSS pass."""
+def _verb(text, on_click, tone=None):
+    """Type-set action — mono, no pill chrome (matches Direct's act bar). Styled
+    by the canonical QPushButton#DsVerb QSS rule; ``tone`` selects the color."""
     btn = QtWidgets.QPushButton(text)
     btn.setObjectName("DsVerb")
     btn.setCursor(Qt.PointingHandCursor)
     btn.setFlat(True)
-    rest = color or t.TEXT_SECONDARY
-    btn.setStyleSheet(
-        "QPushButton#DsVerb{background:transparent; border:none; padding:2px 0;"
-        " color:%s; font-family:%s; font-size:11px; letter-spacing:1.4px;}"
-        "QPushButton#DsVerb:hover{color:%s;}"
-        % (rest, t.FONT_MONO, t.TEXT_ACCENT)
-    )
+    if tone:
+        btn.setProperty("tone", tone)
     btn.clicked.connect(on_click)
     return btn
 
@@ -256,11 +251,11 @@ class FaceReview(QtWidgets.QWidget):
         # — the close: accept / revert / commit —
         acts = QtWidgets.QHBoxLayout()
         acts.setSpacing(t.SPACE_MD)
-        acts.addWidget(_verb("ACCEPT", lambda _=False: self.accepted.emit(), color=t.GROW))
+        acts.addWidget(_verb("ACCEPT", lambda _=False: self.accepted.emit(), tone="ok"))
         acts.addWidget(_verb("↶ REVERT", lambda _=False: self.reverted.emit()))
         acts.addStretch(1)
         acts.addWidget(_verb("COMMIT TO /STAGE", lambda _=False: self.committed.emit(),
-                             color=t.WARM))
+                             tone="hot"))
         col.addLayout(acts)
         col.addStretch(1)
 

--- a/python/synapse/panel/face_work.py
+++ b/python/synapse/panel/face_work.py
@@ -1,0 +1,281 @@
+"""FaceWork — the Work face: *the walk-away glance* (Pentagram pass, Mile 4).
+
+When the agent is working, this is the surface the artist leaves up and walks
+away from. It promotes the live signals that say "it's running, and it's fine":
+
+  · a thinking pulse + the current tool status   (is it moving?)
+  · a **cook preview** — a bucket grid           (how far along?)
+  · a plan-with-progress, fed by the live tool    (what's it doing, in order?)
+    stream and the MOE routing_log
+  · the HealthInfographic                          (is it healthy?)
+
+Composed from the proven runtime — it embeds the existing ``HealthInfographic``
+and reuses ``routing_log`` rather than reinventing them. Every dependency is
+optional so the face always instantiates (graceful degradation is a contract).
+"""
+
+try:
+    from PySide6 import QtWidgets, QtGui, QtCore
+    from PySide6.QtCore import Qt, QTimer
+except ImportError:  # pragma: no cover - Houdini ships PySide6
+    from PySide2 import QtWidgets, QtGui, QtCore
+    from PySide2.QtCore import Qt, QTimer
+
+from synapse.panel.designsystem import tokens as t
+from synapse.panel.designsystem import components as c
+
+try:
+    from synapse.panel.designsystem.loader import BouncingToy
+except Exception:  # pragma: no cover
+    BouncingToy = None
+try:
+    from synapse.panel.health_infographic import HealthInfographic
+except Exception:  # pragma: no cover
+    HealthInfographic = None
+try:
+    from synapse.panel.routing_log import get_routing_log
+except Exception:  # pragma: no cover
+    get_routing_log = None
+
+# tool phase → (glyph, color-token) for the plan-with-progress rows
+_PHASE = {
+    "running": ("→", t.SIGNAL),
+    "done":    ("✓", t.GROW),
+    "ok":      ("✓", t.GROW),
+    "error":   ("✗", t.ERROR),
+    "failed":  ("✗", t.ERROR),
+}
+
+
+class BucketGrid(QtWidgets.QWidget):
+    """The cook preview — an N×M grid of buckets that fill as work lands.
+
+    Two modes: *determinate* (``set_progress(done, total)`` maps real cook /
+    render progress onto the grid) and an *indeterminate pulse* (a scanline
+    sweep) for when the agent is busy but no counted progress is wired yet —
+    it reads alive without fabricating a number.
+    """
+
+    def __init__(self, cols=8, rows=5, parent=None):
+        super().__init__(parent)
+        self.setObjectName("DsSection")
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self._cols, self._rows = cols, rows
+        self._n = cols * rows
+        self._done = 0
+        self._live = set()
+        self._determinate = False
+        self._head = 0
+        self._timer = QTimer(self)
+        self._timer.setInterval(110)
+        self._timer.timeout.connect(self._tick)
+        self.setMinimumHeight(150)
+
+    def sizeHint(self):
+        return QtCore.QSize(300, 170)
+
+    # -- state -----------------------------------------------------------
+    def set_progress(self, done, total, live=None):
+        """Map real cook progress (done/total) onto the grid cells."""
+        self._determinate = True
+        self.stop_pulse()
+        frac = (done / float(total)) if total else 0.0
+        self._done = max(0, min(self._n, int(round(frac * self._n))))
+        if live:
+            self._live = {self._done} if self._done < self._n else set()
+        else:
+            self._live = set()
+        self.update()
+
+    def start_pulse(self):
+        """Indeterminate 'busy' sweep (no counted progress available)."""
+        self._determinate = False
+        if not self._timer.isActive():
+            self._timer.start()
+
+    def stop_pulse(self):
+        if self._timer.isActive():
+            self._timer.stop()
+        self.update()
+
+    def reset(self):
+        self._done = 0
+        self._live = set()
+        self._head = 0
+        self._determinate = False
+        self.update()
+
+    def _tick(self):
+        self._head = (self._head + 1) % self._n
+        self.update()
+
+    # -- paint -----------------------------------------------------------
+    def paintEvent(self, _event):
+        p = QtGui.QPainter(self)
+        p.fillRect(self.rect(), QtGui.QColor(t.VOID))   # opaque dark ground
+        gap = 1.0
+        w = (self.width() - (self._cols + 1) * gap) / float(self._cols)
+        h = (self.height() - (self._rows + 1) * gap) / float(self._rows)
+        pending = QtGui.QColor(t.GROUND)
+        done = QtGui.QColor(t.SIGNAL); done.setAlpha(70)
+        live = QtGui.QColor(t.GROW); live.setAlpha(175)
+        trail = 6
+        p.setPen(Qt.NoPen)
+        for i in range(self._n):
+            r, col = divmod(i, self._cols)
+            x = gap + col * (w + gap)
+            y = gap + r * (h + gap)
+            color = pending
+            if self._determinate:
+                if i in self._live:
+                    color = live
+                elif i < self._done:
+                    color = done
+            else:
+                dist = (self._head - i) % self._n
+                if i == self._head:
+                    color = live
+                elif dist < trail:
+                    color = done
+            p.setBrush(color)
+            p.drawRect(QtCore.QRectF(x, y, w, h))
+        p.end()
+
+
+class FaceWork(QtWidgets.QWidget):
+    """The Work face content surface. The panel delegates its working-state
+    signals here (``set_thinking`` / ``set_tool_status`` / ``set_health``)."""
+
+    _MAX_STEPS = 6
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("DsSection")
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self._steps = []   # ordered [name, phase] — the live plan-with-progress
+
+        col = QtWidgets.QVBoxLayout(self)
+        col.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_SM)
+        col.setSpacing(t.SPACE_SM)
+
+        # — activity + current tool status —
+        head = QtWidgets.QHBoxLayout()
+        head.setSpacing(t.SPACE_SM)
+        self._toy = BouncingToy() if BouncingToy is not None else None
+        if self._toy is not None:
+            head.addWidget(self._toy)
+        self._status = c.label("Standing by", role="caption")
+        self._status.setStyleSheet("color:%s;" % t.TEXT_SECONDARY)
+        head.addWidget(self._status)
+        head.addStretch(1)
+        col.addLayout(head)
+
+        # — the cook preview (the focus of the glance) —
+        self._cook = BucketGrid()
+        col.addWidget(self._cook)
+        self._cook_lbl = c.label("waiting for work", role="caption")
+        self._cook_lbl.setStyleSheet("color:%s;" % t.TEXT_TERTIARY)
+        col.addWidget(self._cook_lbl)
+
+        # — plan-with-progress (driven by the live tool stream + routing_log) —
+        self._plan_title = c.label("PLAN", role="label")
+        self._plan_title.setStyleSheet(
+            "color:%s; letter-spacing:1.5px;" % t.TEXT_TERTIARY)
+        col.addWidget(self._plan_title)
+        self._plan_box = QtWidgets.QVBoxLayout()
+        self._plan_box.setSpacing(2)
+        col.addLayout(self._plan_box)
+        self._render_plan()
+
+        # — observability (the existing infographic, embedded here) —
+        if HealthInfographic is not None:
+            self._health = HealthInfographic(parent=self)
+            col.addWidget(self._health)
+        else:
+            self._health = None
+        col.addStretch(1)
+
+    # -- panel-facing API ------------------------------------------------
+    def set_thinking(self, on):
+        """Working ↔ at rest. Couples the toy + the cook's indeterminate pulse."""
+        if self._toy is not None:
+            self._toy.start() if on else self._toy.stop()
+        if on:
+            self._cook.start_pulse()
+        else:
+            self._cook.stop_pulse()
+            self._status.setText("Standing by")
+
+    def set_tool_status(self, name, phase, detail=None):
+        """A live tool event → update the status line + the plan-with-progress."""
+        self._status.setText("%s  %s" % (name, phase))
+        # update-or-append this tool as a plan step
+        for step in self._steps:
+            if step[0] == name:
+                step[1] = phase
+                break
+        else:
+            self._steps.append([name, phase])
+            if len(self._steps) > self._MAX_STEPS:
+                self._steps.pop(0)
+        self._render_plan()
+
+    def set_cook(self, done, total, live=True, label=None):
+        """Wire real cook / render progress onto the bucket grid."""
+        self._cook.set_progress(done, total, live=live)
+        self._cook_lbl.setText(
+            label or ("cooking %d / %d" % (done, total)))
+
+    def set_health(self, data):
+        if self._health is not None:
+            self._health.set_data(data)
+
+    def reset(self):
+        self._steps = []
+        self._cook.reset()
+        self._cook_lbl.setText("waiting for work")
+        self._render_plan()
+
+    # -- plan rendering --------------------------------------------------
+    def _routing_summary(self):
+        """Best-effort: the last routed agent pair from the MOE routing_log."""
+        if get_routing_log is None:
+            return ""
+        try:
+            decisions = get_routing_log().to_dict().get("decisions", [])
+        except Exception:
+            return ""
+        if not decisions:
+            return ""
+        last = decisions[-1]
+        adv = last.get("advisory", "none")
+        pair = last.get("primary", "?")
+        if adv and adv != "none":
+            pair += " + " + adv
+        return pair
+
+    def _clear_plan(self):
+        while self._plan_box.count():
+            item = self._plan_box.takeAt(0)
+            w = item.widget()
+            if w is not None:
+                w.setParent(None)
+                w.deleteLater()
+
+    def _render_plan(self):
+        self._clear_plan()
+        routed = self._routing_summary()
+        if routed:
+            self._plan_title.setText("PLAN · routed %s" % routed)
+        else:
+            self._plan_title.setText("PLAN")
+        if not self._steps:
+            row = c.label("no steps yet", role="caption")
+            row.setStyleSheet("color:%s;" % t.TEXT_TERTIARY)
+            self._plan_box.addWidget(row)
+            return
+        for name, phase in self._steps:
+            glyph, color = _PHASE.get(phase, ("·", t.TEXT_SECONDARY))
+            row = c.label("%s  %s" % (glyph, name), role="caption")
+            row.setStyleSheet("color:%s;" % color)
+            self._plan_box.addWidget(row)

--- a/python/synapse/panel/message_formatter.py
+++ b/python/synapse/panel/message_formatter.py
@@ -1,68 +1,72 @@
-"""Convert SYNAPSE responses to styled HTML for QTextEdit rendering.
+"""Convert SYNAPSE responses to styled HTML for the chat display.
 
-Handles plain text, code blocks (```python, ```vex), node paths
-(/obj/geo1/scatter1), parameter names, lists, and status indicators.
+Mile 3 (Pentagram pass) — *speakers are told apart by type, not bubbles.*
+The human voice carries a single signal-blue hairline rule and brighter text;
+the agent voice is plain, dimmer body copy with no chrome. Node references
+render as **artifact chips** — a node mark + mono path, a thing you can click,
+not a sentence. Signal blue is the one chromatic event; it comes from the
+vendored design system (#8FB3D9), not the legacy cyan.
 
-Supports message grouping (WhatsApp-style), timestamps, and font scaling.
+Public surface is unchanged (chat_display.py depends on it):
+``format_response``, ``format_user_message``, ``format_synapse_message``,
+``format_system_message``, ``format_timestamp_divider``.
 """
 
 import html
 import re
 
-# -- Design tokens (from canonical design system) -------------------------
+# -- Design tokens — the vendored single source of truth (the chrome's blue,
+#    not the legacy panel.tokens cyan). Robust literal fallback keeps the
+#    formatter working if the package path is unavailable (runtime contract).
 try:
-    from synapse.panel import tokens as _t
-    _NEAR_BLACK = _t.NEAR_BLACK
-    _CARBON = _t.CARBON
-    _VOID = _t.VOID
-    _GRAPHITE = _t.GRAPHITE
-    _SIGNAL = _t.SIGNAL
-    _TEXT = _t.TEXT
-    _TEXT_DIM = _t.TEXT_DIM
-    _ERROR = _t.ERROR
-    _WARNING = _t.WARN
-    _SUCCESS = _t.GROW
-    _FONT_MONO = _t.FONT_MONO
-    _FONT_SANS = _t.FONT_SANS
-    _BODY_PX = _t.SIZE_BODY
-    _SMALL_PX = _t.SIZE_SMALL
-    _LABEL_PX = _t.SIZE_LABEL
-    _BUBBLE_PAD = _t.CHAT_BUBBLE_PADDING
-    _BUBBLE_RAD = _t.CHAT_BUBBLE_RADIUS
-    _BUBBLE_MARGIN_Y = _t.CHAT_BUBBLE_MARGIN_Y
-    _GROUP_MARGIN_Y = _t.CHAT_GROUP_MARGIN_Y
-    _TIMESTAMP_SZ = _t.CHAT_TIMESTAMP_SIZE
-except ImportError:
-    _NEAR_BLACK = "#3C3C3C"
-    _CARBON = "#333333"
-    _VOID = "#252525"
-    _GRAPHITE = "#222222"
-    _SIGNAL = "#00D4FF"
-    _TEXT = "#E0E0E0"
-    _TEXT_DIM = "#999999"
+    from synapse.panel.designsystem import tokens as _t
+    _SIGNAL      = _t.SIGNAL          # the one chromatic event
+    _TEXT        = _t.TEXT_PRIMARY    # agent voice / body
+    _TEXT_BRIGHT = _t.TEXT_BRIGHT     # human voice (emphasis)
+    _TEXT_DIM    = _t.TEXT_TERTIARY   # system lines / captions
+    _GROUND      = _t.GROUND          # chip + code-block inset
+    _LINE        = _t.GRAPHITE        # hairline borders
+    _ERROR       = _t.ERROR
+    _WARNING     = _t.WARN
+    _SUCCESS     = _t.GROW
+    _FONT_MONO   = _t.FONT_MONO
+    _BODY_PX     = _t.SIZE_BODY
+    _SMALL_PX    = _t.SIZE_SMALL
+    _LABEL_PX    = _t.SIZE_LABEL
+    _GROUP_MARGIN_Y = _t.SPACE_MD
+    _MSG_MARGIN_Y   = _t.SPACE_XS
+    _TIMESTAMP_SZ   = _t.SIZE_LABEL
+except Exception:  # pragma: no cover - exercised only without the package path
+    _SIGNAL = "#8FB3D9"
+    _TEXT = "#ADADAD"
+    _TEXT_BRIGHT = "#C4C4C4"
+    _TEXT_DIM = "#5E5E5E"
+    _GROUND = "#262626"
+    _LINE = "#2A2A2A"
     _ERROR = "#FF3D71"
     _WARNING = "#FFAB00"
     _SUCCESS = "#00E676"
     _FONT_MONO = "JetBrains Mono"
-    _FONT_SANS = "DM Sans"
-    _BODY_PX = 26
-    _SMALL_PX = 22
-    _LABEL_PX = 22
-    _BUBBLE_PAD = 14
-    _BUBBLE_RAD = 12
-    _BUBBLE_MARGIN_Y = 2
+    _BODY_PX = 12
+    _SMALL_PX = 14
+    _LABEL_PX = 13
     _GROUP_MARGIN_Y = 16
-    _TIMESTAMP_SZ = 18
+    _MSG_MARGIN_Y = 4
+    _TIMESTAMP_SZ = 13
 
 # Monospace font stack
 _MONO = "'{mono}', 'Consolas', 'Courier New', monospace".format(mono=_FONT_MONO)
 
 # Regex patterns
-_CODE_BLOCK_RE = re.compile(
-    r"```(\w*)\n(.*?)```", re.DOTALL
-)
+_CODE_BLOCK_RE = re.compile(r"```(\w*)\n(.*?)```", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`([^`]+)`")
-_NODE_PATH_RE = re.compile(r"(/(?:obj|out|stage|shop|mat|ch|tasks|vex)/[\w/]+)")
+# Houdini node-network roots + the USD prim roots the comp surfaces as artifacts
+# (/materials/AMD/Dark_Glass, /Render/Products/...). Curated, not a catch-all,
+# so prose slashes don't accidentally become chips.
+_NODE_PATH_RE = re.compile(
+    r"(/(?:obj|out|stage|shop|mat|ch|tasks|vex|"
+    r"materials|Render|World|cameras|lights|geo)/[\w/]+)"
+)
 _LIST_ITEM_RE = re.compile(r"^[\-\*]\s+(.+)$", re.MULTILINE)
 
 
@@ -72,7 +76,8 @@ def _scale(px, font_scale=1.0):
 
 
 def _status_prefix(status):
-    """Return a colored Unicode prefix for status strings."""
+    """Return a colored Unicode dot for status strings (the only place status
+    hues appear — body copy stays neutral)."""
     if status in ("ok", "success"):
         return '<span style="color:{c}">&#9679;</span> '.format(c=_SUCCESS)
     if status in ("warning", "warn"):
@@ -83,54 +88,55 @@ def _status_prefix(status):
 
 
 def _format_code_block(match, font_scale=1.0):
-    """Render a fenced code block as a styled <pre>."""
+    """Render a fenced code block as a quiet inset (no heavy chrome)."""
     lang = match.group(1) or ""
     code = html.escape(match.group(2).rstrip())
     lang_label = ""
     if lang:
         lang_label = (
             '<div style="color:{dim}; font-size:{sz}px; '
-            'margin-bottom:4px;">{lang}</div>'
-        ).format(dim=_TEXT_DIM, sz=_scale(_SMALL_PX, font_scale), lang=lang)
+            'margin-bottom:4px; font-family:{mono};">{lang}</div>'
+        ).format(dim=_TEXT_DIM, sz=_scale(_SMALL_PX, font_scale),
+                 mono=_MONO, lang=lang)
     return (
-        '<div style="background:{bg}; border-radius:6px; padding:10px; '
-        'margin:6px 0;">'
+        '<div style="background:{bg}; padding:10px; margin:6px 0;">'
         "{label}"
         '<pre style="margin:0; color:{fg}; font-family:{mono}; '
         'font-size:{sz}px; white-space:pre-wrap;">{code}</pre>'
         "</div>"
     ).format(
-        bg=_NEAR_BLACK,
-        fg=_TEXT,
-        mono=_MONO,
-        sz=_scale(_SMALL_PX, font_scale),
-        label=lang_label,
-        code=code,
+        bg=_GROUND, fg=_TEXT, mono=_MONO,
+        sz=_scale(_SMALL_PX, font_scale), label=lang_label, code=code,
     )
 
 
 def _format_inline_code(match, font_scale=1.0):
-    """Render `inline code` with styled background."""
+    """Render `inline code` as mono signal text — a thing named in the line,
+    no bubble (matches the comp's `.code`)."""
     code = html.escape(match.group(1))
     return (
-        '<code style="background:{bg}; color:{fg}; font-family:{mono}; '
-        'padding:2px 5px; border-radius:3px; font-size:{sz}px;">'
+        '<code style="color:{fg}; font-family:{mono}; font-size:{sz}px;">'
         "{code}</code>"
     ).format(
-        bg=_NEAR_BLACK, fg=_SIGNAL, mono=_MONO,
-        sz=_scale(_SMALL_PX, font_scale), code=code,
+        fg=_SIGNAL, mono=_MONO, sz=_scale(_SMALL_PX, font_scale), code=code,
     )
 
 
 def _format_node_path(match, font_scale=1.0):
-    """Render a Houdini node path as a clickable link."""
+    """Render a Houdini node path as a clickable **artifact chip** — a node
+    mark + the mono path, a thing rather than a sentence fragment. The
+    ``node:`` href keeps click-to-locate (ChatDisplay.node_clicked) intact."""
     path = match.group(1)
+    sz = _scale(_SMALL_PX, font_scale)
     return (
-        '<a href="node:{path}" style="color:{c}; text-decoration:none; '
-        'font-family:{mono}; font-size:{sz}px;">{path}</a>'
+        '<a href="node:{path}" style="text-decoration:none;">'
+        '<span style="background:{bg}; font-family:{mono}; font-size:{sz}px;">'
+        '<span style="color:{mark};">&#9642;</span> '
+        '<span style="color:{fg};">{path}</span>'
+        "&#160;</span></a>"
     ).format(
-        path=path, c=_SIGNAL, mono=_MONO,
-        sz=_scale(_SMALL_PX, font_scale),
+        path=path, bg=_GROUND, mark=_SIGNAL, fg=_TEXT_BRIGHT,
+        mono=_MONO, sz=sz,
     )
 
 
@@ -147,16 +153,10 @@ def _format_list_items(text):
 
 
 def _process_rich_text(raw, font_scale=1.0):
-    """Apply code block, inline code, node path, and list formatting."""
-    raw = _CODE_BLOCK_RE.sub(
-        lambda m: _format_code_block(m, font_scale), raw
-    )
-    raw = _INLINE_CODE_RE.sub(
-        lambda m: _format_inline_code(m, font_scale), raw
-    )
-    raw = _NODE_PATH_RE.sub(
-        lambda m: _format_node_path(m, font_scale), raw
-    )
+    """Apply code block, inline code, node-chip, and list formatting."""
+    raw = _CODE_BLOCK_RE.sub(lambda m: _format_code_block(m, font_scale), raw)
+    raw = _INLINE_CODE_RE.sub(lambda m: _format_inline_code(m, font_scale), raw)
+    raw = _NODE_PATH_RE.sub(lambda m: _format_node_path(m, font_scale), raw)
     raw = _format_list_items(raw)
 
     # Newlines to <br> (but not inside <pre> blocks)
@@ -167,34 +167,11 @@ def _process_rich_text(raw, font_scale=1.0):
     return "".join(parts)
 
 
-def _timestamp_html(timestamp, font_scale=1.0):
-    """Render a right-aligned dimmed timestamp below the message body."""
-    if not timestamp:
-        return ""
-    return (
-        '<div style="text-align:right; color:{dim}; font-size:{sz}px; '
-        'margin-top:4px; font-family:{mono};">{ts}</div>'
-    ).format(
-        dim=_TEXT_DIM, sz=_scale(_TIMESTAMP_SZ, font_scale),
-        mono=_MONO, ts=html.escape(str(timestamp)),
-    )
-
-
 def format_response(response, font_scale=1.0):
-    """Convert a SYNAPSE response dict to styled HTML for QTextEdit.
+    """Convert a SYNAPSE response (dict or str) to styled HTML.
 
-    Parameters
-    ----------
-    response : dict or str
-        If dict, expects optional keys: ``status``, ``message``, ``result``,
-        ``content``, ``text``.  If str, treated as plain text.
-    font_scale : float
-        Multiplier for all font sizes (default 1.0).
-
-    Returns
-    -------
-    str
-        HTML fragment suitable for QTextEdit.insertHtml().
+    The agent voice: neutral body copy, no chrome. Node refs become artifact
+    chips; a status, if present, leads with a single colored dot.
     """
     if isinstance(response, str):
         raw = response
@@ -213,165 +190,51 @@ def format_response(response, font_scale=1.0):
     prefix = _status_prefix(status) if status else ""
 
     return (
-        '<div style="color:{fg}; font-size:{sz}px;">'
-        "{prefix}{body}</div>"
+        '<div style="color:{fg}; font-size:{sz}px;">{prefix}{body}</div>'
     ).format(
-        fg=_TEXT, sz=_scale(_BODY_PX, font_scale),
-        prefix=prefix, body=raw,
+        fg=_TEXT, sz=_scale(_BODY_PX, font_scale), prefix=prefix, body=raw,
     )
 
 
 def format_user_message(text, grouped=False, timestamp=None, font_scale=1.0):
-    """Format a user message bubble with WhatsApp-style spacing.
+    """The human voice: a single signal-blue hairline rule + brighter text.
+    No bubble, no label — type and the rule tell the speaker apart.
 
-    Parameters
-    ----------
-    text : str
-        The user's message text.
-    grouped : bool
-        If True, suppress sender label and use tight margin (same-sender continuation).
-    timestamp : str or None
-        Timestamp string to display below the message.
-    font_scale : float
-        Multiplier for all font sizes.
-
-    Returns
-    -------
-    str
-        HTML fragment for the user message bubble.
+    A two-cell table carries the rule: QTextDocument paints table-cell
+    backgrounds reliably where it ignores block ``border-left``. ``timestamp``
+    is accepted for signature compatibility but no longer rendered (taut).
     """
-    escaped = html.escape(text)
-    escaped = escaped.replace("\n", "<br>")
-
-    pad = _scale(_BUBBLE_PAD, font_scale)
-    pad_h = _scale(_BUBBLE_PAD + 4, font_scale)  # Horizontal gets a bit more
-    margin_y = _BUBBLE_MARGIN_Y if grouped else _GROUP_MARGIN_Y
+    escaped = html.escape(text).replace("\n", "<br>")
     body_sz = _scale(_BODY_PX, font_scale)
-    label_sz = _scale(_SMALL_PX, font_scale)
-
-    # WhatsApp-style directional radius: user bubbles rounded on left, flat top-right when grouped
-    if grouped:
-        radius = "{r}px {flat}px {r}px {r}px".format(
-            r=_BUBBLE_RAD, flat=4
-        )
-    else:
-        radius = "{r}px {r}px {r}px {r}px".format(r=_BUBBLE_RAD)
-
-    sender_label = ""
-    if not grouped:
-        sender_label = (
-            '<span style="color:{dim}; font-size:{sz}px; '
-            'font-family:{mono}; letter-spacing:1px;">You</span><br>'
-        ).format(dim=_TEXT_DIM, sz=label_sz, mono=_MONO)
-
-    ts_html = _timestamp_html(timestamp, font_scale)
-
+    my = _MSG_MARGIN_Y if grouped else _GROUP_MARGIN_Y
     return (
-        '<div style="background:{bg}; border: 1px solid {border}; '
-        'border-radius:{radius}; padding:{pad}px {padh}px; '
-        'margin:{my}px 0 {my}px 40px; color:{fg}; font-size:{sz}px;">'
-        '{label}{body}{ts}</div>'
-    ).format(
-        bg=_CARBON, border=_GRAPHITE, radius=radius,
-        pad=pad, padh=pad_h, my=margin_y,
-        fg=_TEXT, sz=body_sz, label=sender_label,
-        body=escaped, ts=ts_html,
-    )
+        '<table border="0" cellspacing="0" cellpadding="0" width="100%" '
+        'style="margin:{my}px 0;"><tr>'
+        '<td width="2" style="background:{sig};"></td>'
+        '<td width="10"></td>'
+        '<td style="color:{fg}; font-size:{sz}px;">{body}</td>'
+        "</tr></table>"
+    ).format(my=my, sig=_SIGNAL, fg=_TEXT_BRIGHT, sz=body_sz, body=escaped)
 
 
 def format_synapse_message(content, grouped=False, timestamp=None, font_scale=1.0):
-    """Format a SYNAPSE response bubble with WhatsApp-style spacing.
-
-    Parameters
-    ----------
-    content : dict or str
-        Response payload from the server.
-    grouped : bool
-        If True, suppress sender label and use tight margin.
-    timestamp : str or None
-        Timestamp string to display below the message.
-    font_scale : float
-        Multiplier for all font sizes.
-
-    Returns
-    -------
-    str
-        HTML fragment for the synapse message bubble.
-    """
+    """The agent voice: plain, dimmer body copy — no rule, no bubble, no label.
+    Results inside it surface as artifact chips via the rich-text pipeline."""
     body = format_response(content, font_scale)
-
-    pad = _scale(_BUBBLE_PAD, font_scale)
-    pad_h = _scale(_BUBBLE_PAD + 4, font_scale)
-    margin_y = _BUBBLE_MARGIN_Y if grouped else _GROUP_MARGIN_Y
-    label_sz = _scale(_SMALL_PX, font_scale)
-
-    # WhatsApp-style: synapse bubbles rounded on right, flat top-left when grouped
-    if grouped:
-        radius = "{flat}px {r}px {r}px {r}px".format(
-            r=_BUBBLE_RAD, flat=4
-        )
-    else:
-        radius = "{r}px {r}px {r}px {r}px".format(r=_BUBBLE_RAD)
-
-    sender_label = ""
-    if not grouped:
-        sender_label = (
-            '<span style="color:{accent}; font-size:{sz}px; '
-            'font-weight:bold; font-family:{mono}; '
-            'letter-spacing:2px;">SYNAPSE</span><br>'
-        ).format(accent=_SIGNAL, sz=label_sz, mono=_MONO)
-
-    ts_html = _timestamp_html(timestamp, font_scale)
-
-    return (
-        '<div style="background:{bg}; border: 1px solid {border}; '
-        'border-radius:{radius}; padding:{pad}px {padh}px; '
-        'margin:{my}px 40px {my}px 0;">'
-        '{label}{body}{ts}</div>'
-    ).format(
-        bg=_VOID, border=_GRAPHITE, radius=radius,
-        pad=pad, padh=pad_h, my=margin_y,
-        label=sender_label, body=body, ts=ts_html,
-        mono=_MONO,
-    )
+    my = _MSG_MARGIN_Y if grouped else _GROUP_MARGIN_Y
+    return '<div style="margin:{my}px 0;">{body}</div>'.format(my=my, body=body)
 
 
 def format_system_message(text, font_scale=1.0):
-    """Format a system/status message (centered, dimmed).
-
-    Returns
-    -------
-    str
-        HTML fragment for the system message.
-    """
+    """A quiet, centered status interjection (not a speaker)."""
     escaped = html.escape(text)
     return (
         '<div style="text-align:center; color:{dim}; font-size:{sz}px; '
         'margin:6px 0; font-style:italic;">{text}</div>'
-    ).format(
-        dim=_TEXT_DIM, sz=_scale(_SMALL_PX, font_scale), text=escaped,
-    )
+    ).format(dim=_TEXT_DIM, sz=_scale(_SMALL_PX, font_scale), text=escaped)
 
 
 def format_timestamp_divider(timestamp_text, font_scale=1.0):
-    """Format a centered timestamp divider between message groups.
-
-    Parameters
-    ----------
-    timestamp_text : str
-        e.g. "2:34 PM" or "Today 2:34 PM"
-
-    Returns
-    -------
-    str
-        HTML fragment for the timestamp divider.
-    """
-    return (
-        '<div style="text-align:center; color:{dim}; font-size:{sz}px; '
-        'margin:{my}px 0; font-family:{mono}; letter-spacing:0.5px;">'
-        '{text}</div>'
-    ).format(
-        dim=_TEXT_DIM, sz=_scale(_TIMESTAMP_SZ, font_scale),
-        my=_GROUP_MARGIN_Y // 2, mono=_MONO,
-        text=html.escape(str(timestamp_text)),
-    )
+    """Group breaks are carried by negative space now, not timestamp chrome.
+    Returns empty — kept so ChatDisplay's grouping call site is unchanged."""
+    return ""

--- a/python/synapse/panel/styles.py
+++ b/python/synapse/panel/styles.py
@@ -5,6 +5,10 @@ for HDA mode views, ``animate_stack_transition()`` for smooth page switches.
 """
 
 from . import tokens as t
+# Mile 7 de-cyan: pull the brand SIGNAL family from the vendored design system
+# (#8FB3D9) so the gate + chat surfaces render the signature blue, not the
+# legacy panel.tokens cyan. Token sources stay untouched (local fix).
+from .designsystem import tokens as _ds
 
 
 def get_hda_stylesheet():
@@ -27,11 +31,11 @@ def get_hda_stylesheet():
         "  selection-background-color: {sel};"
         "}}".format(
             bg=t.HDA_INPUT_BG, fg=t.BONE, border=t.HDA_INPUT_BORDER,
-            font=t.FONT_SANS, sz=t.SIZE_BODY, sel=t.HDA_INPUT_FOCUS,
+            font=t.FONT_SANS, sz=t.SIZE_BODY, sel=(_ds.SIGNAL + "40"),
         )
         + " QTextEdit#HdaPromptInput:focus {{"
         "  border-color: {sig};"
-        "}}".format(sig=t.SIGNAL)
+        "}}".format(sig=_ds.SIGNAL)
 
         + " QComboBox#HdaContextSelector {{"
         "  background: {bg};"
@@ -57,15 +61,15 @@ def get_hda_stylesheet():
         "  font-weight: 700;"
         "  letter-spacing: 1px;"
         "}}".format(
-            bg=t.STATE_DESCRIBE, fg=t.VOID,
+            bg=_ds.SIGNAL, fg=t.VOID,
             font=t.FONT_MONO, sz=t.SIZE_LABEL,
         )
         + " QPushButton#HdaGenerateBtn:hover {{"
         "  background: {bg}CC;"
-        "}}".format(bg=t.STATE_DESCRIBE)
+        "}}".format(bg=_ds.SIGNAL)
         + " QPushButton#HdaGenerateBtn:pressed {{"
         "  background: {bg}99;"
-        "}}".format(bg=t.STATE_DESCRIBE)
+        "}}".format(bg=_ds.SIGNAL)
 
         # === Building View ===
         + " QWidget#BuildingView {{"
@@ -136,8 +140,8 @@ def get_hda_stylesheet():
         "  font-size: {sz}px;"
         "  font-weight: 700;"
         "}}".format(
-            bg=t.MODE_ACTIVE_BG, border=t.MODE_ACTIVE_BORDER,
-            fg=t.SIGNAL, font=t.FONT_MONO, sz=t.SIZE_LABEL,
+            bg=(_ds.SIGNAL + "26"), border=(_ds.SIGNAL + "66"),
+            fg=_ds.SIGNAL, font=t.FONT_MONO, sz=t.SIZE_LABEL,
         )
 
         + " QPushButton#ModeToggleInactive {{"
@@ -173,7 +177,7 @@ def get_hda_stylesheet():
         + " QPushButton#HdaActionBtn:hover {{"
         "  border-color: {border};"
         "  color: {fg};"
-        "}}".format(border=t.SIGNAL + "66", fg=t.BONE)
+        "}}".format(border=_ds.SIGNAL + "66", fg=t.BONE)
 
         + " QPushButton#CancelBtn {{"
         "  background: transparent;"
@@ -216,13 +220,13 @@ def get_quick_action_button_stylesheet():
         "  color: {white};"
         "}}"
         "QPushButton:pressed {{"
-        "  background: rgba(0, 212, 255, 0.15);"
+        "  background: rgba(143, 179, 217, 0.15);"
         "  border-color: {accent};"
         "  color: {accent};"
         "}}".format(
             bg=t.CARBON, fg=t.BONE, border=t.GRAPHITE,
             sz=t.SIZE_SMALL, pad=t.SPACE_SM, hover=t.HOVER,
-            accent=t.SIGNAL, white=t.WHITE, mono=t.FONT_MONO,
+            accent=_ds.SIGNAL, white=t.WHITE, mono=t.FONT_MONO,
         )
     )
 
@@ -243,7 +247,7 @@ def get_input_stylesheet():
         "  border: 1px solid {accent};"
         "}}".format(
             bg=t.VOID, fg=t.BONE, border=t.GRAPHITE,
-            sz=t.SIZE_UI, accent=t.SIGNAL, sans=t.FONT_SANS,
+            sz=t.SIZE_UI, accent=_ds.SIGNAL, sans=t.FONT_SANS,
         )
     )
 
@@ -268,8 +272,8 @@ def get_send_button_stylesheet():
         "QPushButton:pressed {{"
         "  background: {pressed};"
         "}}".format(
-            accent=t.SIGNAL, bg=t.VOID, sz=t.SIZE_UI,
-            hover=t.SIGNAL_HOVER, pressed=t.SIGNAL_PRESS,
+            accent=_ds.SIGNAL, bg=t.VOID, sz=t.SIZE_UI,
+            hover=_ds.SIGNAL_HOVER, pressed=_ds.SIGNAL_PRESS,
             mono=t.FONT_MONO,
         )
     )
@@ -289,12 +293,12 @@ def get_connect_button_stylesheet():
         "  min-width: 100px;"
         "}}"
         "QPushButton#connect_button:hover {{"
-        "  background: rgba(0, 212, 255, 0.1);"
+        "  background: rgba(143, 179, 217, 0.1);"
         "}}"
         "QPushButton#connect_button:pressed {{"
-        "  background: rgba(0, 212, 255, 0.2);"
+        "  background: rgba(143, 179, 217, 0.2);"
         "}}".format(
-            accent=t.SIGNAL, mono=t.FONT_MONO, sz=t.SIZE_SMALL,
+            accent=_ds.SIGNAL, mono=t.FONT_MONO, sz=t.SIZE_SMALL,
         )
     )
 
@@ -314,13 +318,13 @@ def get_ws_url_button_stylesheet():
         "QPushButton#ws_path_button:hover {{"
         "  color: {accent};"
         "  border-color: {accent};"
-        "  background: rgba(0, 212, 255, 0.1);"
+        "  background: rgba(143, 179, 217, 0.1);"
         "}}"
         "QPushButton#ws_path_button:pressed {{"
-        "  background: rgba(0, 212, 255, 0.2);"
+        "  background: rgba(143, 179, 217, 0.2);"
         "}}".format(
             slate=t.SLATE, border=t.GRAPHITE, mono=t.FONT_MONO,
-            sz=t.SIZE_LABEL, accent=t.SIGNAL,
+            sz=t.SIZE_LABEL, accent=_ds.SIGNAL,
         )
     )
 
@@ -359,7 +363,7 @@ def get_context_bar_path_stylesheet():
         "color: {c}; font-size: {s}px; font-family: '{mono}', "
         "'Consolas', monospace; letter-spacing: 0.5px;"
         " border: none;".format(
-            c=t.SIGNAL, s=t.SIZE_SMALL, mono=t.FONT_MONO
+            c=_ds.SIGNAL, s=t.SIZE_SMALL, mono=t.FONT_MONO
         )
     )
 
@@ -416,7 +420,7 @@ def get_section_label_stylesheet():
     """HDA Describe view section label: mono, SIGNAL cyan, letter-spaced."""
     return (
         "color: {sig}; font-size: 10px; "
-        "font-family: monospace; letter-spacing: 2px;".format(sig=t.SIGNAL)
+        "font-family: monospace; letter-spacing: 2px;".format(sig=_ds.SIGNAL)
     )
 
 
@@ -526,7 +530,7 @@ def get_chat_display_stylesheet():
         "  border: 1px solid {border};"
         "  border-radius: 4px;"
         "  padding: {pad}px;"
-        "  selection-background-color: rgba(0, 212, 255, 0.3);"
+        "  selection-background-color: rgba(143, 179, 217, 0.3);"
         "  selection-color: {white};"
         "}}"
         "QScrollBar:vertical {{"
@@ -573,14 +577,14 @@ def get_growing_input_stylesheet():
         "  border: 1px solid {accent};"
         "}}".format(
             bg=t.VOID, fg=t.BONE, border=t.GRAPHITE,
-            sz=t.SIZE_UI, accent=t.SIGNAL, sans=t.FONT_SANS,
+            sz=t.SIZE_UI, accent=_ds.SIGNAL, sans=t.FONT_SANS,
         )
     )
 
 
 def get_context_chip_stylesheet(accent=False):
     """Pill chip for context info above input."""
-    fg = t.SIGNAL if accent else t.TEXT_DIM
+    fg = _ds.SIGNAL if accent else t.TEXT_DIM
     return (
         "background: {bg}; border: 1px solid {border}; "
         "border-radius: 10px; padding: 2px 8px; "
@@ -610,13 +614,13 @@ def get_quick_action_pill_stylesheet():
         "  color: {white};"
         "}}"
         "QPushButton:pressed {{"
-        "  background: rgba(0, 212, 255, 0.15);"
+        "  background: rgba(143, 179, 217, 0.15);"
         "  border-color: {accent};"
         "  color: {accent};"
         "}}".format(
             bg=t.CARBON, fg=t.BONE, border=t.GRAPHITE,
             sz=t.SIZE_LABEL, hover=t.HOVER,
-            accent=t.SIGNAL, white=t.WHITE, mono=t.FONT_MONO,
+            accent=_ds.SIGNAL, white=t.WHITE, mono=t.FONT_MONO,
         )
     )
 
@@ -638,7 +642,7 @@ def get_font_size_button_stylesheet():
         "  color: {accent};"
         "  border-color: {accent};"
         "}}".format(
-            fg=t.TEXT_DIM, border=t.GRAPHITE, accent=t.SIGNAL,
+            fg=t.TEXT_DIM, border=t.GRAPHITE, accent=_ds.SIGNAL,
             sans=t.FONT_SANS, sz=t.SIZE_LABEL,
         )
     )
@@ -647,7 +651,7 @@ def get_font_size_button_stylesheet():
 def get_typing_indicator_stylesheet():
     """Styling for the animated typing dots area."""
     return (
-        "color: {sig}; font-style: italic;".format(sig=t.SIGNAL)
+        "color: {sig}; font-style: italic;".format(sig=_ds.SIGNAL)
     )
 
 

--- a/python/synapse/panel/synapse_panel.py
+++ b/python/synapse/panel/synapse_panel.py
@@ -543,22 +543,16 @@ class SynapsePanel(QtWidgets.QWidget):
             data = None
         wf.set_health(data)
 
-    def _verb(self, text, on_click, accent=False):
-        """A type-set action — mono, letter-spaced, no pill chrome (Mile 3).
-        Verbs read as type, not buttons; the work is the hero, not the controls.
-        Inline-styled so it overrides the DsPill look without touching qss.py
-        (the QSS design pass is Mile 7)."""
+    def _verb(self, text, on_click, tone=None):
+        """A type-set action — mono, no pill chrome (Mile 3). Styled by the
+        canonical QPushButton#DsVerb QSS rule (Mile 7 finalized it); ``tone`` ∈
+        {None, 'ok', 'hot', 'accent'} selects the semantic color via property."""
         btn = QtWidgets.QPushButton(text)
         btn.setObjectName("DsVerb")
         btn.setCursor(Qt.PointingHandCursor)
         btn.setFlat(True)
-        rest = t.TEXT_ACCENT if accent else t.TEXT_SECONDARY
-        btn.setStyleSheet(
-            "QPushButton#DsVerb{background:transparent; border:none; padding:2px 0;"
-            " color:%s; font-family:%s; font-size:11px; letter-spacing:1.4px;}"
-            "QPushButton#DsVerb:hover{color:%s;}"
-            % (rest, t.FONT_MONO, t.TEXT_ACCENT)
-        )
+        if tone:
+            btn.setProperty("tone", tone)
         btn.clicked.connect(on_click)
         return btn
 
@@ -579,7 +573,7 @@ class SynapsePanel(QtWidgets.QWidget):
         self._font_btn.setToolTip("Font size — click to cycle")
         lay.addWidget(self._font_btn)
         self._more_btn = self._verb(
-            "⌘K", lambda _=False: self._open_palette(), accent=True)
+            "⌘K", lambda _=False: self._open_palette(), tone="accent")
         self._more_btn.setToolTip("Command palette — every tool, two axes")
         lay.addWidget(self._more_btn)
         return w

--- a/python/synapse/panel/synapse_panel.py
+++ b/python/synapse/panel/synapse_panel.py
@@ -57,6 +57,11 @@ try:
     from synapse.panel.face_work import FaceWork
 except Exception:  # pragma: no cover
     FaceWork = None
+try:
+    from synapse.panel.face_review import FaceReview, detect_render_flags
+except Exception:  # pragma: no cover
+    FaceReview = None
+    detect_render_flags = None
 
 _VERSION = "7.0.0"
 
@@ -364,22 +369,68 @@ class SynapsePanel(QtWidgets.QWidget):
         return page
 
     def _build_review_face(self):
-        """Review — the payoff. The render becomes the hero in Mile 5; for now
-        this surface carries the consent gate (reversibility / provenance)."""
+        """Review — the payoff (Mile 5). FaceReview owns the render-hero, verdict,
+        credit/provenance, quality flags (incl. BL-007/008), the graduated gate,
+        and accept/revert/commit. ``self._gate`` aliases the embedded gate so the
+        consent wiring (_wire_gate / _on_gate_raised) is unchanged."""
+        if FaceReview is not None:
+            self._review_face = FaceReview()
+            self._gate = self._review_face.gate
+            self._review_face.accepted.connect(self._on_accept)
+            self._review_face.reverted.connect(self._on_revert)
+            self._review_face.committed.connect(self._on_commit)
+            return self._review_face
+        # graceful fallback — keep the consent gate present without FaceReview
+        self._review_face = None
         page = self._section()
         col = QtWidgets.QVBoxLayout(page)
         col.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_SM)
-        col.setSpacing(t.SPACE_SM)
         if GateWidget is not None:
             self._gate = GateWidget(parent=page)
             col.addWidget(self._gate)
         else:
             self._gate = None
-        hint = c.label("render · verdict · credit land here — mile 5", role="caption")
-        hint.setStyleSheet("color:%s;" % t.TEXT_TERTIARY)
-        col.addWidget(hint)
         col.addStretch(1)
         return page
+
+    def _populate_review(self):
+        """On 'done', fill the Review face with what we can: a taut verdict from
+        the last reply + provenance from the routing_log (best-effort)."""
+        rf = getattr(self, "_review_face", None)
+        if rf is None:
+            return
+        text = "".join(getattr(self, "_stream_buf", []) or []).strip()
+        if text:
+            verdict = text.split("\n", 1)[0].strip()
+            if len(verdict) > 140:
+                verdict = verdict[:137] + "…"
+            rf.set_verdict(verdict)
+        rf.refresh_provenance()
+
+    def _on_accept(self):
+        try:
+            self._chat.append_system_message("Accepted — keeping the result.")
+        except Exception:
+            pass
+
+    def _on_revert(self):
+        # Reversibility: route an undo through the proven agent/bridge path
+        # rather than touching the substrate from the panel.
+        try:
+            self._chat.append_system_message("Reverting the last change…")
+        except Exception:
+            pass
+        self._send("Undo the last change using houdini_undo, then confirm what was reverted.")
+
+    def _on_commit(self):
+        # Commit is a consent moment — it routes through the gate; the panel
+        # never writes /stage itself (the substrate stays Gold's zone).
+        try:
+            self._chat.append_system_message(
+                "Commit to /stage requested — routing through the consent gate.")
+        except Exception:
+            pass
+        self._set_face("review")
 
     def _build_hda_form(self):
         """Native-designsystem describe→build flow (the build runs through the
@@ -818,6 +869,14 @@ class SynapsePanel(QtWidgets.QWidget):
         wf = getattr(self, "_work_face", None)
         if wf is not None:
             wf.set_tool_status(name, verb, _detail)   # feed the plan-with-progress
+        # a render finishing → refresh the Review face's quality flags (BL-007/008)
+        rf = getattr(self, "_review_face", None)
+        if (rf is not None and detect_render_flags is not None
+                and "render" in name.lower() and phase in ("done", "error")):
+            try:
+                rf.set_flags(detect_render_flags())
+            except Exception:
+                pass
         if phase == "running":
             self._request_face("work")   # a live tool → the walk-away glance
 
@@ -842,6 +901,7 @@ class SynapsePanel(QtWidgets.QWidget):
             self._manual_face = None
             self._request_face("work")
         elif not busy and self._was_busy:
+            self._populate_review()      # fill verdict + provenance for the payoff
             self._request_face("review")
         self._was_busy = busy
 

--- a/python/synapse/panel/synapse_panel.py
+++ b/python/synapse/panel/synapse_panel.py
@@ -73,6 +73,7 @@ class _GrowingInput(QtWidgets.QTextEdit):
     """Auto-growing chat input. Enter sends; Shift+Enter newlines."""
 
     submitted = Signal()
+    focus_lost = Signal()      # lets the face controller honor a deferred switch
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -98,6 +99,10 @@ class _GrowingInput(QtWidgets.QTextEdit):
             self.submitted.emit()
             return
         super().keyPressEvent(e)
+
+    def focusOutEvent(self, e):
+        super().focusOutEvent(e)
+        self.focus_lost.emit()
 
 
 class _InputResizeGrip(QtWidgets.QWidget):
@@ -159,6 +164,12 @@ class SynapsePanel(QtWidgets.QWidget):
         self._pending_context = []  # paths dropped in; prepended to the next send
         self._font_scale = t.FONT_SCALE_DEFAULT
 
+        # state→face controller (Pentagram pass, Mile 2)
+        self._current_face = "direct"
+        self._manual_face = None     # a pill pick; held until the next work edge
+        self._pending_face = None    # an auto switch deferred by the focus guard
+        self._was_busy = False
+
         self.setAcceptDrops(True)
         self._build_ui()
         self._wire_gate()
@@ -193,38 +204,70 @@ class SynapsePanel(QtWidgets.QWidget):
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(0)
 
-        root.addWidget(self._build_header())
+        # Persistent rail (Mile 1) → context ribbon → switcher → the three faces.
+        # Each face is a full content surface; the controller brings the right
+        # one forward as the agent's state changes. The work is the hero.
+        root.addWidget(self._build_rail())          # mark-as-status · state · Stop
         root.addWidget(c.divider())
         root.addWidget(self._build_context_ribbon())
-        root.addWidget(self._build_mode_bar())
-        root.addWidget(self._build_converse(), 1)   # dominant
-        root.addWidget(self._build_activity_row())
-        root.addWidget(self._build_trust())
-        root.addWidget(self._build_act())
-        root.addWidget(self._build_input())
-        root.addWidget(c.divider())
-        root.addWidget(self._build_footer())
+        root.addWidget(self._build_mode_bar())      # Direct · Work · Review pills
+        root.addWidget(self._build_faces(), 1)      # dominant — the stacked faces
+        self._set_face("direct")                    # idle resting face
 
-    def _build_header(self):
+    def _build_rail(self):
+        """The persistent rail (Pentagram pass, Mile 1).
+
+        One strip replacing the old header AND footer: the mark-as-status +
+        wordmark + state phrase on top; connection, an activity meter, and Stop
+        beneath. Termination and live state never scroll away.
+        """
         w = self._section()
-        w.setObjectName("DsHeader")          # subtle cool→warm gradient atmosphere
-        lay = QtWidgets.QHBoxLayout(w)
-        lay.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_SM)
-        lay.setSpacing(t.SPACE_SM)
-        glyph = c.label("◖", role="display")
-        glyph.setStyleSheet("color:%s;" % t.WARM)   # warm human accent (Cohere)
-        mark = c.label("SYNAPSE", role="display")
-        lay.addWidget(glyph)
-        self._header_dot = c.StatusDot("idle")
+        w.setObjectName("DsHeader")          # keep the subtle cool→warm gradient
+        col = QtWidgets.QVBoxLayout(w)
+        col.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_SM)
+        col.setSpacing(t.SPACE_XS)
+
+        # line 1 — identity + state. The mark fills with the agent's state.
+        top = QtWidgets.QHBoxLayout()
+        top.setSpacing(t.SPACE_SM)
+        self._mark = c.MarkDot("idle", diameter=16)
+        word = c.label("SYNAPSE", role="display")
+        word.setStyleSheet(
+            "color:%s; font-size:16px; letter-spacing:2px;" % t.TEXT_BRIGHT
+        )
         self._header_status = c.label("Standing by", role="caption")
+        self._header_status.setStyleSheet("color:%s;" % t.TEXT_SECONDARY)
         overflow = c.Button("⋯", variant="ghost")
         overflow.setFixedWidth(32)
         overflow.clicked.connect(self._show_overflow)
-        lay.addWidget(mark)
-        lay.addWidget(self._header_dot)
-        lay.addWidget(self._header_status)
-        lay.addStretch(1)
-        lay.addWidget(overflow)
+        top.addWidget(self._mark)
+        top.addWidget(word)
+        top.addStretch(1)
+        top.addWidget(self._header_status)
+        top.addWidget(overflow)
+        col.addLayout(top)
+
+        # line 2 — connection · activity meter · Stop. The meter lifts to WARM
+        # while the agent works, dim at rest (observability, always on).
+        bot = QtWidgets.QHBoxLayout()
+        bot.setSpacing(t.SPACE_SM)
+        self._foot_dot = c.StatusDot("disconnected")
+        self._foot_label = c.label("Not connected", role="caption")
+        self._foot_label.setStyleSheet("color:%s;" % t.TEXT_TERTIARY)
+        self._observe = QtWidgets.QWidget()
+        self._observe.setObjectName("DsRailMeter")
+        self._observe.setAttribute(Qt.WA_StyledBackground, True)
+        self._observe.setFixedHeight(3)
+        self._observe.setStyleSheet("background:%s; border-radius:2px;" % t.SIGNAL_TINT)
+        self._stop_btn = c.Button("Stop", variant="danger")
+        self._stop_btn.setMinimumWidth(64)
+        self._stop_btn.clicked.connect(self._on_stop)
+        self._stop_btn.setEnabled(False)
+        bot.addWidget(self._foot_dot)
+        bot.addWidget(self._foot_label)
+        bot.addWidget(self._observe, 1)
+        bot.addWidget(self._stop_btn)
+        col.addLayout(bot)
         return w
 
     def _build_context_ribbon(self):
@@ -259,20 +302,87 @@ class SynapsePanel(QtWidgets.QWidget):
         self._converse_stack.setMinimumHeight(380)
         return self._converse_stack
 
+    # the three faces, in switcher order
+    _FACE_INDEX = {"direct": 0, "work": 1, "review": 2}
+
     def _build_mode_bar(self):
+        """The switcher: Direct · Work · Review. Pills are a manual override of
+        the state→face controller; the controller drives them otherwise."""
         w = self._section()
         lay = QtWidgets.QHBoxLayout(w)
         lay.setContentsMargins(t.SPACE_MD, 0, t.SPACE_MD, 0)
         lay.setSpacing(t.SPACE_XS)
-        self._chat_pill = c.Pill("Chat")
-        self._hda_pill = c.Pill("Build HDA")
-        self._chat_pill.clicked.connect(lambda: self._set_mode("chat"))
-        self._hda_pill.clicked.connect(lambda: self._set_mode("hda"))
-        lay.addWidget(self._chat_pill)
-        lay.addWidget(self._hda_pill)
+        self._face_pills = {}
+        for face, text in (("direct", "Direct"), ("work", "Work"), ("review", "Review")):
+            pill = c.Pill(text)
+            pill.clicked.connect(lambda _=False, f=face: self._set_face(f, manual=True))
+            lay.addWidget(pill)
+            self._face_pills[face] = pill
         lay.addStretch(1)
-        self._set_mode("chat")
         return w
+
+    def _build_faces(self):
+        """The three faces in one stack. Each is a full content surface; the
+        controller decides which is forward. Interiors are recomposed in later
+        miles (Direct=3, Work=4, Review=5) — here they hold the proven widgets."""
+        self._faces = QtWidgets.QStackedWidget()
+        self._faces.addWidget(self._build_direct_face())   # 0 · idle / converse
+        self._faces.addWidget(self._build_work_face())     # 1 · working / glance
+        self._faces.addWidget(self._build_review_face())   # 2 · done / the payoff
+        self._faces.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
+        )
+        self._faces.setMinimumHeight(380)
+        return self._faces
+
+    def _build_direct_face(self):
+        """Direct — converse + quick actions + input. The artist's surface."""
+        page = self._section()
+        col = QtWidgets.QVBoxLayout(page)
+        col.setContentsMargins(0, 0, 0, 0)
+        col.setSpacing(0)
+        col.addWidget(self._build_converse(), 1)   # chat | Build-HDA inner stack
+        col.addWidget(self._build_act())
+        col.addWidget(self._build_input())
+        return page
+
+    def _build_work_face(self):
+        """Work — the walk-away glance. Activity + observability live here; the
+        cook preview + plan-with-progress land in Mile 4."""
+        page = self._section()
+        col = QtWidgets.QVBoxLayout(page)
+        col.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_SM)
+        col.setSpacing(t.SPACE_SM)
+        col.addWidget(self._build_activity_row())
+        # Observability infographic — the visible end of the RSI loop (Line O).
+        if HealthInfographic is not None:
+            self._health = HealthInfographic(parent=page)
+            col.addWidget(self._health)
+        else:
+            self._health = None
+        hint = c.label("the cook lands here — mile 4", role="caption")
+        hint.setStyleSheet("color:%s;" % t.TEXT_TERTIARY)
+        col.addWidget(hint)
+        col.addStretch(1)
+        return page
+
+    def _build_review_face(self):
+        """Review — the payoff. The render becomes the hero in Mile 5; for now
+        this surface carries the consent gate (reversibility / provenance)."""
+        page = self._section()
+        col = QtWidgets.QVBoxLayout(page)
+        col.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_SM)
+        col.setSpacing(t.SPACE_SM)
+        if GateWidget is not None:
+            self._gate = GateWidget(parent=page)
+            col.addWidget(self._gate)
+        else:
+            self._gate = None
+        hint = c.label("render · verdict · credit land here — mile 5", role="caption")
+        hint.setStyleSheet("color:%s;" % t.TEXT_TERTIARY)
+        col.addWidget(hint)
+        col.addStretch(1)
+        return page
 
     def _build_hda_form(self):
         """Native-designsystem describe→build flow (the build runs through the
@@ -308,12 +418,50 @@ class SynapsePanel(QtWidgets.QWidget):
         lay.addStretch(1)
         return page
 
-    def _set_mode(self, mode):
+    def _set_direct_view(self, view):
+        """Toggle Direct's inner surface: the chat (0) or the Build-HDA form (1).
+        Build HDA is no longer a top-level face — it lives inside Direct (⌘K too)."""
         if hasattr(self, "_converse_stack"):
-            self._converse_stack.setCurrentIndex(1 if mode == "hda" else 0)
-        for pill, m in ((self._chat_pill, "chat"), (self._hda_pill, "hda")):
-            pill.setProperty("active", mode == m)
+            self._converse_stack.setCurrentIndex(1 if view == "hda" else 0)
+        self._set_face("direct")   # the HDA form lives on the Direct surface
+
+    # ------------------------------------------------------- face controller
+    def _input_focused(self):
+        inp = getattr(self, "_input", None)
+        return inp is not None and inp.hasFocus()
+
+    def _set_face(self, face, manual=False):
+        """Bring a face forward. ``manual=True`` is a pill pick — it holds until
+        the next work cycle begins, so the controller won't fight the artist."""
+        if not hasattr(self, "_faces") or face not in self._FACE_INDEX:
+            return
+        if manual:
+            self._manual_face = face
+            self._pending_face = None
+        self._faces.setCurrentIndex(self._FACE_INDEX[face])
+        self._current_face = face
+        for f, pill in getattr(self, "_face_pills", {}).items():
+            pill.setProperty("active", f == face)
             c.repolish(pill)
+
+    def _request_face(self, face):
+        """The state controller wants ``face``. Honor two guards:
+        never yank away from Direct while the artist is typing, and don't
+        override a manual pill pick (a real gate clears the manual hold first)."""
+        if face != "direct" and self._input_focused():
+            self._pending_face = face     # defer; applied on input focus-out
+            return
+        if self._manual_face is not None and self._manual_face != face:
+            self._pending_face = face
+            return
+        self._set_face(face)
+
+    def _apply_pending_face(self):
+        """Input lost focus → honor any auto switch the focus guard deferred."""
+        if (self._pending_face and self._manual_face is None
+                and not self._input_focused()):
+            face, self._pending_face = self._pending_face, None
+            self._set_face(face)
 
     def _on_build_hda(self):
         prompt = self._hda_prompt.toPlainText().strip()
@@ -322,7 +470,7 @@ class SynapsePanel(QtWidgets.QWidget):
         ctx = self._hda_ctx.currentText()
         helptxt = " Include help text." if self._hda_help.isChecked() else ""
         self._hda_prompt.clear()
-        self._set_mode("chat")
+        self._set_direct_view("chat")
         self._send(
             "Build a %s HDA: %s. Use the houdini_hda_package tool, then show me "
             "the node path and the promoted parameters.%s" % (ctx, prompt, helptxt)
@@ -360,26 +508,6 @@ class SynapsePanel(QtWidgets.QWidget):
             data = None
         self._health.set_data(data)
 
-    def _build_trust(self):
-        self._trust = self._section()
-        lay = QtWidgets.QVBoxLayout(self._trust)
-        lay.setContentsMargins(t.SPACE_MD, 0, t.SPACE_MD, 0)
-        lay.setSpacing(t.SPACE_XS)
-        # Observability infographic (ambient, persistent) above the gate card
-        # (transient, action). The infographic is the visible end of the
-        # recursive-observability loop — RSI Line O.
-        if HealthInfographic is not None:
-            self._health = HealthInfographic(parent=self._trust)
-            lay.addWidget(self._health)
-        else:
-            self._health = None
-        if GateWidget is not None:
-            self._gate = GateWidget(parent=self._trust)
-            lay.addWidget(self._gate)
-        else:
-            self._gate = None
-        return self._trust
-
     def _build_act(self):
         w = self._section()
         lay = QtWidgets.QHBoxLayout(w)
@@ -389,6 +517,9 @@ class SynapsePanel(QtWidgets.QWidget):
             pill = c.Pill(label_text)
             pill.clicked.connect(lambda _=False, p=prompt: self._send(p))
             lay.addWidget(pill)
+        hda_pill = c.Pill("Build HDA")   # demoted from a top-level face into Direct
+        hda_pill.clicked.connect(lambda: self._set_direct_view("hda"))
+        lay.addWidget(hda_pill)
         self._font_btn = c.Pill("Aa")
         self._font_btn.setToolTip("Font size — click to cycle")
         self._font_btn.clicked.connect(self._cycle_font_scale)
@@ -406,6 +537,7 @@ class SynapsePanel(QtWidgets.QWidget):
         col.setSpacing(t.SPACE_XS)
         self._input = _GrowingInput()
         self._input.submitted.connect(self._on_submit)
+        self._input.focus_lost.connect(self._apply_pending_face)
         col.addWidget(_InputResizeGrip(self._input))   # drag handle at the top
         row = QtWidgets.QHBoxLayout()
         row.setSpacing(t.SPACE_SM)
@@ -414,7 +546,7 @@ class SynapsePanel(QtWidgets.QWidget):
         attach.setToolTip("Attach image / file as context")
         attach.clicked.connect(self._on_attach)
         self._send_btn = c.Button("Send", variant="primary")
-        self._send_btn.setFixedWidth(64)
+        self._send_btn.setMinimumWidth(72)
         self._send_btn.clicked.connect(self._on_submit)
         row.addWidget(self._input, 1)
         row.addWidget(attach)
@@ -444,30 +576,30 @@ class SynapsePanel(QtWidgets.QWidget):
                 pass
             self._input.setFocus()
 
-    def _build_footer(self):
-        w = self._section()
-        lay = QtWidgets.QHBoxLayout(w)
-        lay.setContentsMargins(t.SPACE_MD, t.SPACE_XS, t.SPACE_MD, t.SPACE_XS)
-        self._foot_dot = c.StatusDot("disconnected")
-        self._foot_label = c.label("Not connected", role="caption")
-        self._stop_btn = c.Button("Stop", variant="danger")
-        self._stop_btn.setFixedWidth(64)
-        self._stop_btn.clicked.connect(self._on_stop)
-        self._stop_btn.setEnabled(False)
-        lay.addWidget(self._foot_dot)
-        lay.addWidget(self._foot_label)
-        lay.addStretch(1)
-        lay.addWidget(self._stop_btn)
-        return w
-
     # ------------------------------------------------------------ behavior
     def _wire_gate(self):
-        """GateWidget self-registers HumanGate callbacks; nothing else needed.
-
-        Wiring it into the tree is what closes the consent gap — the legacy
-        shipped panel never instantiated it.
+        """GateWidget self-registers HumanGate callbacks; wiring it into the
+        tree is what closes the consent gap (the legacy shipped panel never
+        instantiated it). Mile 2 also taps its proposal relay so a raised gate
+        brings the Review face forward — reversibility surfaces when it matters.
         """
-        return
+        gate = getattr(self, "_gate", None)
+        if gate is not None:
+            try:
+                gate._proposal_received.connect(self._on_gate_raised)
+            except Exception:
+                pass
+
+    def _on_gate_raised(self, proposal):
+        """A gate proposal arrived → bring Review forward (skip noisy INFORM).
+        A real gate supersedes a manual park, but still respects the focus guard."""
+        if isinstance(proposal, dict):
+            level = proposal.get("level", "")
+        else:
+            level = getattr(proposal, "level", "")
+        if level and level != "inform":
+            self._manual_face = None
+            self._request_face("review")
 
     def _show_overflow(self):
         menu = QtWidgets.QMenu(self)
@@ -553,6 +685,10 @@ class SynapsePanel(QtWidgets.QWidget):
             self._send(text)
 
     def _send(self, text):
+        # Submitting is the artist handing off — drop input focus so the
+        # controller's working→Work switch isn't held back by the focus guard.
+        if getattr(self, "_input", None) is not None:
+            self._input.clearFocus()
         display = text
         if self._pending_context:
             text = "[Context: %s]\n%s" % (", ".join(self._pending_context), text)
@@ -676,6 +812,8 @@ class SynapsePanel(QtWidgets.QWidget):
     def _on_tool_status(self, name, phase, _detail):
         verb = {"running": "running", "done": "ok", "error": "failed"}.get(phase, phase)
         self._set_header("working", "%s %s" % (name, verb))
+        if phase == "running":
+            self._request_face("work")   # a live tool → the walk-away glance
 
     def _on_stop(self):
         if self._worker is not None:
@@ -686,11 +824,23 @@ class SynapsePanel(QtWidgets.QWidget):
     def _set_busy(self, busy):
         self._send_btn.setEnabled(not busy)
         self._stop_btn.setEnabled(busy)
+        self._observe.setStyleSheet(
+            "background:%s; border-radius:2px;" % (t.WARM if busy else t.SIGNAL_TINT)
+        )
         self._set_header("working" if busy else "idle",
                          "Working on it" if busy else "Standing by")
+        # state→face edges: a new work cycle clears any manual park and shows
+        # Work; work finishing shows Review (the payoff). idle→Direct is the
+        # resting default and is set explicitly when a fresh turn begins.
+        if busy and not self._was_busy:
+            self._manual_face = None
+            self._request_face("work")
+        elif not busy and self._was_busy:
+            self._request_face("review")
+        self._was_busy = busy
 
     def _set_header(self, status, phrase):
-        self._header_dot.set_status(status)
+        self._mark.set_state(status)
         self._header_status.setText(phrase)
 
     def _update_context(self):

--- a/python/synapse/panel/synapse_panel.py
+++ b/python/synapse/panel/synapse_panel.py
@@ -24,10 +24,6 @@ from synapse.panel.designsystem import tokens as t
 from synapse.panel.designsystem import qss
 from synapse.panel.designsystem import components as c
 from synapse.panel.designsystem import motion
-try:
-    from synapse.panel.designsystem.loader import BouncingToy
-except Exception:  # pragma: no cover
-    BouncingToy = None
 
 # Proven runtime + widgets — composed, not rewritten. All optional so the panel
 # always instantiates (graceful degradation is a runtime contract).
@@ -57,6 +53,10 @@ try:
 except Exception:  # pragma: no cover
     HealthInfographic = None
     agent_health = None
+try:
+    from synapse.panel.face_work import FaceWork
+except Exception:  # pragma: no cover
+    FaceWork = None
 
 _VERSION = "7.0.0"
 
@@ -347,23 +347,20 @@ class SynapsePanel(QtWidgets.QWidget):
         return page
 
     def _build_work_face(self):
-        """Work — the walk-away glance. Activity + observability live here; the
-        cook preview + plan-with-progress land in Mile 4."""
+        """Work — the walk-away glance. FaceWork (Mile 4) owns the cook preview,
+        plan-with-progress, live tool status, the thinking pulse, and the
+        embedded observability infographic. The panel delegates its working
+        signals to it (set_thinking / set_tool_status / set_health)."""
+        if FaceWork is not None:
+            self._work_face = FaceWork()
+            return self._work_face
+        # graceful fallback — the surface stays present even without FaceWork
+        self._work_face = None
         page = self._section()
-        col = QtWidgets.QVBoxLayout(page)
-        col.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_SM)
-        col.setSpacing(t.SPACE_SM)
-        col.addWidget(self._build_activity_row())
-        # Observability infographic — the visible end of the RSI loop (Line O).
-        if HealthInfographic is not None:
-            self._health = HealthInfographic(parent=page)
-            col.addWidget(self._health)
-        else:
-            self._health = None
-        hint = c.label("the cook lands here — mile 4", role="caption")
-        hint.setStyleSheet("color:%s;" % t.TEXT_TERTIARY)
-        col.addWidget(hint)
-        col.addStretch(1)
+        lay = QtWidgets.QVBoxLayout(page)
+        lay.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_SM)
+        lay.addWidget(c.label("Work face unavailable in this build", role="caption"))
+        lay.addStretch(1)
         return page
 
     def _build_review_face(self):
@@ -476,37 +473,24 @@ class SynapsePanel(QtWidgets.QWidget):
             "the node path and the promoted parameters.%s" % (ctx, prompt, helptxt)
         )
 
-    def _build_activity_row(self):
-        """A bouncing rubber-toy 'thinking' loader (hidden until working)."""
-        self._activity = self._section()
-        lay = QtWidgets.QHBoxLayout(self._activity)
-        lay.setContentsMargins(t.SPACE_MD, t.SPACE_XS, t.SPACE_MD, t.SPACE_XS)
-        lay.addStretch(1)
-        self._toy = BouncingToy() if BouncingToy is not None else None
-        if self._toy is not None:
-            lay.addWidget(self._toy)
-        lay.addWidget(c.label("thinking…", role="caption"))
-        lay.addStretch(1)
-        self._activity.setVisible(False)
-        return self._activity
-
     def _set_thinking(self, on):
-        if hasattr(self, "_activity"):
-            self._activity.setVisible(on)
-        if getattr(self, "_toy", None) is not None:
-            self._toy.start() if on else self._toy.stop()
+        """Delegate the thinking pulse to the Work face (Mile 4)."""
+        wf = getattr(self, "_work_face", None)
+        if wf is not None:
+            wf.set_thinking(on)
 
     def _update_health(self):
         """Timer-driven: poll the bridge, persist recommendations + run the
         meta-recursion analyzer, paint the infographic. Best-effort — a missing
         bridge or shared/ just yields the 'awaiting telemetry' empty state."""
-        if getattr(self, "_health", None) is None or agent_health is None:
+        wf = getattr(self, "_work_face", None)
+        if wf is None or agent_health is None:
             return
         try:
             data = agent_health.poll_agent_health()
         except Exception:
             data = None
-        self._health.set_data(data)
+        wf.set_health(data)
 
     def _verb(self, text, on_click, accent=False):
         """A type-set action — mono, letter-spaced, no pill chrome (Mile 3).
@@ -831,6 +815,9 @@ class SynapsePanel(QtWidgets.QWidget):
     def _on_tool_status(self, name, phase, _detail):
         verb = {"running": "running", "done": "ok", "error": "failed"}.get(phase, phase)
         self._set_header("working", "%s %s" % (name, verb))
+        wf = getattr(self, "_work_face", None)
+        if wf is not None:
+            wf.set_tool_status(name, verb, _detail)   # feed the plan-with-progress
         if phase == "running":
             self._request_face("work")   # a live tool → the walk-away glance
 

--- a/python/synapse/panel/synapse_panel.py
+++ b/python/synapse/panel/synapse_panel.py
@@ -508,25 +508,44 @@ class SynapsePanel(QtWidgets.QWidget):
             data = None
         self._health.set_data(data)
 
+    def _verb(self, text, on_click, accent=False):
+        """A type-set action — mono, letter-spaced, no pill chrome (Mile 3).
+        Verbs read as type, not buttons; the work is the hero, not the controls.
+        Inline-styled so it overrides the DsPill look without touching qss.py
+        (the QSS design pass is Mile 7)."""
+        btn = QtWidgets.QPushButton(text)
+        btn.setObjectName("DsVerb")
+        btn.setCursor(Qt.PointingHandCursor)
+        btn.setFlat(True)
+        rest = t.TEXT_ACCENT if accent else t.TEXT_SECONDARY
+        btn.setStyleSheet(
+            "QPushButton#DsVerb{background:transparent; border:none; padding:2px 0;"
+            " color:%s; font-family:%s; font-size:11px; letter-spacing:1.4px;}"
+            "QPushButton#DsVerb:hover{color:%s;}"
+            % (rest, t.FONT_MONO, t.TEXT_ACCENT)
+        )
+        btn.clicked.connect(on_click)
+        return btn
+
     def _build_act(self):
         w = self._section()
         lay = QtWidgets.QHBoxLayout(w)
-        lay.setContentsMargins(t.SPACE_MD, t.SPACE_XS, t.SPACE_MD, t.SPACE_XS)
-        lay.setSpacing(t.SPACE_XS)
+        lay.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_SM)
+        lay.setSpacing(t.SPACE_MD)
         for label_text, prompt in _QUICK_ACTIONS:
-            pill = c.Pill(label_text)
-            pill.clicked.connect(lambda _=False, p=prompt: self._send(p))
-            lay.addWidget(pill)
-        hda_pill = c.Pill("Build HDA")   # demoted from a top-level face into Direct
-        hda_pill.clicked.connect(lambda: self._set_direct_view("hda"))
-        lay.addWidget(hda_pill)
-        self._font_btn = c.Pill("Aa")
-        self._font_btn.setToolTip("Font size — click to cycle")
-        self._font_btn.clicked.connect(self._cycle_font_scale)
-        lay.addWidget(self._font_btn)
+            lay.addWidget(self._verb(
+                label_text.upper(), lambda _=False, p=prompt: self._send(p)))
+        # Build HDA: demoted from a top-level face into a Direct verb (+ ⌘K).
+        lay.addWidget(self._verb(
+            "BUILD HDA", lambda _=False: self._set_direct_view("hda")))
         lay.addStretch(1)
-        self._more_btn = c.Pill("⌘K  more…")
-        self._more_btn.clicked.connect(self._open_palette)
+        self._font_btn = self._verb(
+            "Aa", lambda _=False: self._cycle_font_scale())
+        self._font_btn.setToolTip("Font size — click to cycle")
+        lay.addWidget(self._font_btn)
+        self._more_btn = self._verb(
+            "⌘K", lambda _=False: self._open_palette(), accent=True)
+        self._more_btn.setToolTip("Command palette — every tool, two axes")
         lay.addWidget(self._more_btn)
         return w
 

--- a/python/synapse/panel/tool_filter.py
+++ b/python/synapse/panel/tool_filter.py
@@ -49,6 +49,64 @@ def _get_router():
     return _router
 
 
+# ── Two-axis palette taxonomy (Mile 6) ───────────────────────────
+# The ⌘K palette lets the artist self-identify two ways: by what they want
+# DONE (verb) and by WHERE they are (context). Pure classification — no router,
+# no side effects — so both palettes can share one taxonomy.
+PALETTE_VERBS = ("build", "fix", "explain", "optimize", "render")
+PALETTE_CONTEXTS = ("SOP", "LOP", "COP", "Karma", "USD")
+
+# verb keyword sets, checked in priority order; "build" is the default.
+_VERB_KEYWORDS = {
+    "render":   ("render", "karma", "husk", "farm", "flipbook", "rendersettings"),
+    "fix":      ("fix", "repair", "diagnose", "doctor", "undo", "redo", "recover",
+                 "validate", "preflight", "cleanup", "migrate", "heal"),
+    "optimize": ("optim", "profile", "metric", "tune", "wedge", "batch",
+                 "scheduler", "performance"),
+    "explain":  ("explain", "inspect", "query", "network_explain", "trace",
+                 "analyze", "lookup", "search", "recall", "describe", "status",
+                 "summary", "scene_info", "stage_info", "get_", "info",
+                 "capture", "monitor", "stats", "help"),
+}
+_VERB_ORDER = ("render", "fix", "optimize", "explain")
+
+# context keyword sets, checked in priority order; no match → None ("Other").
+_CONTEXT_KEYWORDS = {
+    "COP":   ("cops_", "copernicus", "pixel_sort", "reaction_diffusion", "wetmap",
+              "slap_comp", "stylize", "growth_propagation", "composite_aov",
+              "temporal_analysis"),
+    "Karma": ("karma", "husk", "mtlx", "materialx", "material", "light", "render",
+              "farm", "flipbook", "aov", "frame"),
+    "USD":   ("usd", "prim", "stage", "sublayer", "payload", "variant",
+              "collection", "reference", "instancer"),
+    "LOP":   ("solaris", "lop"),
+    "SOP":   ("sop", "scatter", "vex", "wrangle", "deform"),
+}
+_CONTEXT_ORDER = ("COP", "Karma", "USD", "LOP", "SOP")
+
+
+def classify_tool(name, title="", desc=""):
+    """Classify a tool/command into ``(verb, context)`` for the two-axis palette.
+
+    verb    ∈ PALETTE_VERBS          — what the artist wants done (default 'build')
+    context ∈ PALETTE_CONTEXTS|None  — where they are (None = no clear context)
+
+    Pure and side-effect free; safe to call from any UI thread.
+    """
+    text = " ".join((str(name or ""), str(title or ""), str(desc or ""))).lower()
+    verb = "build"
+    for v in _VERB_ORDER:
+        if any(k in text for k in _VERB_KEYWORDS[v]):
+            verb = v
+            break
+    context = None
+    for ctx in _CONTEXT_ORDER:
+        if any(k in text for k in _CONTEXT_KEYWORDS[ctx]):
+            context = ctx
+            break
+    return verb, context
+
+
 # ── Base tools (always included regardless of routing) ───────────
 _BASE_TOOLS = frozenset({
     "synapse_ping",

--- a/python/synapse/panel/tool_palette.py
+++ b/python/synapse/panel/tool_palette.py
@@ -22,6 +22,7 @@ except ImportError:  # pragma: no cover - Houdini ships PySide6
 
 from synapse.panel.designsystem import tokens as t
 from synapse.panel.designsystem import components as c
+from synapse.panel.designsystem import qss
 
 try:
     from synapse.panel.tool_filter import (
@@ -149,6 +150,9 @@ class ToolPalette(QtWidgets.QWidget):
         self.setObjectName("DsRoot")
         self.setAttribute(Qt.WA_StyledBackground, True)
         self.setWindowFlags(Qt.Popup)
+        # Popup is a separate top-level window — give it the canonical sheet so
+        # DsChip / DsList / DsField render from the design system, not defaults.
+        self.setStyleSheet(qss.stylesheet())
         self.setMinimumSize(440, 480)
         self._rows = _load_entries()
 
@@ -224,18 +228,9 @@ class ToolPalette(QtWidgets.QWidget):
             self._style_chip(btn, v == self._context)
 
     def _style_chip(self, btn, active):
-        if active:
-            btn.setStyleSheet(
-                "QPushButton#DsChip{background:%s; color:%s; border:none;"
-                " border-radius:3px; padding:3px 8px; font-family:%s;"
-                " font-size:10px; letter-spacing:1px;}"
-                % (t.SIGNAL_TINT, t.TEXT_ACCENT, t.FONT_MONO))
-        else:
-            btn.setStyleSheet(
-                "QPushButton#DsChip{background:transparent; color:%s; border:none;"
-                " padding:3px 8px; font-family:%s; font-size:10px; letter-spacing:1px;}"
-                "QPushButton#DsChip:hover{color:%s;}"
-                % (t.TEXT_TERTIARY, t.FONT_MONO, t.TEXT_SECONDARY))
+        # Styled by the canonical QPushButton#DsChip[active] QSS rule (Mile 7).
+        btn.setProperty("active", bool(active))
+        c.repolish(btn)
 
     # ------------------------------------------------------------------
     def _visible(self):

--- a/python/synapse/panel/tool_palette.py
+++ b/python/synapse/panel/tool_palette.py
@@ -23,6 +23,32 @@ except ImportError:  # pragma: no cover - Houdini ships PySide6
 from synapse.panel.designsystem import tokens as t
 from synapse.panel.designsystem import components as c
 
+try:
+    from synapse.panel.tool_filter import (
+        classify_tool, PALETTE_VERBS, PALETTE_CONTEXTS,
+    )
+except Exception:  # pragma: no cover
+    classify_tool = None
+    PALETTE_VERBS = ("build", "fix", "explain", "optimize", "render")
+    PALETTE_CONTEXTS = ("SOP", "LOP", "COP", "Karma", "USD")
+
+
+def _ctx_rank(ctx):
+    return list(PALETTE_CONTEXTS).index(ctx) if ctx in PALETTE_CONTEXTS else len(PALETTE_CONTEXTS)
+
+
+def _ctx_label(ctx):
+    return ctx if ctx else "Other"
+
+
+def _classify(name, title, desc):
+    if classify_tool is None:
+        return "build", None
+    try:
+        return classify_tool(name, title, desc)
+    except Exception:
+        return "build", None
+
 _MATERIAL_PRESETS = [
     "glass", "mirror", "rough_metal", "polished_metal", "skin",
     "cloth", "plastic", "ceramic", "wax", "rubber",
@@ -68,43 +94,48 @@ def _load_entries():
     """All palette entries as dicts {domain, title, desc, send, destructive}."""
     entries = []
 
-    # a) the 110 registry tools
+    # a) the 110 registry tools — classified on both axes (verb × context)
     try:
         from synapse.mcp._tool_registry import TOOL_DEFS
         for d in TOOL_DEFS:
             name, desc, destr = d[0], d[3], bool(d[6])
             title = name.replace("houdini_", "").replace("synapse_", "").replace("_", " ").title()
+            verb, ctx = _classify(name, title, desc)
             entries.append(dict(domain=_domain(name), title=title, desc=desc,
-                                send="Use the `%s` tool." % name, destructive=destr))
+                                send="Use the `%s` tool." % name, destructive=destr,
+                                verb=verb, context=ctx))
     except Exception:
         pass
 
-    # b) legacy knowledge: slash-commands + recipes + APEX + VEX
+    # b) legacy knowledge: slash-commands + recipes + APEX + VEX (pre-tagged)
     try:
         from synapse.panel.command_palette import build_palette_entries
         for e in build_palette_entries():
             send = (_CATEGORY_PREFIX.get(e.category, "") + (e.description or e.label)).strip()
             entries.append(dict(domain=_CATEGORY_DOMAIN.get(e.category, "Commands"),
                                 title=e.label, desc=e.description or "", send=send,
-                                destructive=False))
+                                destructive=False,
+                                verb=getattr(e, "verb", "build"),
+                                context=getattr(e, "context", None)))
     except Exception:
         pass
 
-    # c) galleries: material presets + render tiers
+    # c) galleries: material presets (build · Karma) + render tiers (render · Karma)
     for m in _MATERIAL_PRESETS:
         pretty = m.replace("_", " ").title()
         entries.append(dict(domain="Materials", title="Material: %s" % pretty,
                             desc="Create a %s material and assign it" % pretty.lower(),
                             send="Create a %s material (houdini_create_material) and assign it "
                                  "to the selected geometry." % m,
-                            destructive=False))
+                            destructive=False, verb="build", context="Karma"))
     for tier in _RENDER_TIERS:
         entries.append(dict(domain="Render", title="Render: %s" % tier.title(),
                             desc="Render at %s quality" % tier,
                             send="Render the current scene at %s quality (render_progressively)." % tier,
-                            destructive=False))
+                            destructive=False, verb="render", context="Karma"))
 
-    entries.sort(key=lambda e: (e["domain"], e["title"]))
+    # grouped by context (where), then verb (what), then title
+    entries.sort(key=lambda e: (_ctx_rank(e["context"]), e["verb"], e["title"]))
     return entries
 
 
@@ -132,33 +163,104 @@ class ToolPalette(QtWidgets.QWidget):
         self._search.installEventFilter(self)
         lay.addWidget(self._search)
 
+        # two axes — reach a tool by what you want DOne or by WHERE you are
+        self._verb = None
+        self._context = None
+        self._verb_chips = {}
+        self._ctx_chips = {}
+        lay.addLayout(self._build_chip_row("verb", "DO"))
+        lay.addLayout(self._build_chip_row("context", "WHERE"))
+        self._style_chips()
+
         self._list = QtWidgets.QListWidget()
         self._list.setObjectName("DsList")
         self._list.itemActivated.connect(self._choose)
         self._list.itemClicked.connect(self._choose)
         lay.addWidget(self._list, 1)
 
-        hint = c.label("↑↓ navigate · Enter run · Esc close · destructive items are gated",
-                       role="caption")
+        hint = c.label("↑↓ navigate · Enter run · Esc close · filter by DO × WHERE · "
+                       "destructive items are gated", role="caption")
         lay.addWidget(hint)
 
         self._populate(self._rows)
         self._search.setFocus()
 
     # ------------------------------------------------------------------
+    def _build_chip_row(self, kind, tag_text):
+        """A row of toggle chips for one axis (verb or context). 'All' clears it."""
+        row = QtWidgets.QHBoxLayout()
+        row.setSpacing(t.SPACE_XS)
+        tag = c.label(tag_text, role="caption")
+        tag.setStyleSheet("color:%s; letter-spacing:1.5px;" % t.TEXT_TERTIARY)
+        tag.setMinimumWidth(44)
+        row.addWidget(tag)
+        chips = self._verb_chips if kind == "verb" else self._ctx_chips
+        values = [None] + list(PALETTE_VERBS if kind == "verb" else PALETTE_CONTEXTS)
+        for v in values:
+            text = "All" if v is None else (v.title() if kind == "verb" else v)
+            btn = QtWidgets.QPushButton(text)
+            btn.setObjectName("DsChip")
+            btn.setCursor(Qt.PointingHandCursor)
+            btn.setFlat(True)
+            btn.clicked.connect(lambda _=False, k=kind, val=v: self._set_axis(k, val))
+            chips[v] = btn
+            row.addWidget(btn)
+        row.addStretch(1)
+        return row
+
+    def _set_axis(self, kind, value):
+        """Set (or toggle off) the active filter on one axis, then re-filter."""
+        if kind == "verb":
+            self._verb = None if self._verb == value else value
+        else:
+            self._context = None if self._context == value else value
+        self._style_chips()
+        self._refilter(self._search.text())
+
+    def _style_chips(self):
+        for v, btn in self._verb_chips.items():
+            self._style_chip(btn, v == self._verb)
+        for v, btn in self._ctx_chips.items():
+            self._style_chip(btn, v == self._context)
+
+    def _style_chip(self, btn, active):
+        if active:
+            btn.setStyleSheet(
+                "QPushButton#DsChip{background:%s; color:%s; border:none;"
+                " border-radius:3px; padding:3px 8px; font-family:%s;"
+                " font-size:10px; letter-spacing:1px;}"
+                % (t.SIGNAL_TINT, t.TEXT_ACCENT, t.FONT_MONO))
+        else:
+            btn.setStyleSheet(
+                "QPushButton#DsChip{background:transparent; color:%s; border:none;"
+                " padding:3px 8px; font-family:%s; font-size:10px; letter-spacing:1px;}"
+                "QPushButton#DsChip:hover{color:%s;}"
+                % (t.TEXT_TERTIARY, t.FONT_MONO, t.TEXT_SECONDARY))
+
+    # ------------------------------------------------------------------
+    def _visible(self):
+        """Rows passing the active verb + context filters (axis navigation)."""
+        rows = self._rows
+        if self._verb:
+            rows = [e for e in rows if e.get("verb") == self._verb]
+        if self._context:
+            rows = [e for e in rows if e.get("context") == self._context]
+        return rows
+
     def _populate(self, rows):
         self._list.clear()
         last_domain = None
         for e in rows:
-            if e["domain"] != last_domain:
-                head = QtWidgets.QListWidgetItem(e["domain"].upper())
+            group = _ctx_label(e.get("context"))
+            if group != last_domain:
+                head = QtWidgets.QListWidgetItem(group.upper())
                 head.setFlags(Qt.NoItemFlags)
                 try:
                     head.setForeground(QColor(t.TEXT_TERTIARY))
                 except Exception:
                     pass
                 self._list.addItem(head)
-                last_domain = e["domain"]
+                last_domain = group
             label = ("  ⚠ " if e["destructive"] else "  ") + e["title"]
             item = QtWidgets.QListWidgetItem(label)
             item.setData(Qt.UserRole, e["send"])
@@ -178,13 +280,12 @@ class ToolPalette(QtWidgets.QWidget):
 
     def _refilter(self, text):
         q = text.strip().lower()
-        if not q:
-            self._populate(self._rows)
-            return
-        filtered = [e for e in self._rows
+        rows = self._visible()              # apply the verb × context axes first
+        if q:
+            rows = [e for e in rows
                     if q in e["title"].lower() or q in e["desc"].lower()
                     or q in e["send"].lower()]
-        self._populate(filtered)
+        self._populate(rows)
 
     def _choose(self, item):
         send = item.data(Qt.UserRole)

--- a/tests/test_chat_panel.py
+++ b/tests/test_chat_panel.py
@@ -162,6 +162,12 @@ class TestMessageFormatterNodePath:
         result = format_response("ROP at /out/usdrender1")
         assert 'href="node:/out/usdrender1"' in result
 
+    def test_usd_prim_path_becomes_chip(self):
+        # Mile 3 — the comp's Direct artifact is a USD prim path, not a /obj
+        # node path. It must still resolve to a clickable node: chip.
+        result = format_response("rebound at /materials/AMD/Dark_Glass")
+        assert 'href="node:/materials/AMD/Dark_Glass"' in result
+
     def test_no_path_no_link(self):
         result = format_response("No paths here")
         assert "href" not in result
@@ -214,16 +220,19 @@ class TestMessageFormatterStatus:
 
 
 class TestUserMessageFormat:
-    """Test user message bubble formatting."""
+    """Mile 3 — the human voice: a signal hairline + brighter text, no bubble."""
 
-    def test_user_message_has_you_label(self):
+    def test_user_message_has_signal_rule(self):
+        # The single hairline rule on the human voice uses the canonical
+        # signal blue (#8FB3D9), not the legacy cyan, not a bubble.
         result = format_user_message("Hello")
-        assert "You" in result
+        assert "#8FB3D9" in result
 
-    def test_user_message_has_background(self):
+    def test_user_message_has_no_bubble(self):
+        # Bubbles are dead: no CARBON fill, no rounded container.
         result = format_user_message("Hello")
-        # User bubble uses CARBON (#333333) from design system
-        assert "#333333" in result
+        assert "#333333" not in result
+        assert "border-radius" not in result
 
     def test_user_message_escapes_html(self):
         result = format_user_message("<script>alert(1)</script>")
@@ -232,15 +241,20 @@ class TestUserMessageFormat:
 
 
 class TestSynapseMessageFormat:
-    """Test synapse message bubble formatting."""
+    """Mile 3 — the agent voice: plain body copy, no label, no bubble."""
 
-    def test_synapse_label(self):
+    def test_synapse_no_bubble(self):
         result = format_synapse_message("Hello")
-        assert "SYNAPSE" in result
+        assert "Hello" in result
+        assert "border-radius" not in result
+        assert "#333333" not in result
 
-    def test_synapse_accent_color(self):
-        result = format_synapse_message("Hello")
-        assert "#00D4FF" in result
+    def test_synapse_uses_canonical_signal(self):
+        # Node refs surface as artifact chips in the canonical signal blue
+        # (#8FB3D9) — the de-cyaned single chromatic event, not #00D4FF.
+        result = format_synapse_message("rebound at /obj/geo1/mat")
+        assert "#8FB3D9" in result
+        assert "#00D4FF" not in result
 
 
 class TestSystemMessageFormat:

--- a/tests/test_chat_panel.py
+++ b/tests/test_chat_panel.py
@@ -257,6 +257,33 @@ class TestSynapseMessageFormat:
         assert "#00D4FF" not in result
 
 
+class TestStylesDecyaned:
+    """Mile 7 — styles.py renders the signature blue (#8FB3D9), not legacy cyan."""
+
+    def _all_styles(self):
+        from synapse.panel import styles
+        return "".join([
+            styles.get_chat_display_stylesheet(),
+            styles.get_send_button_stylesheet(),
+            styles.get_growing_input_stylesheet(),
+            styles.get_quick_action_button_stylesheet(),
+            styles.get_connect_button_stylesheet(),
+            styles.get_ws_url_button_stylesheet(),
+            styles.get_context_bar_path_stylesheet(),
+            styles.get_quick_action_pill_stylesheet(),
+            styles.get_font_size_button_stylesheet(),
+            styles.get_hda_stylesheet(),
+        ])
+
+    def test_no_legacy_cyan(self):
+        out = self._all_styles().upper()
+        assert "00D4FF" not in out
+        assert "0, 212, 255" not in out and "0,212,255" not in out
+
+    def test_signature_blue_present(self):
+        assert "8FB3D9" in self._all_styles().upper()
+
+
 class TestSystemMessageFormat:
     """Test system message formatting."""
 

--- a/tests/test_panel_faces.py
+++ b/tests/test_panel_faces.py
@@ -196,6 +196,60 @@ def test_cook_progress_is_determinate():
     assert "14 / 30" in p._work_face._cook_lbl.text()
 
 
+def test_review_face_present_with_gate():
+    # Mile 5 — the Review face is the real FaceReview, and self._gate aliases
+    # the embedded gate so the consent wiring stays intact.
+    p = _make_panel()
+    assert p._review_face is not None
+    assert p._gate is p._review_face.gate
+
+
+def test_review_show_result_populates_all_parts():
+    # Simulated 'done' → render + verdict + credit + flags + paths all render.
+    p = _make_panel()
+    rf = p._review_face
+    rf.show_result(
+        verdict="The crystal reads at the scene's IOR now — Dark_Glass landed.",
+        credit=[("DECISION", "Dark_Glass", "over Diamond, closer to scene IOR"),
+                ("VIA", "materiallinker → link_type_1", "")],
+        flags=[("ok", "render ok"), ("fail", "EXR not written — BL-007")],
+        paths=["/materials/AMD/link_type_1", "/Render/Products/render_settings"],
+        meta="karma_xpu · f1 · 1920×1080",
+    )
+    assert "Dark_Glass" in rf._verdict.text()
+    assert rf._credit_box.count() == 2
+    assert rf._flags_box.count() == 2
+    # offscreen: the window is never shown, so check explicit visibility state
+    assert not rf._paths.isHidden()
+    assert "link_type_1" in rf._paths.text()
+
+
+def test_bl007_flag_detects_missing_output():
+    # BL-007: no file on disk → the silent-no-output failure is flagged red.
+    from synapse.panel.face_review import bl007_flag
+    status, text = bl007_flag("")
+    assert status == "fail" and "BL-007" in text
+
+
+def test_review_actions_wired_to_panel():
+    # accept/commit signals reach the panel handlers without error; commit
+    # keeps the Review face forward (it routes through the gate, not /stage).
+    p = _make_panel()
+    p._review_face.accepted.emit()
+    p._review_face.committed.emit()
+    assert _idx(p) == 2
+
+
+def test_done_edge_populates_review_verdict():
+    # The done edge switches to Review and lifts the first line as the verdict.
+    p = _make_panel()
+    p._stream_buf = ["Dark_Glass landed; the crystal reads at the scene IOR now."]
+    p._was_busy = True
+    p._set_busy(False)
+    assert _idx(p) == 2
+    assert "Dark_Glass" in p._review_face._verdict.text()
+
+
 def _run_all():
     fns = [v for k, v in sorted(globals().items())
            if k.startswith("test_") and callable(v)]

--- a/tests/test_panel_faces.py
+++ b/tests/test_panel_faces.py
@@ -158,6 +158,44 @@ def test_scripted_conversation_renders():
     assert "node:/materials/AMD/Dark_Glass" in html_, "node ref must stay a chip anchor"
 
 
+def test_work_face_present():
+    # Mile 4 — the Work face is the real FaceWork, not a placeholder.
+    p = _make_panel()
+    assert p._work_face is not None
+    assert hasattr(p._work_face, "_cook")
+
+
+def test_work_face_pulses_while_thinking():
+    # The cook preview runs its indeterminate sweep while the agent thinks,
+    # and stops at rest — "the walk-away glance" reads alive.
+    p = _make_panel()
+    p._set_thinking(True)
+    assert p._work_face._cook._timer.isActive()
+    p._set_thinking(False)
+    assert not p._work_face._cook._timer.isActive()
+
+
+def test_tool_status_feeds_plan():
+    # Live tool events drive the plan-with-progress; a phase change updates the
+    # step in place (no duplicate), and normalizes done→ok.
+    p = _make_panel()
+    p._on_tool_status("houdini_render", "running", "")
+    assert "houdini_render" in [s[0] for s in p._work_face._steps]
+    p._on_tool_status("houdini_render", "done", "")
+    steps = p._work_face._steps
+    assert [s[0] for s in steps].count("houdini_render") == 1
+    assert steps[-1][1] == "ok"
+
+
+def test_cook_progress_is_determinate():
+    # Real cook counts switch the grid out of pulse into determinate progress.
+    p = _make_panel()
+    p._work_face.set_cook(14, 30)
+    assert p._work_face._cook._determinate
+    assert not p._work_face._cook._timer.isActive()
+    assert "14 / 30" in p._work_face._cook_lbl.text()
+
+
 def _run_all():
     fns = [v for k, v in sorted(globals().items())
            if k.startswith("test_") and callable(v)]

--- a/tests/test_panel_faces.py
+++ b/tests/test_panel_faces.py
@@ -1,0 +1,163 @@
+"""Mile 2 — three faces + state→face controller. Behavioral pins.
+
+Adversarial G1 check: instantiation isn't enough — the gate is "switches
+manually + auto on simulated state changes." These exercise the controller
+directly (no live worker, no Houdini) so the contract can't silently regress.
+
+Run offscreen via Houdini's Python (stock CPython lacks PySide):
+    hython tests/test_panel_faces.py        # exits 0 / 1
+Also collectable by pytest where PySide imports.
+"""
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+for _p in (_ROOT, os.path.join(_ROOT, "python")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+# --- tiny hou stub so the panel's best-effort context reads don't explode ---
+class _Hou:
+    class _HipFile:
+        def basename(self):
+            return "untitled.hip"
+
+    hipFile = _HipFile()
+
+    @staticmethod
+    def frame():
+        return 1
+
+    @staticmethod
+    def selectedNodes():
+        return []
+
+
+sys.modules.setdefault("hou", _Hou)
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PySide6 import QtWidgets  # noqa: F401
+    _HAVE_QT = True
+except ImportError:
+    try:
+        from PySide2 import QtWidgets  # noqa: F401
+        _HAVE_QT = True
+    except ImportError:
+        _HAVE_QT = False
+
+try:
+    import pytest
+    if not _HAVE_QT:
+        pytestmark = pytest.mark.skip(reason="PySide unavailable — run via hython")
+except Exception:
+    pytest = None
+
+
+_APP = None
+
+
+def _make_panel():
+    global _APP
+    if _APP is None:
+        _APP = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    from synapse.panel.synapse_panel import SynapsePanel
+    return SynapsePanel()
+
+
+def _idx(panel):
+    return panel._faces.currentIndex()
+
+
+def test_initial_face_is_direct():
+    p = _make_panel()
+    assert p._current_face == "direct"
+    assert _idx(p) == 0
+
+
+def test_manual_pill_switches_and_holds():
+    p = _make_panel()
+    p._set_face("review", manual=True)
+    assert _idx(p) == 2 and p._current_face == "review"
+    assert p._manual_face == "review"
+    # auto request is deferred while a manual pick holds
+    p._request_face("work")
+    assert _idx(p) == 2, "manual park must not be overridden by an auto request"
+    assert p._pending_face == "work"
+
+
+def test_busy_rising_edge_clears_manual_and_shows_work():
+    p = _make_panel()
+    p._set_face("review", manual=True)
+    p._set_busy(True)
+    assert p._manual_face is None, "a new work cycle clears the manual park"
+    assert _idx(p) == 1 and p._current_face == "work"
+
+
+def test_busy_falling_edge_shows_review():
+    p = _make_panel()
+    p._set_busy(True)
+    p._set_busy(False)
+    assert _idx(p) == 2 and p._current_face == "review"
+
+
+def test_tool_running_shows_work():
+    p = _make_panel()
+    p._set_face("direct")
+    p._on_tool_status("houdini_render", "running", "")
+    assert _idx(p) == 1 and p._current_face == "work"
+
+
+def test_focus_guard_defers_then_applies_on_focus_out():
+    p = _make_panel()
+    p._set_face("direct")
+    orig = p._input_focused
+    p._input_focused = lambda: True          # artist is typing
+    try:
+        p._request_face("work")
+        assert _idx(p) == 0, "must never yank away from Direct while typing"
+        assert p._pending_face == "work"
+    finally:
+        p._input_focused = orig
+    p._apply_pending_face()                  # input lost focus
+    assert _idx(p) == 1 and p._current_face == "work"
+
+
+def test_gate_raised_shows_review_and_supersedes_manual():
+    p = _make_panel()
+    p._set_face("direct", manual=True)
+    p._on_gate_raised({"level": "approve"})
+    assert _idx(p) == 2 and p._current_face == "review"
+
+
+def test_inform_gate_is_ignored():
+    p = _make_panel()
+    p._set_face("direct")
+    p._on_gate_raised({"level": "inform"})
+    assert _idx(p) == 0, "noisy INFORM proposals must not steal the face"
+
+
+def _run_all():
+    fns = [v for k, v in sorted(globals().items())
+           if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print("  ok   %s" % fn.__name__)
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            print("  FAIL %s — %s" % (fn.__name__, exc))
+    print("%d/%d passed" % (len(fns) - failed, len(fns)))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    if not _HAVE_QT:
+        print("PySide unavailable — run via hython.")
+        sys.exit(1)
+    sys.exit(_run_all())

--- a/tests/test_panel_faces.py
+++ b/tests/test_panel_faces.py
@@ -141,6 +141,23 @@ def test_inform_gate_is_ignored():
     assert _idx(p) == 0, "noisy INFORM proposals must not steal the face"
 
 
+def test_scripted_conversation_renders():
+    # Mile 3 — a scripted Direct conversation must render through ChatDisplay
+    # without choking on the new HTML (table-based human rule, artifact chips),
+    # and node refs must keep their clickable node: anchor.
+    p = _make_panel()
+    chat = p._chat
+    chat.append_user_message("swap crystal_import to Dark_Glass and re-render")
+    chat.append_synapse_message(
+        "On it — rebinding at /materials/AMD/Dark_Glass, then a draft cook."
+    )
+    chat.append_system_message("Added to context: /obj/geo1")
+    plain = chat.toPlainText()
+    assert "Dark_Glass" in plain and "crystal_import" in plain
+    html_ = chat.toHtml()
+    assert "node:/materials/AMD/Dark_Glass" in html_, "node ref must stay a chip anchor"
+
+
 def _run_all():
     fns = [v for k, v in sorted(globals().items())
            if k.startswith("test_") and callable(v)]

--- a/tests/test_panel_faces.py
+++ b/tests/test_panel_faces.py
@@ -250,6 +250,34 @@ def test_done_edge_populates_review_verdict():
     assert "Dark_Glass" in p._review_face._verdict.text()
 
 
+def test_classify_tool_two_axes():
+    # Mile 6 — the verb × context taxonomy classifies tools sensibly.
+    from synapse.panel.tool_filter import classify_tool
+    assert classify_tool("houdini_render")[0] == "render"
+    assert classify_tool("houdini_create_usd_prim") == ("build", "USD")
+    assert classify_tool("cops_pixel_sort")[1] == "COP"
+    assert classify_tool("synapse_inspect_scene")[0] == "explain"
+    assert classify_tool("tops_diagnose")[0] == "fix"
+
+
+def test_tool_palette_two_axis_filter():
+    # The ⌘K palette opens with both axes navigable; each filters the rows.
+    from synapse.panel.tool_palette import ToolPalette
+    _make_panel()                       # ensure a QApplication exists
+    pal = ToolPalette()
+    assert None in pal._verb_chips and "render" in pal._verb_chips and len(pal._verb_chips) == 6
+    assert None in pal._ctx_chips and "COP" in pal._ctx_chips and len(pal._ctx_chips) == 6
+    base = len(pal._visible())
+    pal._set_axis("verb", "render")
+    assert pal._verb == "render"
+    assert all(e["verb"] == "render" for e in pal._visible())
+    assert len(pal._visible()) <= base
+    pal._set_axis("context", "Karma")   # combine both axes
+    assert all(e["verb"] == "render" and e["context"] == "Karma" for e in pal._visible())
+    pal._set_axis("verb", "render")     # toggling the same chip clears it
+    assert pal._verb is None
+
+
 def _run_all():
     fns = [v for k, v in sorted(globals().items())
            if k.startswith("test_") and callable(v)]

--- a/tests/test_panel_faces.py
+++ b/tests/test_panel_faces.py
@@ -50,6 +50,20 @@ except ImportError:
     except ImportError:
         _HAVE_QT = False
 
+# Real Qt only. Sibling tests evict real PySide and leave stubs in sys.modules
+# (test_chat_panel: a MagicMock; test_hda_panel: a types.ModuleType subclass with
+# QApplication=MagicMock) — neither can build a panel. Verify QtWidgets.QApplication
+# is a genuine PySide *type*; any stub fails that, so we skip (this suite is
+# hython-only). Without this, a leaked stub flips _HAVE_QT True and every test
+# fails on fake widgets (passes alone, fails under the full stock-CI suite).
+if _HAVE_QT:
+    try:
+        _qapp = getattr(QtWidgets, "QApplication", None)
+        if not (isinstance(_qapp, type) and "PySide" in getattr(_qapp, "__module__", "")):
+            _HAVE_QT = False
+    except Exception:
+        _HAVE_QT = False
+
 try:
     import pytest
     if not _HAVE_QT:


### PR DESCRIPTION
## SYNAPSE panel — the Pentagram pass

Re-layout (not a rewrite) of the docked panel into **three faces driven by a state→face controller**, with *the work as the hero*. Every widget already existed; this rewires `_build_ui`, adds the controller, and lands the design moves. **Panel-layer only** — no USD substrate, Michael Gold''s RFC zones untouched.

### The seven miles
- **1/7** `002b444` — persistent rail + mark-as-status (termination · observability · cost, always on)
- **2/7** `d80f54d` — three faces + state-driven switching (idle→Direct / working→Work / done·gate→Review; manual-override pills; focus guard)
- **3/7** `0841487` — speaker-by-type chat (bubbles killed; node refs → artifact chips; de-cyaned to `#8FB3D9`)
- **4/7** `5155621` — Work face, the walk-away glance (cook-preview bucket grid + plan-with-progress + embedded health)
- **5/7** `2484a55` — Review face, the payoff (render-hero + verdict + credit/provenance + BL-007/008 flags + gated commit)
- **6/7** `3f3cee3` — two-axis ⌘K (verb × context, `classify_tool`)
- **7/7** `3539ec4` — design pass: final QSS, font cascade, de-cyan; fidelity locked at the live anchor
- `7e8d526` — G3 readability gate (`audit_panel.py --strict`) + the gate tooling

### Gates
- **G1** — `python run_panel.py --smoke` exit 0; `tests/test_panel_faces.py` **20/20**.
- **G2** — live in Houdini 21.0.671: visual fidelity **accepted**, all three faces vs the v4 comp.
- **G3** — `python audit_panel.py --strict` **exit 0** (WCAG contrast + type-scale floors + offscreen Qt usability). 2 advisory WARN (tertiary-on-SURFACE 2.8:1; 10 hit-targets < 26px).
- Stock suite: **124 pass**.

### Known / deferred
- 2 pre-existing `test_design_system` reds — the multi-source cyan/blue token gremlin (`test_hda_panel` pins cyan, `test_design_system` pins blue). `styles.py` de-cyaned locally; full unification deferred (edits a passing test — a separate call).
- Streaming-visibility (working→Work switches while the agent''s ack streams into Direct) — locked-design behavior, flagged for a fresh look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rebuilt SYNAPSE panel with persistent status rail and three state-driven faces (Direct, Work, Review).
  * Two-axis command palette (verb × context) for improved tool discovery.
  * Work face displays planning steps and real-time cooking progress with health metrics.
  * Review face shows render results with quality flags and provenance tracking.
  * Auto face-switching based on work state and user decisions.

* **Quality**
  * New design-system auditing for typography contrast and UI compliance verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->