### PR TITLE
latency: refactor close-out — H-4 de-dup + numeric reopen-gates (done-as-banked)

### DIFF
--- a/LATENCY_PLAN.md
+++ b/LATENCY_PLAN.md
@@ -254,3 +254,52 @@ Once implemented, instrument these:
 - `memory_write_ms` (before/after async queue)
 - `circuit_breaker_trips` per hour
 - `watchdog_false_positives` per session (should be 0 after hwebserver)
+
+---
+
+## Finish Line + Reopen Gates  (the Mile-0 ruler decides)  ·  2026-06-02
+
+The latency refactor is **DONE-as-banked.** Mile 0 instrumentation proved no
+in-scope read hotspot; the big-ticket report items were refuted as non-problems
+(Mile 2 = 17µs; hwebserver = ~2s *slower*); and adversarial recon (2026-06-02)
+refuted the last proposed lever — **batch-tool "selection discipline" is NOT a
+latency win**: `claude_worker.py:147-157` already multiplexes the N tool calls
+from one assistant turn into a *single* LLM round-trip, so a batch tool only
+shaves serial 20-65ms localhost hops that sit *under* the ~2s Houdini
+main-event-loop mutation floor. The only critical-path costs left — the LLM
+stream per loop turn and that ~2s mutation floor — are not reachable by
+application code in this repo.
+
+**SHIPPED + pinned by tests:** Mile 0 (`synapse_metrics` + `synapse_tool_duration_ms`
+histogram + `synapse_memory_entries_total` gauge==`store.count()` — `tests/test_metrics_invariants.py`);
+Mile 1 (`write_session_end` skips bodyless stubs — `tests/test_scene_memory.py`);
+Mile 3a (`synapse_inspect_node` `include_geometry=False` default — `tests/test_inspect_node_default.py`);
+H-4 (session-summary de-dup — `tests/test_session_summary_dedup.py`). Mile 2 SKIPPED
+(non-problem); C-2 already covered by the Mile 1 guard.
+
+**FINISH-LINE CHECK** = `synapse_metrics` (`synapse_tool_duration_ms` per-tool p50/p95
+from the cumulative buckets 5..5000ms) cross-checked against
+`python _benchmark_latency.py` round-trip avg/med/p95 over a **real** session
+(≥50 measured calls, not synthetic).
+
+The three remaining items stay **parked behind numeric reopen-gates** — do not
+build one until its gate fires on real data:
+
+- **3b dirty-flag inspect cache** — build ONLY if `synapse_tool_duration_ms` p95
+  for `tool="inspect_node"` (and/or `inspect_scene`) exceeds **250 ms** over a real
+  session (`..._bucket{le="250"}/count` drops below 0.95) AND `inspect_node` is among
+  the top-3 highest-`sum_ms` tools that session. Below that, the shipped Mile-3a
+  `include_geometry=False` default already keeps the common path cheap.
+- **Mile 5 async render dispatch** — build ONLY if `synapse_tool_duration_ms` p95 for
+  render tools (`autonomous_render`/`safe_render`/`render`/`render_sequence`) exceeds
+  **2000 ms** over a real session, OR `_benchmark_latency.py` shows create_node/mutation
+  median above 2000 ms (the documented ~2s floor) on the hot path.
+- **hwebserver migration (Phase 3)** — build ONLY if `_benchmark_latency.py` p95 for the
+  read mix (ping, get_health, get_scene_info, get_selection, context) exceeds **5 ms**
+  over a real session AND a fresh hwebserver A/B re-measures its prior ~2070 ms ping
+  floor (2026-02-08 table) as below 5 ms. Until SideFX removes that ~2s dispatch floor,
+  websockets stays primary — DEFERRED-not-abandoned.
+
+Every gate number is anchored to an existing histogram bucket boundary or a
+documented floor, so it reads directly from `synapse_metrics` / `_benchmark_latency`
+with **no new instrumentation**.

--- a/python/synapse/memory/store.py
+++ b/python/synapse/memory/store.py
@@ -806,7 +806,8 @@ class SynapseMemory:
         keywords: List[str] = None,
         source: str = "user",
         node_paths: List[str] = None,
-        links: List[Dict] = None
+        links: List[Dict] = None,
+        summary: str = ""
     ) -> Memory:
         """
         Add a new memory.
@@ -819,6 +820,10 @@ class SynapseMemory:
             source: Who created this ("user", "ai", "auto")
             node_paths: Related Houdini node paths
             links: Links to other memories [{"target_id": "...", "type": "...", "reason": "..."}]
+            summary: Explicit one-line summary. If empty (default), it is
+                auto-derived from the first content line — which produces
+                duplicate headings for templated content like session summaries
+                (H-4). Pass an explicit summary for such writes.
 
         Returns:
             The created Memory object
@@ -851,7 +856,8 @@ class SynapseMemory:
             hip_file=hip_file,
             hip_version=hip_version,
             frame=frame,
-            node_paths=node_paths or []
+            node_paths=node_paths or [],
+            summary=summary
         )
 
         # Add links

--- a/python/synapse/session/tracker.py
+++ b/python/synapse/session/tracker.py
@@ -174,7 +174,13 @@ class SynapseBridge:
                 content=summary,
                 memory_type=MemoryType.SUMMARY,
                 tags=["session", "summary"],
-                source="auto"
+                source="auto",
+                # H-4: an explicit, session-distinguishing summary. Without it,
+                # Memory.__post_init__ auto-derives summary from the first content
+                # line — always the literal "## Session Summary" heading — so
+                # recent_activity shows N identical rows to the AI on every connect.
+                summary=f"Session summary — {session.commands_executed} cmds, "
+                        f"{len(getattr(session, 'nodes_created', []) or [])} nodes ({session_id})",
             )
 
         return summary

--- a/tests/test_session_summary_dedup.py
+++ b/tests/test_session_summary_dedup.py
@@ -1,0 +1,54 @@
+"""H-4 regression: session summaries must not collapse to identical rows.
+
+Before the fix, SynapseMemory.add() had no `summary` param, so every memory's
+summary auto-derived from the first content line (Memory.__post_init__). Session
+summaries all start with the literal "## Session Summary" heading, so
+get_connection_context surfaced N identical recent_activity rows to the AI on
+every connect. The fix plumbs an explicit, session-distinguishing summary through
+add() at the tracker write site.
+
+Pure-Python (no Qt / no hou) — runs in stock CI.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "python"))
+
+from synapse.memory.store import SynapseMemory
+from synapse.memory.models import MemoryType
+
+
+_TEMPLATED_BODY = "## Session Summary\n- did some things\n- and more"
+
+
+def test_explicit_summary_is_honored_not_autoderived(tmp_path):
+    mem = SynapseMemory(project_path=str(tmp_path))
+    m = mem.add(
+        content=_TEMPLATED_BODY,
+        memory_type=MemoryType.SUMMARY,
+        source="auto",
+        summary="Session summary — 3 cmds, 2 nodes (sess-A)",
+    )
+    # the explicit summary wins — the duplicated heading never leaks through
+    assert m.summary == "Session summary — 3 cmds, 2 nodes (sess-A)"
+    assert not m.summary.startswith("## Session Summary")
+
+
+def test_two_identical_bodies_get_distinct_summaries(tmp_path):
+    mem = SynapseMemory(project_path=str(tmp_path))
+    a = mem.add(content=_TEMPLATED_BODY, memory_type=MemoryType.SUMMARY,
+                source="auto", summary="Session summary — 3 cmds, 2 nodes (sess-A)")
+    b = mem.add(content=_TEMPLATED_BODY, memory_type=MemoryType.SUMMARY,
+                source="auto", summary="Session summary — 5 cmds, 1 nodes (sess-B)")
+    # the symptom — identical templated bodies — now yields distinct summaries
+    assert a.summary != b.summary
+
+
+def test_omitted_summary_still_autoderives(tmp_path):
+    # backward-compat: the defaulted param preserves the auto-derive path
+    mem = SynapseMemory(project_path=str(tmp_path))
+    m = mem.add(content="hello world\nmore detail", memory_type=MemoryType.NOTE,
+                source="test")
+    assert m.summary and m.summary.startswith("hello world")


### PR DESCRIPTION
## Latency refactor — close-out

Applies the latency harness to *finishing the latency refactor*. The honest verdict: **done-as-banked.** Mile 0 instrumentation already proved no in-scope read hotspot, and adversarial recon refuted the last proposed lever.

### The finding
**Mile 4 (batch-tool selection) is a PHANTOM latency win.** `claude_worker.py:147-157` already multiplexes the N tool calls from one assistant turn into a *single* LLM round-trip, so a batch tool only shaves 20-65ms localhost hops that sit *under* the ~2s Houdini main-event-loop mutation floor. The only critical-path costs left — the LLM stream and that ~2s floor — aren''t reachable by app code. A 4-agent adversarial VERIFY workflow killed it before any code was written.

### What landed
- **`2e1b6e5` H-4 fix** — `SynapseMemory.add()` gains an optional `summary` (defaulted, positional-safe); `tracker.end_session` passes an explicit session-distinguishing summary so `get_connection_context` stops surfacing N identical `## Session Summary` rows to the AI on connect. `tests/test_session_summary_dedup.py` (3 pass).
- **`4670d93` reopen-gates** — `LATENCY_PLAN.md` finish-line + numeric, reproducible reopen-gates for the deferred items (3b / Mile 5 / hwebserver), anchored to `synapse_tool_duration_ms` buckets + `_benchmark_latency` — fire on real-session data, no new instrumentation.

### Resolved from the roadmap
Mile 0/1/3a SHIPPED (test-pinned). Mile 2 SKIPPED (17µs non-problem). C-2 already covered by the Mile 1 guard. Mile 4 refuted. 3b / Mile 5 / hwebserver parked behind numeric gates.

### Known
- 3 pre-existing `TestCharizardEvolution` failures (USD-evolution, parked; confirmed unrelated via stash).
- H-4 is a context-quality fix, not a latency win (in Contract-2 scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)