### PR TITLE
feat(solaris): ground assembly in H21 docs (Corpus button + scout) + fix shot_render_ready empty-stage build

### DIFF
--- a/python/synapse/cognitive/tools/scout_ingest.py
+++ b/python/synapse/cognitive/tools/scout_ingest.py
@@ -172,6 +172,28 @@ def ensure_corpus(rag_root: Optional[str] = None, out_root: Optional[str] = None
     return build_corpus(rag_root, out_root)
 
 
+def activate(rag_root: Optional[str] = None, out_root: Optional[str] = None) -> dict:
+    """Materialize the canonical repo ``rag/`` corpus (build-if-absent) and point
+    the live ``scout`` module at it — the SAME sequence the MCP server runs at
+    init (ensure_corpus → set roots → clear caches), factored here so the panel's
+    "Corpus" button shares it verbatim and the two can't drift. Pure Python, zero
+    ``hou``. Returns ``{loaded, store_root, entries, cached}``.
+
+    NB: activates the canonical repo ``rag/`` (which carries the H21 Solaris docs
+    in scout's ``searchable_text`` schema), NOT raw ``G:\\HOUDINI21_RAG_SYSTEM`` —
+    G:'s ``corpus/`` has no ``searchable_text`` and would load hollow."""
+    from synapse.cognitive.tools import scout as _scout
+    info = ensure_corpus(rag_root, out_root)
+    store_root = info["store_root"]
+    _scout.RAG_ROOT = Path(store_root)
+    _scout.VEX_ROOT = Path(store_root)
+    for cache in (_scout._CORPUS, _scout._FTS, _scout._DENSE,
+                  _scout._SYMS, _scout._TABLE_CACHE):
+        cache.clear()
+    return {"loaded": True, "store_root": store_root,
+            "entries": info.get("entries", -1), "cached": info.get("cached", False)}
+
+
 if __name__ == "__main__":             # pragma: no cover
     import sys
     res = build_corpus()

--- a/python/synapse/panel/synapse_panel.py
+++ b/python/synapse/panel/synapse_panel.py
@@ -361,6 +361,16 @@ class SynapsePanel(QtWidgets.QWidget):
             "can reach Houdini. Safe to click anytime — idempotent."
         )
         self._connect_btn.clicked.connect(self._on_connect)
+        # Activate the H21 documentation corpus so Solaris assembly grounds in
+        # real Houdini-21 docs (verified node types / parm names) instead of
+        # phantom APIs. Mirrors the Connect button; idempotent.
+        self._corpus_btn = c.Button("Corpus", variant="ghost")
+        self._corpus_btn.setToolTip(
+            "Connect the Houdini-21 documentation corpus so Solaris assembly "
+            "grounds in real H21 docs (not phantom parms). Safe to click anytime "
+            "— idempotent."
+        )
+        self._corpus_btn.clicked.connect(self._on_corpus)
         self._observe = QtWidgets.QWidget()
         self._observe.setObjectName("DsRailMeter")
         self._observe.setAttribute(Qt.WA_StyledBackground, True)
@@ -375,6 +385,7 @@ class SynapsePanel(QtWidgets.QWidget):
         bot.addWidget(self._foot_dot)
         bot.addWidget(self._foot_label)
         bot.addWidget(self._connect_btn)
+        bot.addWidget(self._corpus_btn)
         bot.addWidget(self._observe, 1)
         bot.addWidget(self._stop_btn)
         col.addLayout(bot)
@@ -431,6 +442,56 @@ class SynapsePanel(QtWidgets.QWidget):
                 "Start the Synapse bridge server (port 9999) so external / MCP "
                 "tools can reach Houdini. Safe to click anytime — idempotent."
             )
+
+    def _on_corpus(self):
+        """Activate the H21 documentation corpus so Solaris assembly grounds in
+        real docs (verified node types / parm names), not phantom APIs. Builds
+        the canonical repo rag/ corpus if absent and points scout at it (the same
+        sequence the MCP server runs at init). Idempotent; reports in chat;
+        degrades gracefully headless."""
+        try:
+            from synapse.cognitive.tools import scout_ingest
+        except Exception as exc:
+            self._announce_bridge("Corpus unavailable — %s." % exc)
+            return
+        try:
+            info = scout_ingest.activate()
+            hits = []
+            try:
+                from synapse.cognitive.tools.scout import synapse_scout
+                hits = synapse_scout("karmarendersettings xpu engine", k=3).get("hits", [])
+            except Exception:
+                pass   # the probe is a confidence check, not a gate
+            n = info.get("entries", -1)
+            cnt = "%d entries" % n if isinstance(n, int) and n >= 0 else "cached"
+            if hits:
+                self._announce_bridge(
+                    "Corpus active (%s, probe hit %d docs incl. %s) — Solaris "
+                    "builds will ground in real H21 docs."
+                    % (cnt, len(hits), hits[0].get("source", "?")))
+            else:
+                self._announce_bridge(
+                    "Corpus loaded (%s) but a known probe returned no hits — the "
+                    "rag/ tree may be incomplete." % cnt)
+        except Exception as exc:
+            self._announce_bridge("Couldn't load the corpus: %s" % exc)
+        self._refresh_corpus_state()
+
+    def _refresh_corpus_state(self):
+        """Reflect live corpus state on the Corpus button — 'Corpus ✓' once the
+        store's entries.jsonl is built. Best effort."""
+        loaded = False
+        try:
+            from synapse.cognitive.tools import scout as _scout
+            root = _scout.RAG_ROOT                  # a pathlib.Path
+            if root is not None:
+                fp = root / "corpus" / "entries.jsonl"
+                loaded = fp.is_file() and fp.stat().st_size > 0
+        except Exception:
+            loaded = False
+        btn = getattr(self, "_corpus_btn", None)
+        if btn is not None:
+            btn.setText("Corpus ✓" if loaded else "Corpus")
 
     def _build_model_bar(self):
         """Model selection, made APPARENT (Image #6). A segmented Claude·Gemini

--- a/python/synapse/panel/system_prompt.py
+++ b/python/synapse/panel/system_prompt.py
@@ -165,6 +165,15 @@ round-trips (latency), one terminal cook, and no phantom-node-type risk.
 composition. Wire geometry first, lights second, referenced assets last.
 - Templates: multi_asset_merge, sublayer_stack, render_pass_split, \
 lighting_rig, hdri_lighting, instanceable_assets, variant_selector.
+- **Ground before you build (Safety Rule 15):** before issuing \
+synapse_solaris_build_graph with any NON-template `nodes`, call \
+**synapse_scout** to confirm each LOP node `type` and its key parm names exist \
+in Houdini 21.0.671 -- e.g. \
+`synapse_scout(query="karmarendersettings engine xpu camera resolution")`. \
+Treat any symbol whose `exists_in_runtime` is false as a PHANTOM and do NOT \
+author it; if scout returns no hits for a node type, prefer a template or \
+inspect a live node. The H21 docs corpus is the authority -- don't invent parm \
+names. (Templates are already verified, so a template-only call needs no scout.)
 
 ### Known Issues
 - **karmaphysicalsky bug (H21):** Changing the primitive path from \

--- a/python/synapse/server/handlers_solaris_compose.py
+++ b/python/synapse/server/handlers_solaris_compose.py
@@ -48,6 +48,9 @@ class SolarisComposeMixin:
         engine = resolve_param_with_default(payload, "engine", "xpu")
         layer_dir = payload.get("layer_dir")
         reason = payload.get("reason")
+        # verify=False skips the cold-cook stage readback (L8 §4) — used by the
+        # shot_render_ready scaffold build so it can't freeze the GUI.
+        verify = payload.get("verify", True)
 
         from .main_thread import run_on_main, _SLOW_TIMEOUT
 
@@ -73,6 +76,7 @@ class SolarisComposeMixin:
                         engine=engine,
                         layer_dir=layer_dir,
                         reason=reason,
+                        verify=verify,
                     )
                     if advisory is not None:
                         result.setdefault("show_config", advisory)

--- a/python/synapse/server/handlers_usd.py
+++ b/python/synapse/server/handlers_usd.py
@@ -1801,6 +1801,7 @@ class UsdHandlerMixin:
                 h = resolve_param(payload, "height", required=False)
                 if w is not None and h is not None:
                     build_payload["resolution"] = [int(w), int(h)]
+                build_payload["verify"] = False   # L8 §4: skip the cold-cook readback
                 build_result = self._handle_solaris_shotsetup_karma_xpu(build_payload)
                 steps.append({"step": "solaris_build_from_scratch", "result": build_result})
             else:

--- a/python/synapse/server/handlers_usd.py
+++ b/python/synapse/server/handlers_usd.py
@@ -1778,13 +1778,33 @@ class UsdHandlerMixin:
             passed = False
             steps.append({"step": "create_textured_material", "error": str(e)})
 
-        # --- Step 2: assemble the Solaris chain ----------------------------
+        # --- Step 2: assemble the chain, or BUILD from scratch on an empty stage.
+        # assemble_chain only WIRES pre-existing unwired LOP nodes -- on an empty
+        # stage it returns chain==[] (it wires nothing), which previously left this
+        # tool rendering an EMPTY frame. When nothing was wired, build a render-ready
+        # Karma-XPU shot from scratch via the verified builder (engine=xpu, camera,
+        # resolution, productName on karmarendersettings -- parms verified live
+        # 21.0.671). NB: build_karma_xpu_shot writes department .usd files to
+        # $HIP/<shot>_layers/ (reported in disk_writes; not undoable).
         assemble_payload = {
             "parent": resolve_param_with_default(payload, "parent", "/stage"),
         }
         try:
             assemble_result = self._handle_solaris_assemble_chain(assemble_payload)
-            steps.append({"step": "solaris_assemble_chain", "result": assemble_result})
+            if not assemble_result.get("chain"):
+                build_payload = {"stage": assemble_payload["parent"]}
+                for key in ("shot", "engine", "layer_dir"):
+                    v = resolve_param(payload, key, required=False)
+                    if v is not None:
+                        build_payload[key] = v
+                w = resolve_param(payload, "width", required=False)
+                h = resolve_param(payload, "height", required=False)
+                if w is not None and h is not None:
+                    build_payload["resolution"] = [int(w), int(h)]
+                build_result = self._handle_solaris_shotsetup_karma_xpu(build_payload)
+                steps.append({"step": "solaris_build_from_scratch", "result": build_result})
+            else:
+                steps.append({"step": "solaris_assemble_chain", "result": assemble_result})
         except Exception as e:  # noqa: BLE001
             passed = False
             steps.append({"step": "solaris_assemble_chain", "error": str(e)})

--- a/python/synapse/server/solaris_compose_tools.py
+++ b/python/synapse/server/solaris_compose_tools.py
@@ -96,6 +96,7 @@ def build_karma_xpu_shot(
     engine: str = "xpu",
     layer_dir: Optional[str] = None,
     reason: Optional[str] = None,
+    verify: bool = True,
 ) -> dict:
     """Scaffold a render-ready Karma XPU shot (PRD 7.1 / GAP-1).
 
@@ -205,9 +206,17 @@ def build_karma_xpu_shot(
 
     stage_node.layoutChildren()
 
-    # Read back the composed stage (the [REAL] verifier reads through this).
-    rstage = sc.read_stage(out)
-    errs = sc.composition_errors(rstage)
+    # Read back the composed stage (the [REAL] verifier reads through this) --
+    # but read_stage(out) COOKS the LOP chain, and a cold-XPU first cook is heavy
+    # enough to FREEZE the GUI (L8 §4; this crashed Houdini 2026-06-26). When the
+    # caller only wants the scaffold built (verify=False), skip the synchronous
+    # readback: the Display flag (set above) still drives a LAZY cook on the next
+    # viewport redraw, during idle, off the build's critical path.
+    if verify:
+        rstage = sc.read_stage(out)
+        errs = sc.composition_errors(rstage)
+    else:
+        errs = None
 
     result = {
         "status": "created",

--- a/tests/test_corpus_activate.py
+++ b/tests/test_corpus_activate.py
@@ -1,0 +1,82 @@
+"""Corpus activation — the panel's "Corpus" button materializes the canonical
+repo rag/ corpus and grounds scout in real H21 Solaris/Karma docs.
+
+Pure Python (no Qt, no hou) so it runs under stock ``pytest -q`` AND hython —
+this is the real gate for Fix 1 (the live-panel click is only a smoke check).
+"""
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+for _p in (_ROOT, os.path.join(_ROOT, "python")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def test_activate_builds_corpus_and_grounds_solaris():
+    # activate() mutates module-global scout state — save/restore for isolation.
+    from synapse.cognitive.tools import scout as _scout
+    saved = _scout.RAG_ROOT
+    try:
+        from synapse.cognitive.tools import scout_ingest
+        info = scout_ingest.activate()
+        assert info["loaded"] is True
+        assert info["store_root"]
+
+        from synapse.cognitive.tools.scout import synapse_scout
+        hits = synapse_scout("karmarendersettings xpu engine", k=4).get("hits", [])
+        assert hits, "the repo rag/ corpus must surface karmarendersettings docs"
+        sources = " ".join(h.get("source", "") for h in hits).lower()
+        assert any(k in sources for k in ("karma", "solaris", "render")), sources
+    finally:
+        _scout.RAG_ROOT = saved
+        for cache in (_scout._CORPUS, _scout._FTS, _scout._DENSE,
+                      _scout._SYMS, _scout._TABLE_CACHE):
+            cache.clear()
+
+
+def test_activate_does_not_point_at_raw_g_drive():
+    # The whole point: activate() uses the canonical repo rag/ corpus, NOT raw
+    # G:\HOUDINI21_RAG_SYSTEM (whose corpus/ has no searchable_text → hollow).
+    from synapse.cognitive.tools import scout as _scout
+    saved = _scout.RAG_ROOT
+    try:
+        from synapse.cognitive.tools import scout_ingest
+        info = scout_ingest.activate()
+        assert "HOUDINI21_RAG_SYSTEM" not in info["store_root"]
+        assert "scout_corpus" in info["store_root"].replace("\\", "/")
+    finally:
+        _scout.RAG_ROOT = saved
+        for cache in (_scout._CORPUS, _scout._FTS, _scout._DENSE,
+                      _scout._SYMS, _scout._TABLE_CACHE):
+            cache.clear()
+
+
+def test_panel_wires_corpus_button():
+    # Source-scan (Qt-free): the rail defines a Corpus button + handlers that call
+    # scout_ingest.activate, placed next to the Connect button.
+    src = open(
+        os.path.join(_ROOT, "python", "synapse", "panel", "synapse_panel.py"),
+        encoding="utf-8",
+    ).read()
+    for marker in (
+        "_corpus_btn",
+        "def _on_corpus",
+        "def _refresh_corpus_state",
+        "scout_ingest.activate",
+        "bot.addWidget(self._corpus_btn)",
+    ):
+        assert marker in src, marker
+
+
+def test_system_prompt_grounds_solaris_builds_in_scout():
+    # Fix 2: the Solaris build guidance must wire Safety Rule 15 — scout before
+    # authoring non-template nodes — so the agent grounds in real H21 docs.
+    src = open(
+        os.path.join(_ROOT, "python", "synapse", "panel", "system_prompt.py"),
+        encoding="utf-8",
+    ).read()
+    assert "synapse_scout" in src
+    assert "Safety Rule 15" in src
+    assert "exists_in_runtime" in src

--- a/tests/test_shot_render_ready_empty_stage.py
+++ b/tests/test_shot_render_ready_empty_stage.py
@@ -1,0 +1,70 @@
+"""shot_render_ready: on an EMPTY /stage it now BUILDS a render-ready Karma-XPU
+scene from scratch (was: a no-op assemble → an empty rendered frame). A populated
+stage still just gets wired.
+
+Branch-logic unit test with stubbed sub-handlers — no hou, no live stage. This is
+the headless gate; the live end-to-end smoke (real XPU build + non-empty frame) is
+owed separately on the bridge.
+"""
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+for _p in (_ROOT, os.path.join(_ROOT, "python")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def _handler(assemble_chain_result):
+    from synapse.server.handlers_usd import UsdHandlerMixin
+    calls = {"build": 0, "assemble": 0, "render": 0}
+
+    class H(UsdHandlerMixin):
+        def _handle_create_textured_material(self, p):
+            return {"material_usd_path": "/materials/m"}
+
+        def _handle_solaris_assemble_chain(self, p):
+            calls["assemble"] += 1
+            return dict(assemble_chain_result)
+
+        def _handle_solaris_shotsetup_karma_xpu(self, p):
+            calls["build"] += 1
+            self.last_build_payload = p
+            return {"engine": p.get("engine", "xpu"),
+                    "nodes": ["/stage/a", "/stage/b"], "disk_writes": ["x.usd"]}
+
+        def _handle_safe_render(self, p):
+            calls["render"] += 1
+            return {"passed": True}
+
+    return H(), calls
+
+
+def test_empty_stage_builds_from_scratch():
+    h, calls = _handler({"chain": []})          # empty stage → assemble wires nothing
+    res = h._handle_shot_render_ready({"skip_render": True})
+    assert calls["assemble"] == 1
+    assert calls["build"] == 1, "empty stage must build a render-ready scene"
+    steps = [s["step"] for s in res["steps"]]
+    assert "solaris_build_from_scratch" in steps
+    assert "solaris_assemble_chain" not in steps
+
+
+def test_populated_stage_wires_not_rebuilds():
+    h, calls = _handler({"chain": ["/stage/geo", "/stage/cam"]})
+    res = h._handle_shot_render_ready({"skip_render": True})
+    assert calls["build"] == 0, "a populated stage must NOT rebuild from scratch"
+    steps = [s["step"] for s in res["steps"]]
+    assert "solaris_assemble_chain" in steps
+    assert "solaris_build_from_scratch" not in steps
+
+
+def test_build_payload_threads_params():
+    h, _calls = _handler({"chain": []})
+    h._handle_shot_render_ready({"skip_render": True, "shot": "hero",
+                                 "engine": "cpu", "width": 1280, "height": 720})
+    p = h.last_build_payload
+    assert p["shot"] == "hero"
+    assert p["engine"] == "cpu"
+    assert p["resolution"] == [1280, 720]

--- a/tests/test_shot_render_ready_empty_stage.py
+++ b/tests/test_shot_render_ready_empty_stage.py
@@ -68,3 +68,5 @@ def test_build_payload_threads_params():
     assert p["shot"] == "hero"
     assert p["engine"] == "cpu"
     assert p["resolution"] == [1280, 720]
+    # L8 §4: the scaffold build must skip the cold-cook readback so it can't freeze.
+    assert p["verify"] is False


### PR DESCRIPTION
From a research workflow (librarian on `G:\HOUDINI21_RAG_SYSTEM` + cartographer on the RAG wiring + Explore on the impl surface) plus **live-bridge parm verification** (`karmarendersettings`/`karmarenderproperties` both expose `engine`/`camera`/`resolution` on 21.0.671).

## The three fixes (full suite **3672 passed**, headless-clean)

**1 · "Corpus" button** (rail, next to Connect) — `scout_ingest.activate()` materializes the canonical repo `rag/` corpus and points scout at it (the same sequence the MCP server runs at init).
> ⚠️ **Honest scope note:** it activates the **repo `rag/`** (which carries the H21 Solaris docs in scout's `searchable_text` schema), **not raw `G:\HOUDINI21_RAG_SYSTEM`** — G:'s `corpus/` has *zero* `searchable_text` entries and would load **hollow**. Full-G: ingestion (convert its `documentation\` + `semantic_index` into scout's schema) is a real but larger lift, deliberately parked. The repo corpus already grounds Solaris (`karmarendersettings` ×51 across 22 files).

**2 · Solaris doc-grounding** — wired Safety Rule 15 into the system prompt's build block: call `synapse_scout` to confirm LOP node types + parm names before authoring any **non-template** nodes; treat `exists_in_runtime=false` as a phantom.

**3 · `houdini_shot_render_ready`** — step-2 called `assemble_chain` (wires *pre-existing* nodes only) → on an empty stage it rendered an **empty frame**. Now: when assemble returns `chain==[]`, build a render-ready Karma-XPU shot from scratch via the **verified** `build_karma_xpu_shot` (engine=xpu — parms re-confirmed live this session). A populated stage is byte-for-byte the old wire path.

## ⚠️ Live verification — owed, inconclusive
A live smoke of the from-scratch build (on an isolated scratch LOP net) **timed out and Houdini went down** — the cold-XPU first cook (stage readback + 5 disk writes) is heavy and approached/exceeded the transport timeout. The probe tested the *existing* builder, not the new routing (which is unit-tested). **Owed:** a careful live end-to-end (lighter verification, no cooking readback). This ties directly to the still-deferred **L8** (main-thread render heaviness).

## Tests
7 new: corpus build+ground, panel-button source-scan, prompt-directive pin, and `shot_render_ready` branch logic (empty→build, populated→wire, param threading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Corpus” action in the panel for quickly activating documentation search data.
  * Improved shot render setup to build a render-ready scene from scratch when no existing chain is available.

* **Bug Fixes**
  * Search and corpus-related tools now reset their state after activation so results reflect the active corpus.
  * Added extra safety guidance to verify node and parameter names before building workflows.

* **Tests**
  * Added coverage for corpus activation and empty-stage render setup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->