### PR TITLE
feat(harness): land H22 prep-harness v2 boundary-synthesis

### DIFF
--- a/docs/H22_READINESS_REPORT.md
+++ b/docs/H22_READINESS_REPORT.md
@@ -1,0 +1,196 @@
+# SYNAPSE → Houdini 22 Readiness Report
+
+**Prepared:** 2026-06-26 · **Drop ETA:** mid-July 2026 (~3 weeks) · **Current:** SYNAPSE v5.15.0 on Houdini 21.0.671, Python 3.11, PySide6
+**Grounding:** code at `C:/Users/User/SYNAPSE`, H21 reference docs at `G:/HOUDINI21_RAG_SYSTEM`. Every claim carries `file:line` (code) or a file path (G:\ docs). All counts live-grepped.
+
+---
+
+## 1. Executive summary + readiness verdict
+
+**Verdict: infrastructure-ready, decision-blocked. SYNAPSE will *not* break on drop day if a human crosses three gates first — but it ships today with one hard import-failure cliff and two real bugs that the existing harness does not yet catch.** The migration machinery is genuinely built: a self-verifying harness (`harness/`), a version-stamped phantom-API gate (`scout.py` + the symbol table), a documented 4-step runbook (`docs/studio/UPGRADE.md`), and a written decision brief on the critical blocker (`harness/notes/gate-0.1-sidecar-vs-abi3.md`). Drop day is "verification, not surgery" **only if** H22 keeps Python 3.11; if it bumps to 3.12/3.13, the vendored Anthropic SDK fails to import and the brain does not wake. That single unknown — SideFX has not announced H22's Python version — is the hinge the whole report turns on.
+
+**Top 3 blockers (ranked by blast radius):**
+
+1. **Vendored-SDK ABI lock → total import failure if Python bumps.** Two native wheels are pinned `cp311-cp311-win_amd64` (NOT abi3): `_vendor/pydantic_core/_pydantic_core.cp311-win_amd64.pyd` (5.0 MB) and `_vendor/jiter/jiter.cp311-win_amd64.pyd` (444 KB). The activation gate at `python/synapse/__init__.py:52` is a hard equality `version_info[:2] == (3, 11)`. On 3.12+ the `.pyd` files are unloadable → `ImportError` → daemon boot fails. This is THE blocker; the sidecar-vs-abi3 decision (`harness/notes/gate-0.1-sidecar-vs-abi3.md`) is unresolved.
+2. **Symbol-table skew → phantom-API gate goes inert.** `python/synapse/cognitive/tools/data/h21_symbol_table.json` is stamped `21.0.671` (33,255 symbols, blake2b `ae7688f80a7076dc1c5b9fb3c05ab53d`). The instant H22's `applicationVersionString()` differs, `gate_stamp.py:31-33` reports stale and every `synapse_scout` verdict flips to `null` (gate disarmed) until regenerated. SYNAPSE's #1 failure class (phantom APIs) goes unguarded during the exact window H22 introduces new/renamed APIs.
+3. **USD punycode parm encodings → silent Solaris write misses.** The H21 docs prove these encodings *already shifted once* (`xn__inputsexposure_fya` → `xn__inputsexposure_vya`, `G:/…/solaris_reference/lighting.md` "Common Mistakes" block). SYNAPSE ships a hardcoded alias→encoded map keyed on `xn__inputsintensity_i0a` / `xn__inputsexposure_vya` etc. If H22's USD bumps the encoding again, every light/camera parm write silently misses with no error.
+
+**Two bugs the harness should catch but doesn't yet** (both surface *before* H22, both headless-fixable now): the symbol-table regen reproduces a `dir()` blind spot for lazily-imported `hou` submodules (`hou.qt` / `hou.text` / `hou.secure`), and Phase-0 task 0.2 (build the probe harness) has been BLOCKED for 7 rounds (`harness/state/claude-progress.md:52-59`) — meaning the drop-day API-delta detector is itself unbuilt.
+
+---
+
+## 2. The migration surface
+
+SYNAPSE's H-API footprint cross-referenced against what the G:\ H21 docs actually document vs. leave undocumented. **Breadth:** 67 files import `hou`; ~666 `hou.*` call-sites, 44 `pdg.*`, 175 `pxr/Usd/Sdf` refs; 89 distinct `createNode()` type-strings.
+
+### Documented + stable (low migration risk)
+These are documented in the G:\ reference and are core USD/Solaris primitives unlikely to churn:
+
+| Surface | Doc grounding | Why stable |
+|---|---|---|
+| LIVRPS composition arcs (`edit`/`reference`/`sublayer`/`inheritsfrom`/`variantset`) | `solaris_reference/usd_stage_composition.md:17-30`, `usd_operations.md:123-146` | LOP-type names are USD-canonical; SideFX has held them across releases |
+| Karma delegate IDs `BRAY_HdKarma` (CPU) / `BRAY_HdKarmaXPU` (XPU) | `api_reference/hydra-delegates.md:220-233` | Plugin IDs, registered via plugInfo.json; renaming breaks every third-party delegate too |
+| `pxr.Usd/Sdf/UsdGeom/UsdShade` core authoring | signatures throughout `solaris_reference/` | The `pxr.Usd` *core* path is version-coupled but API-stable; the fragile part is compiled schemas, not core |
+
+### Undocumented / fragile (the migration payload)
+The docs either pin behavior to "Houdini 21" explicitly, or don't cover SYNAPSE's heaviest surface at all:
+
+| Surface | Code site | Doc signal | Risk |
+|---|---|---|---|
+| **USD punycode parm names** — `xn__inputsintensity_i0a`, `xn__inputsexposure_vya`, `xn__karmasubdivisionmesh_beb`, … | UsdLux/Karma authoring; alias map | `lighting.md` Common-Mistakes block documents a *prior* `_fya`→`_vya` shift; `troubleshooting/common_errors.md:39` lists the mappings SYNAPSE depends on | **Highest functional-break probability.** A namespace-encoding change in H22's USD silently misses every light/parm write |
+| **Legacy COP2 node types** `cop2net` (6 sites), `vopcop2gen` (11 sites) | `server/handlers_cops.py` (verified counts) + `routing/recipes/pipeline_recipes.py:1124` | The G:\ COP doc (`cops_compositing.md`) describes **legacy COP2 only** — H20+ Copernicus (`copnet`, GPU COPs) is **not documented at all**, yet SYNAPSE's heaviest API usage is `hou.Cop*` (301 refs) | **Top deprecation risk.** SideFX is mid-migration COPs→Copernicus; the cop2 types are the most likely removal. Most call-sites have no fallback |
+| **`usdrender` vs `usdrender_rop`** | single-entry alias `server/solaris_compose.py:46` (`{"usdrender": "usdrender_rop"}`) | Docs use both names interchangeably (`solaris_nodes.md:70-72`); bare `usdrender` is already a phantom | Must be re-validated on H22; the alias map is one hardcoded entry |
+| **`SchemasForRenderers` / string-based `HasAPI`** | compiled-schema path (not SYNAPSE's core) | `usd-schema-registration.md:278` verbatim: *"Karma does NOT use SchemasForRenderers in Houdini 21 — Houdini handles the mapping internally"* — behavior **pinned to "21"** | Behavioral carve-out explicitly flagged version-dependent; may flip in H22 |
+| **`houdini21.0` pref-dir / `PXR_PLUGINPATH` path pins** | install/discovery guidance SYNAPSE inherits | 42 version-pinned path occurrences across 15 G:\ files; `pxr-pluginpath.md:97` hardpins `…\Houdini 21.0.512\bin\usdGenSchema.cmd` + `$HOUDINI_USER_PREF_DIR=…/houdini21.0` | Pref dir becomes `houdini22.0`; any path-derivation logic must not hardcode `21.0` |
+| **`hou.qt` / `hou.text` / `hou.secure`** | panel + `host/auth.py`, `host/daemon.py` (`hou.secure` used at 45 sites verified) | Not in the symbol table — lazily-imported submodules `dir()` empty at introspection time | These read as phantoms *today*; see §3 symbol-table axis |
+
+**Version pins that must be bumped on drop:** `memory/ledger.py:63` (`CUTOVER_BUILD = "21.0.631"`), the symbol-table stamp, and `daemon.py:355-367` (`WindowsSelectorEventLoopPolicy` — a Python-3.11-specific workaround).
+
+---
+
+## 3. H22 risk matrix
+
+| Axis | Risk | Likelihood | Blast radius | Evidence |
+|---|---|---|---|---|
+| **Vendored ABI / Python version** | `cp311` `.pyd` won't load on 3.12+ → `ImportError` → brain dead | **Medium** (H20.5/21.0/21.5 all 3.11; H22 unannounced) | **Total** — SYNAPSE won't import at all | `__init__.py:52` `== (3,11)`; `_vendor/{pydantic_core,jiter}-*.dist-info/WHEEL:4` = `Tag: cp311-cp311-win_amd64`; `harness/notes/gate-0.1-sidecar-vs-abi3.md:8` |
+| **Symbol table** | Stamp `21.0.671` ≠ running `22.0.x` → gate disarms, all scout verdicts `null` | **Certain** (any build change trips it) | **Wide but graceful** — phantom-API guard inert, agents fall back to hallucinating; no crash | `h21_symbol_table.json` header; `gate_stamp.py:31-33`; `doctor.py:290-296`; `scout._read_symbol_table` stale path |
+| **Symbol-table blind spot** *(bug, exists today)* | Regen reproduces empty `dir()` for `hou.qt`/`hou.text`/`hou.secure` → real APIs read as phantom | **Certain** (introspector never force-imports lazy submodules) | **Medium** — false-phantoms on 45+ `hou.secure` sites, panel `hou.qt` | `introspect_runtime.py:81-104` calls `_walk(hou,…)` directly, no submodule import; CLAUDE.md §11 even mislabels `hou.secure` a phantom |
+| **USD / pxr** | USD bump changes composition/schema or **punycode parm encoding** | **Medium-High** (encoding already shifted once) | **High, silent** — Solaris light/camera/parm writes miss without error | `lighting.md` `_fya`→`_vya`; `common_errors.md:39`; `boost_python` still used in H21 schema bindings (`usd-schema-registration.md:202`) — USD upstream is migrating off boost, H22 USD bump is the likely trigger |
+| **PySide6 / Qt** | Qt API or event-loop change breaks panel boot / signal marshalling | **Low-Medium** | **High** — no UI, no chat panel; daemon can't marshal to main thread | 29 files `from PySide6`; `hou.qt.mainWindow`/`mimeType`/`color` panel-dock + DnD coupling; G:\ docs carry **zero** PySide/Qt version info (gap) |
+| **hou / pdg API renames** | Node-type or method removal: legacy `cop2net`/`vopcop2gen`; PDG event-callback API | **Medium-High** for COP2; **Low** for PDG core | **High** for COPs (301 `hou.Cop*` refs); narrow for PDG | `handlers_cops.py` (`cop2net`×6, `vopcop2gen`×11); G:\ `cops_compositing.md` documents only legacy COP2, **not** Copernicus; PDG event API is repo-tribal-knowledge, not RAG-covered |
+| **Node-type / parm string drift** | 89 hardcoded `createNode()` strings + 36 `xn__` encoded parms | **Medium** | **Variable** — per-feature break, not systemic | `solaris_compose.py:46` single alias entry; `karma`(196)/`usdrender_rop`(23)/`karmarenderproperties`(22) hardcoded; probe is the intended catch-all but is **unbuilt** (task 0.2 blocked) |
+
+---
+
+## 4. Drop-day runbook
+
+Ordered, leveraging the existing harness. Mode A (now) → Mode B (armed when a human writes `harness/state/drop.json`). Three human gates never auto-crossed (`harness/state/claude-progress.md:16-21`).
+
+**Pre-flight (do before drop — see §5):** resolve gate 0.1, fix the introspector blind spot, build/unblock the probe (task 0.2).
+
+**Day 0 — H22 ships:**
+
+1. **Install H22 clean**, then read the three numbers (the Mode-B trigger inputs):
+   ```powershell
+   & "C:\...\Houdini 22.0.xxx\bin\hython.exe" -c "import sys,pxr,PySide6.QtCore as q; print(sys.version_info[:2], getattr(pxr,'__version__','?'), q.__version__)"
+   ```
+2. **Decide the ABI path (HUMAN GATE 0.1)** based on the Python number:
+   - **Python == 3.11** → vendor survives unchanged. Proceed.
+   - **Python == 3.12+ AND sidecar already staged** → brain immune; just verify the IPC seam (`check_brain_answers`).
+   - **Python == 3.12+ AND status-quo** → re-vendor the 2 wheels for the new `cpXX` (`_vendor/README.md:60-82` refresh command), widen `__init__.py:52` to `(3,11),(3,12)`, update `tests/test_vendored_deps.py`. Small, offline.
+3. **Write `harness/state/drop.json` (HUMAN GATE — Mode-B trigger):**
+   ```json
+   { "python": "3.x", "usd": "Y.Z", "pyside": "6.Q.R", "houdini_build": "22.0.xxx" }
+   ```
+4. **Regenerate the symbol table inside H22** (`docs/studio/UPGRADE.md` Step 1):
+   ```powershell
+   & "...\hython.exe" host\introspect_runtime.py
+   ```
+   Overwrites `h21_symbol_table.json` (~1.1 MB diff). Confirm `TABLE: version=22.0.xxx symbols=~33000 truncated=False`. **Commit it.** Bump `ledger.py:63` `CUTOVER_BUILD`.
+5. **Re-install the SYNAPSE package** into H22's pref dir (`UPGRADE.md` Step 3): `python scripts/install_synapse_package.py`. Confirm no `houdini21.0` path leaked.
+6. **Confirm the gate** (`UPGRADE.md` Step 4): one `synapse_scout` call on `hou.LopNode` → expect `gate_armed: true`, `stale: false`, `exists_in_runtime: true`, panel footer clean.
+
+**Day 0–1 — harness Mode B verification (automated):** tasks 1.3 (`import_panel`+`brain_answers` — brain wakes on H22 Python), 1.4 (fire the probe → `.claude/probe_delta.json`), 1.5 (`doctor` green), 1.6 (`theme_ok` — panel reads H22's theme).
+
+**Day 1–N — patch the deltas (harness loop, max 3 repair rounds/task):** task 2.1 promotes **probe truth over pinned constants** — re-validate `solaris_compose.py:46` alias, the 36 `xn__` encodings, and the `cop2net`/`vopcop2gen` types against the live delta. Tasks 2.2/2.3 (new COPs + Solaris features), 2.5 (provenance ledger on H22's schema).
+
+**Day 7+ — demo (HUMAN GATE):** task 3.1 timed runsheet rehearsal, 3.2 record. **Merge to main is human** (harness commits in worktrees only).
+
+---
+
+## 5. Improvements — do now, before the drop (prioritized, headless-safe)
+
+All verifiable via hython offscreen on H21; none require H22. Ranked by risk-reduction per unit effort.
+
+1. **Fix the introspector submodule blind spot** *(small, high value — this is a live bug)*. Patch `introspect_runtime.py:81-83` to force-import the lazy submodules before `_walk`: `import hou.qt, hou.text, hou.secure` (guarded) so `dir()` captures them. Today scout false-phantoms 45+ real `hou.secure` sites and the panel's `hou.qt.*`; **the H22 regen reproduces the gap unless patched first.** Re-run on H21, confirm the three submodules appear, commit the corrected table. (Side benefit: fixes the CLAUDE.md §11 mislabel of `hou.secure` as phantom.)
+
+2. **Unblock and build task 0.2 — the probe harness** *(medium, critical-path)*. It has been BLOCKED 7 rounds (`claude-progress.md:52-59`). On H21 its delta vs pinned constants should be ~empty — *that empty diff is the proof it works before the drop makes the diff real* (`tasks.json:23`). Without it, drop-day has no automated API-delta detector and §3's node-type/parm drift goes uncaught. Give it the spec it's blocked on, or hand-build it from `scripts/run_apex_verify.py` + `science/apex_probes.py`.
+
+3. **Stage the sidecar skeleton (gate 0.1)** *(larger, converts the #1 blocker from "surgery" to "verification")*. The brief recommends sidecar but says *stage it, don't commit blind* (`gate-0.1-sidecar-vs-abi3.md:38`). The seam is already clean — `cognitive/agent_loop.py` has zero `hou` imports; transports exist (`server/websocket.py`, `server/bridge_endpoint.py`). Build a minimal out-of-process skeleton, re-home the `hou.isUIAvailable()` fork-bomb guard to the host launcher, prove `check_brain_answers` green through IPC on H21, and **measure the unmeasured IPC latency** (`gate-0.1:26` flags ~50-100ms as pure speculation). If it lands, H22's Python version stops mattering entirely.
+
+4. **Pre-stage the re-vendor as a one-command script** *(small insurance)*. Even if sidecar is the target, script the `PYTHONNOUSERSITE=1 hython pip install --target _vendor …` refresh + the `__init__.py:52` gate-widen as a single dry-runnable step, so the status-quo fallback is push-button on drop day.
+
+5. **Audit hardcoded `21.0` / pref-dir assumptions** *(small)*. Grep the install/discovery path for `houdini21.0`, `21.0.512`, literal version strings (303 version-literal hits exist repo-wide). The G:\ docs hardpin these (`pxr-pluginpath.md:97`); make sure none of SYNAPSE's own path derivation inherits the assumption before the pref dir becomes `houdini22.0`.
+
+6. **Single-source the version** *(hygiene, already in flight)*. Task 0.3 PASSed (`claude-progress.md:46`) — `__init__.py:61` now reads `5.15.0`. Keep `VERSION` canonical so the drop-day stamp bumps don't desync.
+
+---
+
+## 6. What the G:\ docs could NOT tell us
+
+The H21 corpus is the wrong instrument for H22 facts, and it is honest about it. Confirmed gaps (whole-tree searches returned zero):
+
+- **Python version: never stated.** The only match is a stale doxygen placeholder `…\Houdini X.Y.ZZZ\houdini\python3.7libs` (`hengine21.0/_h_a_p_i__python.html:104`). The docs don't even document H21's real 3.11 → **zero signal** on a 3.11→3.12/3.13 bump. The ABI hinge is invisible to the corpus.
+- **PySide6 / Qt version: never stated** in the H21 reference. The only Qt doc is the *RAG tool's own* `QT_UPGRADE_SUMMARY.md` (root, 2025-12-17), which targets PySide2/PyQt5→Tkinter — stale, unrelated to SYNAPSE's PySide6, not authoritative.
+- **USD/pxr version number: never stated.** Inferable only indirectly via the `boost_python` tell (`usd-schema-registration.md:202`) — USD upstream is migrating off boost, so an H22 USD bump is the *likely* trigger, but the corpus gives no version to diff against.
+- **No changelog / "what's new" / deprecation index for hou/pdg/Solaris exists** anywhere in the tree. `houdini_docs/` is empty; the topic map `_metadata/semantic_index.json` indexes MPM/VEX/geometry only — no migration topic. The root `CLEANUP_AND_MIGRATION_GUIDE.md` is about the RAG store's own file reorg, not Houdini.
+- **Copernicus (`copnet`, GPU COPs) is undocumented** — the COP doc is legacy COP2, the wrong generation for SYNAPSE's 301 `hou.Cop*` refs.
+- **The 803 SideFXLabs HDA schemas carry zero version stamp** (`semantic_index/sidefxlabs_entries.json`) → silent drift if Labs reships for H22.
+- **The only hard API-version stamp in the entire corpus is HAPI = "Houdini Engine 8.0"** (`hengine21.0/_h_a_p_i__migration.html`, built Fri Sep 19 2025; tiny 3-member deprecated list, none on SYNAPSE's path). Useful precedent only: HAPI versions independently of Houdini's marketing number — H22's ABI bump need not track the "22" label.
+
+**What only a live H22 build resolves** (must be read from the runtime, not the corpus): the Python/USD/PySide triple (write to `drop.json`), the real symbol table (regen via `introspect_runtime.py`), the actual `xn__` parm encodings, whether `cop2net`/`vopcop2gen`/`usdrender` survive, and the probe's API delta. The docs ground *which* surfaces are version-keyed; only H22 grounds *what changed*. **The corpus cannot pre-validate a single H22 API** — it tells you exactly where to point the probe, and nothing more.
+
+---
+
+**Bottom line for the TD:** You have ~3 weeks. The drop-day mechanics are built and the runbook is real. Spend the runway on three headless-safe items — (1) patch the introspector blind spot, (2) unblock task 0.2 so the probe actually exists, (3) stage + latency-test the sidecar skeleton so the Python-bump blocker becomes a non-event. Do those and drop day is genuinely verification, not surgery. Skip them and you're debugging a dead brain and an inert phantom-gate on launch day with the corpus unable to help.
+
+**Key files:** `python/synapse/__init__.py:52` · `python/synapse/cognitive/tools/data/h21_symbol_table.json` · `host/introspect_runtime.py:81-104` · `harness/notes/gate-0.1-sidecar-vs-abi3.md` · `harness/tasks.json` · `harness/state/claude-progress.md:52-59` · `docs/studio/UPGRADE.md` · `python/synapse/server/solaris_compose.py:46` · `python/synapse/server/handlers_cops.py` · `python/synapse/memory/ledger.py:63` · `G:/HOUDINI21_RAG_SYSTEM/documentation/solaris_reference/lighting.md` · `…/troubleshooting/common_errors.md:39` · `…/api_reference/usd-schema-registration.md:278`
+
+---
+
+# Appendix — completeness critique (adversarial)
+
+Verification complete. Every claim below is grounded in files I read this session. Here is the adversarial critique.
+
+---
+
+# Adversarial review: SYNAPSE → H22 Readiness Report
+
+**Bottom line:** the report's architecture is sound and its top-3 blockers are real, but it contains **three ungrounded/inflated numbers**, **one wrong failure-mechanism**, and it **misses four concrete risks** — including the single cheapest high-value prep item (fail-closed drift policy) and a latent punycode bug that already exists in the tree today. Detail with citations:
+
+## A. Claims NOT grounded in the code (accuracy failures)
+
+1. **"301 `hou.Cop*` refs / SYNAPSE's heaviest API usage is `hou.Cop*`" — FABRICATED.** `grep "hou\.Cop"` across the entire repo (worktrees excluded) returns **0**. There is no `hou.Cop*` attribute access anywhere. The actual COP surface is **36 node-type-*string* sites** (`cop2net`×9, `vopcop2gen`×11, `copnet`×6, in `server/handlers_cops.py` + `routing/recipes/pipeline_recipes.py`). The risk is real (legacy COP2 strings are the likeliest removal in the Copernicus migration) but the report **overstates its magnitude ~8× and mislabels the mechanism** — it's `createNode("cop2net")` string drift, not Python-API-attribute removal. The report's "most likely removal" verdict survives; the "301 refs / heaviest API usage" framing does not.
+
+2. **`hou.secure` "45 sites" — inflated.** Actual: **25** in `python/synapse/`, **0** in `host/`. Off by ~80%.
+
+3. **`hou.text` is NOT a symbol-table blind spot.** I queried the live table: `hou.qt`→**False**, `hou.secure`→**False**, but **`hou.text`→True** (it IS present). The report lists all three as blind-spot false-phantoms; only two qualify. The §5 fix is still correct (force-import `hou.qt`, `hou.secure` before `_walk` in `introspect_runtime.py:81-83`), just drop `hou.text` from the list.
+
+4. **"task 0.2 BLOCKED for 7 rounds" — misread.** `claude-progress.md` logs **"BLOCKED after 3 rounds"** (the repair-round cap), emitted ~8 times across 2026-06-25. It's "3 repair rounds, re-logged," not 7. The blocked-ness is real; the number is wrong.
+
+5. **Wrong failure *mechanism* on the #1 blocker.** The report says on Python 3.12+ "the `.pyd` files are unloadable → ImportError." Not what happens. `__init__.py:51-57` gates the vendor dir behind `version_info[:2] == (3, 11) and platform.startswith("win")`. On 3.12+ the gate is **False**, so `_vendor/` is **never prepended** — the `.pyd` is never even *attempted*. The real failure is `ModuleNotFoundError: anthropic` (plus httpx/pydantic/anyio — the *entire* vendored stack vanishes, not just the 2 native wheels), because Houdini ships none of them. Outcome (dead brain) is right; mechanism is wrong, and it matters: the fix is **gate-widen + re-vendor**, not just "re-vendor the 2 wheels" — which the runbook gets right but the blocker narrative contradicts. (The gate also means **Linux/macOS seats never load the vendor at all** — `platform.startswith("win")` — an existing portability cliff the report omits.)
+
+6. Minor breadth drift: "67 files import hou" → actual **78**; "89 createNode strings" → ~**79**. Directionally fine.
+
+## B. Missed risks (real, grounded, H22-relevant)
+
+1. **LATENT BUG TODAY: three punycode maps disagree on the same parm.** This is the strongest finding. SYNAPSE hardcodes `inputs:color` as **two different encodings in three files**:
+   - `agent/specialist_modes.py:94` + `mcp/server.py` → `xn__inputscolor_vya`
+   - `core/aliases.py:173` → `xn__inputscolor_kya`
+   - and `color_control`: `specialist_modes.py:95` `…_control_wcb` vs `aliases.py:175` `…_control_r0b`.
+   
+   There is **no single source of truth** for the punycode surface — it's copy-pasted across ≥3 maps and **has already drifted**. At least one encoding is wrong on H21 *right now* (or they silently target different light schemas with no comment saying so). The report flags "USD encoding may shift in H22" but misses that the map is **already internally inconsistent** — which means the H22 USD bump won't just shift one table, it'll detonate a surface that has no canonical version to regenerate against. **Prep:** collapse to one generated map (derive from `prim.GetAttributes()` via a probe), don't hand-maintain three.
+
+2. **`asyncio.WindowsSelectorEventLoopPolicy` / `set_event_loop_policy` is itself deprecated in newer CPython.** Grounded at `python/synapse/host/daemon.py:363-366` (the report's `daemon.py:355-367` cite is correct in range but abbreviates the path; it's `python/synapse/host/daemon.py`, and the gate-0.1 brief uses the same short form). The report and the brief both treat this as "a 3.11 workaround to bump." Neither flags that `set_event_loop_policy` and the policy classes are **deprecation-warned in Python 3.12+ and slated for removal** — so if H22 bumps Python, this code doesn't just need a version bump, it may emit DeprecationWarnings or break outright and needs rewriting to `asyncio.Runner`/explicit loop-factory. Concrete, not cosmetic.
+
+3. **PySide6 unscoped-enum exposure — the specific Qt mechanism the report hand-waves.** Report rates PySide6 "Low-Medium" with no mechanism. The concrete one: **29 files** import PySide6, and `panel/` uses **unscoped enum shortcuts** heavily — `Qt.AlignLeft`×8, `Qt.AlignVCenter`×9, `Qt.NoPen`×10, `Qt.AlignCenter`×5, `Qt.AlignRight`×3. PySide6 tightened enum scoping across 6.x; a multi-version PySide6 jump in H22 can turn these into `AttributeError` (requiring `Qt.AlignmentFlag.AlignLeft`). This is a countable, grep-able pre-drop fix, not a vague "Qt API may change." Plus `hou.qt` (the panel↔Houdini bridge) is one of the genuinely-absent symbol-table entries — so the panel's bridge reads as phantom AND its enum usage is fragile.
+
+4. **MaterialX is effectively unaddressed.** The user named it; the report mentions it only in passing. SYNAPSE hardcodes MaterialX node-type strings — `mtlxstandard_surface`, `mtlxgeompropvalue`, `mtlximage`, `mtlxnormalmap`, `mtlxstandard_volume` (in `handlers_material.py`, `solaris_compose_tools.py`, recipes). MaterialX ships **inside USD** and its version moves with the USD bump — exactly the H22 trigger. New required inputs or node renames silently break shader builds. This belongs in the risk matrix as its own row, not folded into "89 createNode strings."
+
+5. **Karma render: the report flags the wrong layer as stable.** It calls Karma "low risk" because the **delegate IDs** (`BRAY_HdKarma`) are stable — true. But SYNAPSE's actual fragility is the **render-settings parm names**, which it guesses by hardcoded list: `handlers_render.py:114` tries `("renderer","karmarenderertype","renderengine")`; `solaris_compose_tools.py:12` depends on `productName`/`picture` fallback; `handlers_render.py:536` has a husk-no-op fallback. Your own memory notes already record that on H21 `productName` doesn't author the prim and husk silently no-ops on Indie. Those parm-name assumptions are the H22-fragile part, and the report's "stable/low" verdict points at the one part that *won't* move.
+
+6. **PDG event bridge has two divergent implementations, one contradicting live recon.** `shared/bridge.py:601` subclasses `pdg.PyEventHandler`; `host/tops_bridge.py:484` calls the **constructor** `pdg.PyEventHandler(on_pdg_event)`. Your own recon memory says "`PyEventHandler(fn)` has no constructor — register a RAW callable." So one of these two is already on thin ice, and the PDG event-callback API (worker-thread firing, `event.node.name`, 2-arg `addEventHandler`) is precisely the undocumented, version-tribal surface H22 can shift. The report rates PDG "Low" and cites it as "repo-tribal-knowledge" — fair — but misses that the repo holds two contradictory call patterns *today*, so an H22 PDG change breaks at least one with no shared abstraction to fix in one place.
+
+## C. The single highest-value prep item the report under-emphasizes
+
+**Flip the scout drift policy to fail-closed (`SYNAPSE_SCOUT_DRIFT_POLICY=refuse`) as a pre-drop decision — the report omits this entirely.** `docs/studio/UPGRADE.md` documents it: under the **default `warn`**, the instant H22's version string differs, **every** scout verdict silently degrades to `null` and agents resume hallucinating phantom APIs — during the exact week API drift peaks — with only a panel-footer warning. The report calls this degradation "graceful." It's the opposite: it's the #1 failure class (phantom APIs) re-arming silently. `refuse` makes scout **raise** instead, forcing the regen before any ungrounded `hou.*` ships. Near-zero effort, directly defends the system's stated top risk, and the report never mentions the knob exists.
+
+Runner-up: the report buries **stage + latency-test the sidecar skeleton** at §5 #3 and calls it "larger," yet §1 admits the whole report "turns on" H22's Python number — and the gate-0.1 brief's own recommendation is "default to sidecar, stage it, don't commit blind." The sidecar is the *only* item that makes the Python number **irrelevant** (the `agent_loop.py` seam is already zero-`hou`, transports already exist). With 3 weeks, that's a #1, not a #3 — *unless* you bet H22 stays on 3.11 (plausible: H20.5/21.0/21.5 all 3.11), in which case the brief is right that sidecar is over-investment and the probe/regen detection items win. The report should surface that bet explicitly rather than ranking by effort.
+
+## D. One structural reassurance the report misses (in its favor)
+
+The symbol-table regen is **decoupled from the ABI cliff** — and the report never says so. `host/introspect_runtime.py` imports only `hou`/`pdg`/`pxr` (lines 81-104); it does **not** import `synapse` or the vendored SDK. So even if the Python bump kills the brain, you can **still arm the phantom-gate**. The two top blockers are independent failure domains — worth stating, because it means drop-day can restore the safety gate before fixing the brain.
+
+**Net:** keep blockers #1–#3, but (a) fix the COP "301 hou.Cop*" fabrication and the ImportError-mechanism error, (b) add punycode-divergence / MaterialX / PySide6-enum / asyncio-policy-deprecation as first-class rows, (c) re-aim the Karma verdict at parm names not delegate IDs, and (d) add "set drift policy to `refuse`" as the cheapest §5 item.
+
+**Files grounding this critique:** `python/synapse/__init__.py:51-57` · `python/synapse/_vendor/{jiter,pydantic_core}-*.dist-info/WHEEL` (Tag: `cp311-cp311-win_amd64`) · `python/synapse/cognitive/tools/data/h21_symbol_table.json` (`21.0.671`, 33255 sym) · `host/introspect_runtime.py:81-104` · `docs/studio/UPGRADE.md` (Step 1 + `SYNAPSE_SCOUT_DRIFT_POLICY=refuse`) · `python/synapse/host/daemon.py:363-366` · `python/synapse/agent/specialist_modes.py:94-95` vs `python/synapse/core/aliases.py:173-175` vs `python/synapse/mcp/server.py` (punycode `vya`/`kya`, `wcb`/`r0b`) · `python/synapse/server/handlers_render.py:110-114,536` · `python/synapse/server/solaris_compose_tools.py:12` · `python/synapse/server/handlers_cops.py` (`cop2net`/`vopcop2gen`/`copnet`) · `shared/bridge.py:601` vs `python/synapse/host/tops_bridge.py:484` · `python/synapse/panel/gate_stamp.py` · `python/synapse/memory/ledger.py:63` · `harness/notes/gate-0.1-sidecar-vs-abi3.md` · `harness/state/claude-progress.md` (0.2 "BLOCKED after 3 rounds") · `harness/tasks.json`.

--- a/docs/SYNAPSE_H22_BOUNDARY.md
+++ b/docs/SYNAPSE_H22_BOUNDARY.md
@@ -1,0 +1,196 @@
+# SYNAPSE × Houdini 22 — The Boundary
+
+**`SYNAPSE_H22_BOUNDARY.md`**
+
+> **Status:** DRAFT — awaiting human ratification (flip DRAFT → **ratified** to unlock FORGE wiring of `2.7`/`2.8`).
+> **Owner:** Joe Ibrahim
+> **Implemented by:** [`SYNAPSE_H22_PROVIDER_APEX.md`](SYNAPSE_H22_PROVIDER_APEX.md) (D-H22-1 / D-H22-2 / D-H22-4)
+> **Enforced by:** `harness/verify/checks.py` guardrails + the `guardrails` block in `harness/tasks.json`
+> **Context:** H22 drop ETA mid-July 2026 (~3 weeks out) · grounded against SYNAPSE on Houdini 21.0.671
+> **Compiled:** 2026-06-27
+
+---
+
+## 1 · Why this doc exists
+
+Houdini 22 ships a **native APEX MCP** — SideFX's own Model Context Protocol server that makes an
+LLM fluent in APEX (the rigging/graph authoring language). That is the first time a first-party
+Houdini surface overlaps SYNAPSE's territory, and it forces one existential question:
+
+> When the vendor ships a tool that generates APEX better than we ever could, what is SYNAPSE *for*?
+
+Answer it wrong — by racing the MCP on APEX fluency — and SYNAPSE becomes a worse copy of a
+first-party tool. Answer it right and the MCP becomes **an input that makes SYNAPSE stronger**.
+This document draws that line once, names the decisions it implies (D-H22-1…4), and the non-goals
+that protect it. Every guardrail in the harness exists to keep a future change — ours or a
+Generator round's — from quietly crossing it.
+
+---
+
+## 2 · The thesis
+
+> **The native APEX MCP makes the model *fluent*. SYNAPSE makes it *accountable*.**
+> **Orchestrate it as one source among many. Never compete with it, never reimplement it.**
+
+Fluency is a commodity the moment the vendor ships it. Accountability is not, and it is exactly
+what an LLM acting on a live scene lacks: a record of *who decided what, what was actually
+observed, and how to undo it*. SYNAPSE's moat is three things the APEX MCP structurally cannot
+provide alone:
+
+1. **Receipts** — every mutation is undo-wrapped and written to `agent.usd` with `decision` +
+   `reasoning` + `revert`. *No ledger entry ⇒ it didn't happen.*
+2. **Cross-context breadth** — SYNAPSE authors across COP / LOP / SOP / Karma / USD. An APEX-only
+   MCP is a single domain; SYNAPSE is the orchestrator that spans them.
+3. **Runtime truth** — `synapse_scout`'s `exists_in_runtime` flag is decided by a `dir()`
+   introspection of the *live* build, not by a corpus. It is the front-line defense against
+   phantom APIs — and it stays authoritative even over the MCP's own claims.
+
+The MCP plugs into #1–#3; it does not replace them.
+
+---
+
+## 3 · The two roles
+
+### 3.1 The native APEX MCP — a first-party source SYNAPSE consumes
+A registered **provider**, peer to the model providers (Opus / Sonnet / Gemini / Nemotron). It
+answers "what is valid APEX?" with first-party authority. SYNAPSE calls it, never special-cases
+it, and never relabels its output as SYNAPSE's own work.
+
+### 3.2 SYNAPSE — the orchestrator of record
+The layer that decides *which* source to call, wraps every result in the truth contract, lands the
+consequential ones in `agent.usd`, and keeps the whole action reversible. SYNAPSE is where the
+receipts live. That is the product.
+
+---
+
+## 4 · D-H22-1 — Register the MCP as a truth-contract-wrapped provider
+
+**Decision.** The APEX MCP is registered as a first-class provider (`providers.get("apex_mcp")`),
+and every tool call returns a **truth-contract envelope** — normalized on the native
+Anthropic-shaped envelope, *not* a gateway.
+
+The envelope records what was actually observed:
+
+| field | meaning |
+|---|---|
+| `observed` | the raw tool result as returned by the MCP — never synthesized |
+| `claimed` | present only if the handler asserts beyond `observed`; **must equal `observed`** or the contract is violated |
+| `validator_verdict` | the MCP's own "is this valid APEX?" result — carried as a provenance **input**, never restated as a SYNAPSE judgment (see below) |
+| `source` / `tool` / `args_digest` / `ts` | provenance metadata |
+
+**The two-question rule.** *Theirs* answers "is this valid APEX?"; *the truth contract* answers
+"did the handler observe what it claims?" Two different questions. SYNAPSE records both and conflates
+neither — the MCP's verdict rides into `agent.usd` as `synapse:validator_verdict` (provenance, not
+authorship), alongside `decision` + `reasoning` + `revert`.
+
+**Why.** This is the concrete form of "fluent vs accountable." It puts the MCP's output *inside*
+the contract and the ledger without SYNAPSE pretending to have authored or validated it.
+
+**Verified by.** `check_mcp_registered`, `check_mcp_truth_contract`, `check_ledger` · tasks
+scaffold `0.8` (mock) → wire `2.7` (shipped).
+
+---
+
+## 5 · D-H22-2 — Scout federates the MCP; SYNAPSE owns no APEX corpus
+
+**Decision.** `synapse_scout` federates the APEX MCP as a knowledge source. `server/scout_sources.json`
+declares the APEX source with `"kind": "provider"` pointing at `apex_mcp`. SYNAPSE builds and
+maintains **no local APEX-syntax corpus** that competes with the first-party source.
+
+**Why.** A corpus we maintain would be perpetually one drop behind the vendor's ground truth — the
+exact staleness `exists_in_runtime` was built to kill. Federate the authority; don't fork it. Scout's
+own differentiators stay intact and authoritative: `exists_in_runtime` (`dir()`-introspected against
+the live runtime) and the cross-context breadth (SOP/LOP/COP/Karma/USD) an APEX-only MCP will never
+cover. Every federated hit carries `source: "apex_mcp"` and an `exists_in_runtime` flag.
+
+**Verified by.** `check_scout_federates` (source-tagged + `exists_in_runtime` present),
+`check_scout_no_apex_corpus` (standing guardrail) · tasks scaffold `0.9` → wire `2.8`.
+
+---
+
+## 6 · D-H22-3 — Authoring center of gravity stays off rigging/APEX
+
+**Decision.** SYNAPSE's authoring domain is **COP / LOP / SOP / Karma / USD**. Rigging and APEX
+authoring are the native MCP's floor, not SYNAPSE's. The clean signal is a declared
+authoring-domain allowlist (`server/authoring_domains.json`); drift terms (`apex`, `rig`, `rigging`,
+`kinefx`, `muscle`, `cfx`) entering it is a deterministic failure.
+
+**Why.** The fastest way to become a worse copy of the MCP is to slowly grow rigging features
+"because we can." This decision makes that drift *visible and blocked* rather than discovered three
+sprints later. SYNAPSE orchestrates a rig the MCP authored; it does not author the rig.
+
+**Verified by.** `check_no_rigging_drift` (standing guardrail).
+
+---
+
+## 7 · D-H22-4 — Probe the shipped surface; pinned prose is not ground truth
+
+**Decision.** Before any wiring touches the real MCP, `science/mcp_surface_probe.py` enumerates the
+**installed** H22 MCP's actual tool list and diffs it against the recorded surface. `absent` and
+`renamed` endpoints must both be **0** before `2.7`/`2.8` proceed; confirmed-absent endpoints
+**auto-quarantine** without re-litigation.
+
+**Why.** Pre-release documentation is a promise, not an interface. This is the same discipline that
+governs `hou.*`/`pdg.*`/`pxr.*` — the `dir()`-is-a-hard-gate rule — aimed at the MCP's tool surface
+instead of the Python runtime. On H21 the probe points at the mock; an empty diff there proves the
+probe works *before* the drop makes it real.
+
+**Verified by.** `check_mcp_surface_probe` · task `1.7` (gates `2.7`/`2.8`).
+
+---
+
+## 8 · Non-goals — the moat (standing guardrails)
+
+These are the behaviors that erode the boundary. They run on **every** harness task, in addition to
+that task's own `verify` list, so no single Generator round can silently cross the line. A guardrail
+returning `ok:false` is a **deterministic FAIL** (the harness writes a repair ticket and loops
+*before* the adversarial Evaluator is invoked); `ok:null` means "not yet wired" and only **warns**.
+
+| Non-goal | Stated | Enforced by |
+|---|---|---|
+| **Not an APEX implementation** | Reuse the MCP's output; never regenerate APEX ourselves. | (stance; D-H22-1/2 make it structural) |
+| **No APEX corpus in scout** | Federate the first-party source; never fork it into a local corpus. | `scout_no_apex_corpus` *(guardrail)* |
+| **No rigging-authoring drift** | Author COP/LOP/SOP/Karma/USD; rigging is the MCP's floor. | `no_rigging_drift` *(guardrail)* |
+| **No mutation that bypasses the ledger** | Every scene/stage mutation routes through provenance and lands in `agent.usd`. | `provenance_not_bypassed` *(guardrail)* |
+| **No overclaiming an MCP result** | `observed ≥ claimed`; the MCP's verdict is an input, never a SYNAPSE claim. | `check_mcp_truth_contract` *(per D-H22-1 call)* |
+
+If any of these flips false, the moat is leaking. Treat it as a release blocker, not a style note.
+
+---
+
+## 9 · How the harness holds the line
+
+The boundary is not a memo; it is wired into the gate that grinds H22 prep. `run.ts` runs each
+task's `verify` checks **and** the cross-cutting `guardrails` set on every sprint, short-circuiting
+to a repair ticket on any guardrail violation before the Evaluator ever sees the work.
+
+| Directive | Scaffold (Mode A, mock) | Verify (Mode B) | Wire (Mode B) | Checks |
+|---|---|---|---|---|
+| D-H22-1 register provider | `0.8` | — | `2.7` | `mcp_registered`, `mcp_truth_contract`, `ledger` |
+| D-H22-2 scout federates | `0.9` | — | `2.8` | `scout_federates`, `scout_no_apex_corpus` |
+| D-H22-3 no rigging drift | (standing) | (standing) | (standing) | `no_rigging_drift` |
+| D-H22-4 verify surface | (mock diff) | `1.7` | gates `2.7`/`2.8` | `mcp_surface_probe` |
+| Provenance integrity | (standing) | (standing) | (standing) | `provenance_not_bypassed` |
+| Demo with receipts | — | — | `3.3` | `mcp_registered`, `ledger` |
+
+The boundary checks ship as honest scaffolds: until ADAPTed against the real seams
+(`server/providers/apex_mcp.py`, `server/scout_sources.json`, `server/authoring_domains.json`),
+they return `ok:null` and warn — they never fake a pass.
+
+---
+
+## 10 · Staging & ratification
+
+- **Mode A (now, on H21):** scaffold and contract-test the provider seam against the mock
+  (`science/mcp_mock.py`) — tasks `0.8`/`0.9`. This proves the abstraction before H22 exists.
+- **Mode B (drop day, mid-July):** verify the shipped surface (`1.7`), then swap the mock for the
+  real MCP and wire (`2.7`/`2.8`). No design changes — only the endpoint moves.
+
+**Open gates (human-owned):**
+1. **Ratify this document** (DRAFT → ratified) before FORGE wires `2.7`/`2.8`.
+2. **Gold RFC** for `validator_verdict` schema placement in `agent.usd` (`customData` vs a typed USD
+   schema) — do not unilaterally place it.
+3. **D-H22-4 verification** against the shipped H22 build before `2.7`/`2.8` execute.
+
+> Ratification is the human gate the harness will not cross. Until this flips to **ratified**, the
+> boundary is the intended direction; after, it is the enforced contract.

--- a/docs/SYNAPSE_H22_BOUNDARY.md
+++ b/docs/SYNAPSE_H22_BOUNDARY.md
@@ -2,7 +2,7 @@
 
 **`SYNAPSE_H22_BOUNDARY.md`**
 
-> **Status:** DRAFT — awaiting human ratification (flip DRAFT → **ratified** to unlock FORGE wiring of `2.7`/`2.8`).
+> **Status:** **RATIFIED 2026-06-27** (Joe Ibrahim) — the boundary is now the enforced contract. FORGE wiring of `2.7`/`2.8` is unlocked, pending D-H22-4 verification on the shipped build (gate §10.3).
 > **Owner:** Joe Ibrahim
 > **Implemented by:** [`SYNAPSE_H22_PROVIDER_APEX.md`](SYNAPSE_H22_PROVIDER_APEX.md) (D-H22-1 / D-H22-2 / D-H22-4)
 > **Enforced by:** `harness/verify/checks.py` guardrails + the `guardrails` block in `harness/tasks.json`
@@ -187,10 +187,13 @@ they return `ok:null` and warn — they never fake a pass.
   real MCP and wire (`2.7`/`2.8`). No design changes — only the endpoint moves.
 
 **Open gates (human-owned):**
-1. **Ratify this document** (DRAFT → ratified) before FORGE wires `2.7`/`2.8`.
+1. ~~**Ratify this document** (DRAFT → ratified) before FORGE wires `2.7`/`2.8`.~~ ✅ **Ratified 2026-06-27** (Joe Ibrahim).
 2. **Gold RFC** for `validator_verdict` schema placement in `agent.usd` (`customData` vs a typed USD
-   schema) — do not unilaterally place it.
-3. **D-H22-4 verification** against the shipped H22 build before `2.7`/`2.8` execute.
+   schema) — do not unilaterally place it. *(Open — needs Michael Gold.)*
+3. **D-H22-4 verification** against the shipped H22 build before `2.7`/`2.8` execute. *(Open by
+   necessity — needs H22 to exist.)*
 
-> Ratification is the human gate the harness will not cross. Until this flips to **ratified**, the
-> boundary is the intended direction; after, it is the enforced contract.
+> Ratification is the human gate the harness will not cross. As of **2026-06-27** it is ratified:
+> the boundary is no longer the intended direction — it is the enforced contract. The two remaining
+> gates (§10.2, §10.3) stay open out of necessity, not indecision: one needs Michael Gold, the other
+> needs the shipped H22 build.

--- a/docs/SYNAPSE_H22_PROVIDER_APEX.md
+++ b/docs/SYNAPSE_H22_PROVIDER_APEX.md
@@ -1,0 +1,114 @@
+# SYNAPSE × H22 — Native APEX MCP Provider Spec
+
+**`SYNAPSE_H22_PROVIDER_APEX.md`**
+
+> **Status:** DRAFT — design only (ARCHITECT). Wiring (FORGE) is gated on `SYNAPSE_H22_BOUNDARY.md`
+> ratification + D-H22-4 verification against the shipped build.
+> **Owner:** Joe Ibrahim · **Suggested repo path:** `docs/SYNAPSE_H22_PROVIDER_APEX.md`
+> **Implements:** `SYNAPSE_H22_BOUNDARY.md` D-H22-1 / D-H22-2 / D-H22-4
+> **Harness tasks:** scaffold `0.8`/`0.9` (Mode A, mock) → verify `1.7` (Mode B) → wire `2.7`/`2.8` (Mode B) → demo `3.3`
+> **Compiled:** 2026-06-25
+
+---
+
+## 0 · Purpose
+Make SYNAPSE *orchestrate* H22's native APEX MCP as one source among many — never compete with
+it, never reimplement it. The provider seam is the concrete form of "the official MCP makes the
+model fluent; SYNAPSE makes it accountable." Everything below exists to put the MCP's output
+**inside the truth contract and the `agent.usd` ledger.**
+
+---
+
+## 1 · Provider abstraction (normalize on the envelope, not a gateway)
+A provider is a thin adapter that exposes a uniform surface to SYNAPSE's orchestrator. The APEX
+MCP becomes one registered provider alongside the model providers (Opus/Sonnet/Gemini/Nemotron).
+
+- **Registry:** `server/providers/__init__.py` exposes `providers.get("apex_mcp")`. Registration is
+  declarative; the orchestrator never special-cases the MCP.
+- **Normalized on the native Anthropic-shaped envelope** — *not* a gateway like LiteLLM. Same
+  decision as `SYNAPSE_MULTI_PROVIDER_HARNESS_v1.md`: one envelope shape preserves the truth contract.
+- **Mock-first:** `science/mcp_mock.py` stands in for the MCP on H21 — same tool-list shape, benign
+  responses — so `0.8`/`0.9` build and contract-test the seam before H22 exists. Drop day swaps the
+  mock endpoint for the shipped one (verified by `1.7`); no design changes.
+
+```
+orchestrator → providers.get("apex_mcp").call_tool(name, args) → { envelope }
+```
+
+---
+
+## 2 · Truth-contract wrapping
+Every MCP tool call returns an **envelope** that records what was actually observed — a handler
+cannot claim an outcome it didn't see, and that rule extends to provider surfaces.
+
+Envelope (minimum):
+- `observed` — the raw tool result as returned by the MCP (never synthesized).
+- `claimed` — present only if the handler asserts something beyond `observed`; must equal `observed`
+  or the truth contract is violated. (`check_mcp_truth_contract` asserts no overclaim.)
+- `validator_verdict` — the MCP's own "is this valid APEX?" result, **carried as an input**, never
+  restated by SYNAPSE as its own judgment (see §3).
+- `source: "apex_mcp"`, `tool`, `args_digest`, `ts`.
+
+---
+
+## 3 · Validator verdict → provenance (not a Synapse claim)
+The native MCP validates the APEX it generates. SYNAPSE does **not** reimplement APEX validation
+and does **not** relabel that verdict as its own. Instead:
+
+- The verdict rides in the envelope as `validator_verdict`.
+- When an MCP-sourced action mutates the scene/stage, the `agent.usd` ledger entry records it as a
+  provenance **input**: `customData:synapse:validator_verdict` (provenance, not authorship), alongside
+  the usual `decision` + `reasoning` + `revert`.
+- The distinction the Evaluator enforces (rubric 5): *theirs* answers "is this valid APEX?"; *the
+  truth contract* answers "did the handler observe what it claims?" Two different questions; both recorded.
+
+> Schema placement (`customData` vs typed USD schema) for `validator_verdict` is **RFC-only** with
+> Michael Gold — do not unilaterally place it. Track under the Gold schema RFC.
+
+---
+
+## 4 · Scout federation (consume, don't rebuild — D-H22-2)
+`synapse_scout` federates the APEX MCP as a knowledge source; it never owns an APEX-syntax corpus.
+
+- `server/scout_sources.json` declares the APEX source with `"kind": "provider"` pointing at
+  `apex_mcp`. The guardrail `scout_no_apex_corpus` fails the build if a local APEX corpus appears or
+  the source kind isn't `provider`.
+- Scout's own differentiators are untouched and remain authoritative: the `exists_in_runtime` flag
+  (`dir()`-introspected against the live runtime) and cross-context breadth (SOP/LOP/COP/Karma/USD)
+  that an APEX-only MCP will never cover. Every federated hit carries `source: "apex_mcp"` and
+  `exists_in_runtime` (asserted by `check_scout_federates`).
+
+---
+
+## 5 · Shipped-surface probe (D-H22-4 — pre-release prose is not ground truth)
+Before any wiring touches the real MCP, `science/mcp_surface_probe.py` enumerates the **installed**
+H22 MCP's actual tool list and diffs it against the recorded surface:
+
+- On H21 it points at the mock; the diff should be ~empty — that empty diff proves the probe works
+  before the drop makes it real (same logic as `apex_probes.py` task `0.2`).
+- On drop, `absent` and `renamed` endpoints must both be **0** before `2.7`/`2.8` proceed; confirmed-
+  absent endpoints **auto-quarantine** without re-litigation. `check_mcp_surface_probe` gates this.
+
+---
+
+## 6 · Harness mapping
+| Boundary directive | Scaffold (Mode A, mock) | Verify (Mode B) | Wire (Mode B) | Checks |
+|---|---|---|---|---|
+| D-H22-1 register provider | `0.8` | — | `2.7` | `mcp_registered`, `mcp_truth_contract`, `ledger` |
+| D-H22-2 scout federates | `0.9` | — | `2.8` | `scout_federates`, `scout_no_apex_corpus` |
+| D-H22-4 verify surface | (mock diff) | `1.7` | gates `2.7`/`2.8` | `mcp_surface_probe` |
+| §3 verdict-as-provenance | `0.8` | — | `2.7` | `mcp_truth_contract`, `ledger` |
+| demo with receipts | — | — | `3.3` | `mcp_registered`, `ledger` |
+
+---
+
+## 7 · Non-goals (enforced as guardrails)
+- Not an APEX implementation — reuse the MCP's output, never regenerate APEX ourselves.
+- No APEX-syntax corpus in scout — federate (`scout_no_apex_corpus`).
+- No rigging-authoring drift — Synapse authors COP/LOP/SOP/Karma/USD (`no_rigging_drift`).
+- No overclaiming an MCP result — observed ≥ claimed (`mcp_truth_contract`).
+
+## 8 · Open gates
+- Ratify `SYNAPSE_H22_BOUNDARY.md` (flip DRAFT → ratified) before FORGE.
+- Gold RFC for `validator_verdict` schema placement (`customData` vs typed schema).
+- D-H22-4 verification on the shipped H22 build before `2.7`/`2.8` execute.

--- a/docs/SYNAPSE_H22_PROVIDER_APEX.md
+++ b/docs/SYNAPSE_H22_PROVIDER_APEX.md
@@ -2,8 +2,8 @@
 
 **`SYNAPSE_H22_PROVIDER_APEX.md`**
 
-> **Status:** DRAFT — design only (ARCHITECT). Wiring (FORGE) is gated on `SYNAPSE_H22_BOUNDARY.md`
-> ratification + D-H22-4 verification against the shipped build.
+> **Status:** DRAFT — design only (ARCHITECT). Boundary **ratified 2026-06-27**; FORGE wiring now
+> gated only on D-H22-4 verification against the shipped build.
 > **Owner:** Joe Ibrahim · **Suggested repo path:** `docs/SYNAPSE_H22_PROVIDER_APEX.md`
 > **Implements:** `SYNAPSE_H22_BOUNDARY.md` D-H22-1 / D-H22-2 / D-H22-4
 > **Harness tasks:** scaffold `0.8`/`0.9` (Mode A, mock) → verify `1.7` (Mode B) → wire `2.7`/`2.8` (Mode B) → demo `3.3`
@@ -109,6 +109,6 @@ H22 MCP's actual tool list and diffs it against the recorded surface:
 - No overclaiming an MCP result — observed ≥ claimed (`mcp_truth_contract`).
 
 ## 8 · Open gates
-- Ratify `SYNAPSE_H22_BOUNDARY.md` (flip DRAFT → ratified) before FORGE.
+- ~~Ratify `SYNAPSE_H22_BOUNDARY.md` (flip DRAFT → ratified) before FORGE.~~ ✅ Ratified 2026-06-27.
 - Gold RFC for `validator_verdict` schema placement (`customData` vs typed schema).
 - D-H22-4 verification on the shipped H22 build before `2.7`/`2.8` execute.

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,4 +1,4 @@
-# SYNAPSE → H22 harness
+# SYNAPSE → H22 harness  (v2 — boundary-synthesized)
 
 A long-running, self-verifying harness that grinds your H22 preparedness checklist.
 Your own `probe → delta → patch` loop, made autonomous, with an adversarial gate.
@@ -7,14 +7,18 @@ It runs headless for cooks, renders, patches, and worktree commits. It will **no
 to main, decide your architecture, or fire the post-drop pipeline before H22 exists — those
 are deliberate human gates.
 
+**v2 synthesizes `docs/SYNAPSE_H22_BOUNDARY.md`:** orchestrating H22's native APEX MCP is now a
+first-class, drop-week-critical leg (not a stretch), and the boundary's non-goals are enforced
+as cross-cutting guardrails that fail any sprint that erodes the moat.
+
 ## How it runs
 
 **Now (Mode A, on H21):**
 ```bash
 export HYTHON="/path/to/Houdini 21.x/bin/hython"   # Windows: ...\bin\hython.exe
-bun run harness/run.ts            # grinds Phase 0
+bun run harness/run.ts            # grinds Phase 0 (incl. 0.8/0.9 against the mock MCP)
 bun run harness/run.ts --dry      # plan only — see the queue + gates, spawn nothing
-bun run harness/run.ts --task 0.3 # one task
+bun run harness/run.ts --task 0.8 # one task
 ```
 
 **On drop (Mode B, mid-July):** install H22, read the three numbers, then write the trigger:
@@ -27,9 +31,17 @@ bun run harness/run.ts            # probe fires, delta becomes the worklist, loo
 ```
 
 ## The loop
-`fresh Generator (WIP=1) → checks.py (hython · doctor · ledger · render · probe) →
-adversarial Evaluator → PASS or repair-ticket → loop`, capped at `MAX_ROUNDS` (default 3)
-before a task is flagged for you. Passing features wait in worktrees for **your** merge.
+`fresh Generator (WIP=1) → checks.py (hython · doctor · ledger · render · probe · MCP) →
+deterministic guardrail gate → adversarial Evaluator → PASS or repair-ticket → loop`, capped
+at `MAX_ROUNDS` (default 3) before a task is flagged for you. Passing features wait in
+worktrees for **your** merge.
+
+## Guardrails (boundary non-goals — run every sprint)
+`checks.py` runs the `guardrails` set on **every** task in addition to its own `verify` list:
+`scout_no_apex_corpus`, `no_rigging_drift`, `provenance_not_bypassed`. A guardrail with
+`ok:false` is a **deterministic FAIL** — run.ts writes a repair ticket and loops *before*
+the Evaluator is called. A guardrail with `ok:null` ("not wired yet") only **warns**. This is
+how `SYNAPSE_H22_BOUNDARY.md §8` stays true no matter what any Generator round does.
 
 ## The three human gates
 1. **`0.1` sidecar vs abi3** — architecture decision. Harness recommends sidecar, verifies the bridge, doesn't choose.
@@ -39,22 +51,27 @@ before a task is flagged for you. Passing features wait in worktrees for **your*
 ## Files
 | path | role |
 |---|---|
-| `harness/run.ts` | orchestrator — gate loop, worktree routing, Mode A/B switch |
-| `harness/tasks.json` | machine source of truth (sync with the checklist — that's task 0.3) |
+| `harness/run.ts` | orchestrator — gate loop, guardrail short-circuit, worktree routing, Mode A/B switch |
+| `harness/tasks.json` | machine source of truth (sync with the checklist — that's task 0.3); holds `guardrails` |
 | `harness/prompts/generator.md` | fresh-instance builder, WIP=1 |
-| `harness/prompts/evaluator.md` | adversarial Houdini TD — the keystone |
-| `harness/verify/checks.py` | deterministic checks (the Playwright analog) |
-| `harness/state/manifest.schema.json` | verdict / repair-ticket contract |
+| `harness/prompts/evaluator.md` | adversarial Houdini TD — the keystone; 5 rubrics incl. boundary |
+| `harness/verify/checks.py` | deterministic checks (the Playwright analog) + MCP checks + guardrails |
+| `harness/state/manifest.schema.json` | verdict / repair-ticket contract (incl. `boundary` score) |
 | `harness/state/claude-progress.md` | state continuity the Generator reads each boot |
 | `.claude/settings.json` | pre-approved tool allowlist + format hook |
+| `docs/SYNAPSE_H22_BOUNDARY.md` | the boundary doc this harness enforces (the "why") |
+| `docs/SYNAPSE_H22_PROVIDER_APEX.md` | provider-registration spec — what 0.8/2.7 implement |
 | `CLAUDE.md` | distilled conventions (<2,500 tokens, cached) |
 
 ## ADAPT — the only wiring you owe it
-Search the tree for `ADAPT`. The real ones, all in `checks.py` unless noted:
+Search the tree for `ADAPT`. The real ones, mostly in `checks.py`:
 1. **`claude` CLI flags** in `run.ts` `runAgent()` — verify against your `claude --help`.
 2. **Module + bridge ping** — `check_import_panel` / `check_brain_answers` (your real `ping`).
 3. **doctor + probe entrypoints** — how `server/doctor.py` signals green; how `apex_probes.py` writes its delta.
 4. **`agent.usd` schema** — prim type + `decision`/`reasoning`/`revert` attr names in `check_ledger`, and the revert + stage-hash diff in `check_revert_clean`.
 5. **Render** — the USD to render + a real non-black pixel check in `check_render`.
+6. **MCP provider** — `server/providers/apex_mcp.py` registry accessor + tool round-trip envelope (`check_mcp_registered` / `check_mcp_truth_contract`); the mock at `science/mcp_mock.py`; the shipped-surface probe `science/mcp_surface_probe.py` (`check_mcp_surface_probe`).
+7. **Scout federation** — `server/scout_sources.json` (APEX source = federated `provider`) and the query API in `check_scout_federates`.
+8. **Guardrail anchors** — `server/scout_sources.json`, `server/authoring_domains.json`, and the provenance-gateway sentinel in `check_provenance_not_bypassed`.
 
-Until wired, those checks report `ok:false` with a reason — by design. Nothing here fakes a pass.
+Until wired, those checks report `ok:false` (or `ok:null` for guardrails) with a reason — by design. Nothing here fakes a pass.

--- a/harness/tasks.json
+++ b/harness/tasks.json
@@ -1,11 +1,18 @@
 {
-  "_comment": "Machine source of truth for the harness. Human-readable prose lives in the SYNAPSE→H22 checklist HTML; this file is what run.ts executes. Keep the two in sync (that sync IS task 0.3). 'verify' lists the deterministic checks from harness/verify/checks.py that gate the task. 'human_gate' marks a decision the harness must NOT make. 'mode' A runs now on H21; mode B is staged until harness/state/drop.json exists.",
+  "_comment": "Machine source of truth for the harness. Human-readable prose lives in the SYNAPSE→H22 checklist HTML; this file is what run.ts executes. Keep the two in sync (that sync IS task 0.3). 'verify' lists the deterministic checks from harness/verify/checks.py that gate the task. 'human_gate' marks a decision the harness must NOT make. 'mode' A runs now on H21; mode B is staged until harness/state/drop.json exists. v2: grafted with SYNAPSE_H22_BOUNDARY.md — D-H22-1/2/4 are now first-class (and critical), and the boundary non-goals are enforced as cross-cutting guardrails.",
   "checks_vocabulary": [
     "import_panel", "brain_answers", "probe_runs", "probe_clean",
     "version_single_source", "doctor", "cook_existing", "cook_node",
     "hip_opens", "shot_login", "runsheet_present", "clean_install",
-    "nodes_appear", "ledger", "revert_clean", "render", "theme_ok"
+    "nodes_appear", "ledger", "revert_clean", "render", "theme_ok",
+    "mcp_surface_probe", "mcp_registered", "mcp_truth_contract",
+    "scout_federates", "scout_no_apex_corpus", "no_rigging_drift",
+    "provenance_not_bypassed"
   ],
+  "guardrails": {
+    "_comment": "Run on EVERY sprint by checks.py, in addition to the task's own verify list. A guardrail with ok:false ⇒ deterministic FAIL (run.ts short-circuits before the Evaluator and writes a repair ticket). A guardrail with ok:null ⇒ not yet wired ⇒ WARN, never blocks. These enforce SYNAPSE_H22_BOUNDARY.md's non-goals so no Generator round can silently erode the moat: no APEX corpus in scout, no rigging-authoring drift, no mutation that bypasses the ledger.",
+    "checks": ["scout_no_apex_corpus", "no_rigging_drift", "provenance_not_bypassed"]
+  },
   "tasks": [
     {
       "id": "0.1", "phase": "prep", "mode": "A", "crit": true, "layer": "survival",
@@ -53,6 +60,20 @@
       "refs": ["install.py", "synapse_panel.pypanel"],
       "verify": ["clean_install", "nodes_appear"]
     },
+    {
+      "id": "0.8", "phase": "prep", "mode": "A", "crit": true, "layer": "integrate-scaffold",
+      "title": "Scaffold the external-MCP provider seam (truth-contract envelope) against a mock APEX MCP",
+      "refs": ["server/providers/apex_mcp.py", "server/providers/__init__.py", "science/mcp_mock.py", "docs/SYNAPSE_H22_PROVIDER_APEX.md"],
+      "verify": ["mcp_registered", "mcp_truth_contract"],
+      "note": "D-H22-1 scaffold. H22's MCP does not exist yet — build + contract-test the provider abstraction against a mock so drop day is wiring-in, not design. The mock's tool list stands in for the real surface; task 1.7 swaps it for the shipped build. Normalize on the Anthropic-shaped envelope, NOT a gateway."
+    },
+    {
+      "id": "0.9", "phase": "prep", "mode": "A", "crit": true, "layer": "integrate-scaffold",
+      "title": "Wire scout to federate the (mock) APEX MCP — consume, don't rebuild",
+      "refs": ["server/synapse_scout.py", "server/scout_sources.json", "science/mcp_mock.py"],
+      "verify": ["scout_federates", "scout_no_apex_corpus"],
+      "note": "D-H22-2 scaffold. APEX syntax comes ONLY from the federated provider. exists_in_runtime stays authoritative. Scout must own NO APEX-syntax corpus — that is the standing guardrail."
+    },
 
     { "id": "1.1", "mode": "B", "blocked_on": "drop", "crit": true,
       "title": "Install H22 clean + Synapse via package", "human_gate": { "decision": "manual install", "why": "Can't install software that doesn't exist yet." }, "verify": ["clean_install", "nodes_appear"] },
@@ -66,6 +87,11 @@
       "title": "synapse_doctor green on H22", "verify": ["doctor"] },
     { "id": "1.6", "mode": "B", "blocked_on": "drop", "crit": false,
       "title": "Panel reads correctly in H22's new theme", "verify": ["theme_ok"] },
+    { "id": "1.7", "mode": "B", "blocked_on": "drop", "crit": true,
+      "title": "Probe the SHIPPED native APEX MCP tool surface; quarantine absent/renamed endpoints (D-H22-4)",
+      "refs": ["science/mcp_surface_probe.py"],
+      "verify": ["mcp_surface_probe"],
+      "note": "Pre-release prose is NOT ground truth. Introspect the real MCP's tool list on the installed H22 before any wiring. Confirmed-absent endpoints auto-quarantine without re-litigation. Gates 2.7/2.8." },
 
     { "id": "2.1", "mode": "B", "blocked_on": "drop", "crit": true,
       "title": "Patch the probe deltas (promote probe truth over pinned constants)", "verify": ["probe_clean", "cook_existing", "doctor"] },
@@ -79,11 +105,24 @@
       "title": "Provenance proof: both land in agent.usd", "verify": ["ledger", "revert_clean"] },
     { "id": "2.6", "mode": "B", "blocked_on": "drop", "crit": false,
       "title": "Karma XPU render the result on H22", "verify": ["render"] },
+    { "id": "2.7", "mode": "B", "blocked_on": "drop", "crit": true,
+      "title": "Register the shipped APEX MCP as a first-class provider, truth-contract-wrapped, recorded in agent.usd (D-H22-1)",
+      "refs": ["server/providers/apex_mcp.py"],
+      "verify": ["mcp_registered", "mcp_truth_contract", "ledger"],
+      "note": "Swap the mock for the real surface verified by 1.7. Every MCP tool call enters the truth contract; the MCP's own validator verdict lands as a provenance INPUT, never as a Synapse claim. This is the H22 critical-path leg." },
+    { "id": "2.8", "mode": "B", "blocked_on": "drop", "crit": true,
+      "title": "Scout federates the real APEX MCP; no APEX corpus (D-H22-2)",
+      "refs": ["server/synapse_scout.py", "server/scout_sources.json"],
+      "verify": ["scout_federates", "scout_no_apex_corpus"] },
 
     { "id": "3.1", "mode": "B", "blocked_on": "drop", "crit": true,
       "title": "Dry-run the full runsheet, timed", "human_gate": { "decision": "timed rehearsal", "why": "Human-timed; harness can't judge dead air." }, "verify": ["runsheet_present"] },
     { "id": "3.2", "mode": "B", "blocked_on": "drop", "crit": false, "title": "Record the demo", "human_gate": { "decision": "manual capture" }, "verify": [] },
-    { "id": "3.3", "mode": "B", "blocked_on": "drop", "crit": false, "title": "Stretch — Synapse consuming H22's native APEX MCP", "verify": ["import_panel"] },
+    { "id": "3.3", "mode": "B", "blocked_on": "drop", "crit": false,
+      "title": "Demo beat — Synapse orchestrating the native APEX MCP, with receipts",
+      "refs": ["DEMO_SCRIPT.md"],
+      "verify": ["mcp_registered", "ledger"],
+      "note": "Prove leg. Show the boundary live: Synapse calls the native MCP as one source, the call is truth-contract-wrapped and recorded in agent.usd, and is reversible. The receipts are the one thing the native MCP can't do alone — that's the whole pitch." },
     { "id": "3.4", "mode": "B", "blocked_on": "drop", "crit": false, "title": "Capsule the ship state", "human_gate": { "decision": "manual" }, "verify": [] }
   ]
 }

--- a/harness/verify/checks.py
+++ b/harness/verify/checks.py
@@ -228,14 +228,149 @@ def check_theme_ok(ctx):
     # Honest: theme correctness is screenshot + human review. Surface, don't fake-pass.
     return {"ok": False, "detail": "ADAPT/HUMAN: capture panel screenshot in host theme; flagged for visual review, not auto-passed"}
 
+
+def check_mcp_registered(ctx):
+    # D-H22-1: the APEX MCP is registered as a first-class provider and a round-trip tool call
+    # returns a truth-contract-shaped envelope (it carries what was OBSERVED). On H21 this
+    # exercises the provider against the mock. ADAPT: provider registry accessor + a benign tool.
+    code = ("import synapse\n"
+            "try:\n"
+            "    prov = synapse.providers.get('apex_mcp')  # ADAPT registry accessor\n"
+            "    env = prov.call_tool('ping', {})           # ADAPT a benign tool name\n"
+            "    ok = bool(prov) and isinstance(env, dict) and env.get('observed') is not None\n"
+            "    print('MCP-OK' if ok else 'MCP-NO')\n"
+            "except Exception as e:\n"
+            "    print('MCP-ERR', e)")
+    rc, out, err = hython(ctx["hython"], code, ctx["wt"])
+    return {"ok": "MCP-OK" in out, "detail": (out or err).strip()[:500]}
+
+def check_mcp_surface_probe(ctx):
+    # D-H22-4: introspect the native APEX MCP's ACTUAL tool list on the installed build, diff
+    # vs the recorded surface, and quarantine absent/renamed endpoints. Same discipline as
+    # apex_probes, aimed at the MCP's tool surface instead of hou.*. On H21 it points at the
+    # mock (science/mcp_mock.py); the diff should be ~empty — that empty diff proves the probe
+    # works before the drop makes it real.
+    # ADAPT: how mcp_surface_probe.py enumerates the MCP's tools + where it writes the delta.
+    runner = ctx["hython"] or sys.executable
+    rc, out, err = sh([runner, "science/mcp_surface_probe.py", "--diff", "--out",
+                       ".claude/mcp_surface_delta.json"], cwd=ctx["wt"])
+    p = Path(ctx["wt"]) / ".claude/mcp_surface_delta.json"
+    if rc != 0 or not p.exists():
+        return {"ok": False, "detail": (out or err).strip()[:400] or "mcp_surface_probe.py not wired — ADAPT science/mcp_surface_probe.py"}
+    try:
+        d = json.loads(p.read_text())
+        absent, renamed = d.get("absent", []), d.get("renamed", [])
+        ok = not absent and not renamed
+        return {"ok": ok, "detail": f"absent={len(absent)} renamed={len(renamed)} (both must be 0 before wiring)"}
+    except Exception as e:
+        return {"ok": False, "detail": str(e)[:300]}
+
+def check_mcp_truth_contract(ctx):
+    # The handler cannot claim an outcome it didn't observe, and the MCP's own validator verdict
+    # is recorded as a provenance INPUT — never restated as a Synapse claim. ADAPT: envelope fields.
+    code = ("import synapse\n"
+            "try:\n"
+            "    env = synapse.providers.get('apex_mcp').call_tool('validate', {'src': 'noop'})  # ADAPT\n"
+            "    observed = 'observed' in env\n"
+            "    no_overclaim = ('claimed' not in env) or (env.get('claimed') == env.get('observed'))\n"
+            "    verdict_is_input = 'validator_verdict' in env  # the MCP's verdict, carried not asserted\n"
+            "    ok = observed and no_overclaim and verdict_is_input\n"
+            "    print('TC-OK' if ok else 'TC-NO', {'observed': observed, 'verdict_input': verdict_is_input})\n"
+            "except Exception as e:\n"
+            "    print('TC-ERR', e)")
+    rc, out, err = hython(ctx["hython"], code, ctx["wt"])
+    return {"ok": "TC-OK" in out, "detail": (out or err).strip()[:500]}
+
+def check_no_rigging_drift(ctx):
+    # D-H22-3 non-goal: Synapse's authoring center of gravity stays off rigging/APEX — that is
+    # the native MCP's floor. The clean signal is a declared authoring-domain allowlist.
+    # ADAPT: server/authoring_domains.json = {"domains": ["cop","lop","sop","karma","usd"]}.
+    wt = Path(ctx["wt"])
+    allow = wt / "server" / "authoring_domains.json"  # ADAPT path
+    in_scope = {"cop", "cops", "lop", "lops", "sop", "sops", "karma", "usd", "solaris", "mat", "obj"}
+    drift_terms = {"apex", "rig", "rigging", "kinefx", "muscle", "cfx"}
+    if allow.exists():
+        try:
+            decl = {d.lower() for d in json.loads(allow.read_text()).get("domains", [])}
+            drift = decl & drift_terms
+            if drift:
+                return {"ok": False, "detail": f"authoring domains include rigging surface: {sorted(drift)}"}
+            stray = decl - in_scope
+            note = f" (note: undeclared-scope entries {sorted(stray)})" if stray else ""
+            return {"ok": True, "detail": f"authoring domains in-scope: {sorted(decl)}{note}"}
+        except Exception as e:
+            return {"ok": False, "detail": f"authoring_domains.json unreadable: {str(e)[:200]}"}
+    return {"ok": None, "detail": "authoring-domain allowlist not declared yet (ADAPT server/authoring_domains.json)"}
+
+def check_provenance_not_bypassed(ctx):
+    # Non-goal: not a commodity hou.* passthrough. Every scene/stage mutation routes through the
+    # provenance gateway and lands in agent.usd. The rigorous form is a RUNTIME sentinel (perform
+    # a sandboxed mutation, assert the ledger grew by one). Until that's wired this WARNS — it
+    # neither fake-passes nor blocks every sprint.
+    # ADAPT: name the provenance gateway + either a mutation-capable-module manifest (static) or
+    # the sandbox sentinel (runtime, Mode B).
+    return {"ok": None, "detail": "ADAPT: wire the provenance-gateway manifest or the runtime ledger-grew sentinel. Warn-only until then."}
+
+def check_scout_federates(ctx):
+    # D-H22-2: scout returns APEX results tagged as sourced from the federated MCP provider,
+    # and exists_in_runtime remains present + authoritative on every hit. ADAPT: scout query API.
+    code = ("import synapse\n"
+            "try:\n"
+            "    hits = synapse.scout.query('apex rig pose', domains=['apex'])  # ADAPT query API\n"
+            "    src_ok = bool(hits) and all(h.get('source') == 'apex_mcp' for h in hits)\n"
+            "    rt_ok = all('exists_in_runtime' in h for h in hits)\n"
+            "    print('SCOUT-OK' if (src_ok and rt_ok) else 'SCOUT-NO')\n"
+            "except Exception as e:\n"
+            "    print('SCOUT-ERR', e)")
+    rc, out, err = hython(ctx["hython"], code, ctx["wt"])
+    return {"ok": "SCOUT-OK" in out, "detail": (out or err).strip()[:500]}
+
+def check_scout_no_apex_corpus(ctx):
+    # D-H22-2 non-goal: APEX syntax knowledge must come ONLY from the federated MCP, never a
+    # local corpus that competes with the first-party source. ADAPT: scout corpus root + registry.
+    wt = Path(ctx["wt"])
+    forbidden = []
+    for pat in ("**/scout/**/apex*", "**/rag/**/apex*corpus*", "**/corpus/**/apex*"):
+        forbidden += [p for p in wt.glob(pat) if ".git" not in str(p) and "worktrees" not in str(p)]
+    if forbidden:
+        rel = ", ".join(str(p.relative_to(wt)) for p in forbidden[:5])
+        return {"ok": False, "detail": f"local APEX corpus present (must federate, not rebuild): {rel}"}
+    reg = wt / "server" / "scout_sources.json"  # ADAPT path
+    if reg.exists():
+        try:
+            data = json.loads(reg.read_text())
+            apex = data.get("apex") or data.get("APEX")
+            if apex and apex.get("kind") != "provider":
+                return {"ok": False, "detail": f"scout APEX source kind='{apex.get('kind')}' — must be federated 'provider'"}
+            return {"ok": True, "detail": "no local APEX corpus; scout APEX source is federated"}
+        except Exception as e:
+            return {"ok": False, "detail": f"scout_sources.json unreadable: {str(e)[:200]}"}
+    return {"ok": None, "detail": "no APEX corpus found; scout source-registry not wired yet (ADAPT server/scout_sources.json)"}
+
+def run_one(name, task, ctx):
+    fn = DISPATCH.get(name)
+    if not fn:
+        return {"ok": False, "detail": "no check implemented — ADAPT"}
+    if name == "cook_node":
+        return check_cook(ctx, node=(task.get("target_node", "") or "").replace("ADAPT: ", "") or None)
+    return fn(ctx)
+
+
 DISPATCH = {
     "import_panel": check_import_panel, "brain_answers": check_brain_answers,
     "doctor": check_doctor, "probe_runs": check_probe_runs, "probe_clean": check_probe_clean,
     "version_single_source": check_version_single_source, "cook_existing": check_cook,
+    "cook_node": check_cook,  # FIX: was missing → cook_node silently reported "not implemented" on tasks 2.2/2.3
     "hip_opens": check_hip_opens, "shot_login": check_shot_login,
     "runsheet_present": check_runsheet_present, "clean_install": check_clean_install,
     "nodes_appear": check_nodes_appear, "ledger": check_ledger,
     "revert_clean": check_revert_clean, "render": check_render, "theme_ok": check_theme_ok,
+    # v2 — MCP orchestration
+    "mcp_surface_probe": check_mcp_surface_probe, "mcp_registered": check_mcp_registered,
+    "mcp_truth_contract": check_mcp_truth_contract, "scout_federates": check_scout_federates,
+    # v2 — guardrails
+    "scout_no_apex_corpus": check_scout_no_apex_corpus, "no_rigging_drift": check_no_rigging_drift,
+    "provenance_not_bypassed": check_provenance_not_bypassed,
 }
 
 def main():
@@ -246,29 +381,37 @@ def main():
     ap.add_argument("--mode", default="A")
     a = ap.parse_args()
 
-    tasks = json.loads((Path(__file__).resolve().parents[1] / "tasks.json").read_text())["tasks"]
+    doc = json.loads((Path(__file__).resolve().parents[1] / "tasks.json").read_text())
+    tasks = doc["tasks"]
+    guardrail_names = (doc.get("guardrails") or {}).get("checks", [])
     task = next((t for t in tasks if t["id"] == a.task), None)
     if not task:
         print(json.dumps({"verdict": "ERROR", "detail": f"unknown task {a.task}"})); return
 
     ctx = {"wt": a.worktree, "hython": a.hython, "mode": a.mode}
+
+    # task-specific verifies
     facts = {}
     for name in task.get("verify", []):
-        fn = DISPATCH.get(name)
-        if not fn:
-            facts[name] = {"ok": False, "detail": "no check implemented — ADAPT"}
-            continue
-        # cook_node uses the task's target_node; cook_existing uses the default
-        if name == "cook_node":
-            facts[name] = check_cook(ctx, node=task.get("target_node", "").replace("ADAPT: ", "") or None)
-        else:
-            facts[name] = fn(ctx)
+        facts[name] = run_one(name, task, ctx)
 
-    required_ok = all(v.get("ok") for v in facts.values()) if facts else True
+    # cross-cutting guardrails — every sprint
+    guards = {}
+    for name in guardrail_names:
+        guards[name] = run_one(name, task, ctx)
+    violations = [k for k, v in guards.items() if v.get("ok") is False]
+    unwired = [k for k, v in guards.items() if v.get("ok") is None]
+
+    task_ok = all(v.get("ok") for v in facts.values()) if facts else True
+    required_ok = task_ok and not violations
+
     print(json.dumps({
         "task": a.task, "mode": a.mode,
         "verdict": "PASS" if required_ok else "FAIL",
         "checks": facts,
+        "guardrails": guards,
+        "guardrail_violations": violations,
+        "guardrail_unwired": unwired,
     }, indent=2))
 
 if __name__ == "__main__":


### PR DESCRIPTION
Folds the re-bundled **v2 "boundary-synthesized"** H22 prep-harness into `harness/` (its real home) and adds the two H22 design docs. **Review-only — do not merge until the H22 work is ready; promotion to master is a human gate** (per `harness/CLAUDE.md`).

## What & why
The v2 bundle was unpacked to the repo root. Folding it in revealed it was **not** a clean newer copy — its shared check bodies were *older* `ADAPT`-stubs than the live wired harness. So this is an **additive merge, not an overwrite**:

**`harness/verify/checks.py`** — kept every live *wired* check verbatim (real `run_doctor`, `run_apex_verify.py`, `synapse.panel.shot_login`, `get_bridge` — not v2's broken `synapse.ping()` — and `check_clean_install` *with* the 2026-06-24 shipped-surface fix). **Added** v2's 7 boundary checks (`mcp_registered`, `mcp_surface_probe`, `mcp_truth_contract`, `scout_federates`, `scout_no_apex_corpus`, `no_rigging_drift`, `provenance_not_bypassed`) + `run_one` + the guardrails-aware `main`. Boundary checks honestly return `ok:null` ("unwired/warn") until ADAPTed — never fake-pass. Smoke-tested: tasks 0.1 & 0.9 emit valid JSON, zero false guardrail violations.

**`harness/tasks.json`** + **`harness/README.md`** — v2 is a clean superset here, taken whole: D-H22-1/2/4 boundary tasks (0.8/0.9/1.7/2.7/2.8) + the `guardrails` block + matching prose.

**`docs/`** — `H22_READINESS_REPORT.md` and `SYNAPSE_H22_PROVIDER_APEX.md` (the provider-registration spec tasks 0.8/2.7 implement).

## Flags
- `docs/SYNAPSE_H22_BOUNDARY.md` is referenced by tasks.json + README + the boundary checks but was **not in the bundle** — still needs to be authored (follow-up).
- `CLAUDE-FABLE-5.md` (a model system prompt, not repo content) was intentionally left untracked.

Product test surface untouched (no test imports `harness/`); CI runs the full suite as the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Houdini 22 migration readiness documentation with prioritized blockers, risk matrix, and a step-by-step drop-day runbook.
  * Published draft design + boundary documentation for integrating the native APEX MCP as a provider, including guardrails and verification expectations.
* **Bug Fixes**
  * Expanded the harness verification flow with always-on cross-cutting guardrails that fail deterministically on violations and warn when checks aren’t yet wired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->