### PR TITLE
UTILITY FLYWHEEL U.1: wiring-connectivity truth probed, reviewed, and wired into the live path

### DIFF
--- a/.claude/flywheel_u1_findings.json
+++ b/.claude/flywheel_u1_findings.json
@@ -1,0 +1,2601 @@
+{
+ "schema": "flywheel_findings/v1",
+ "task": "U.1",
+ "catalog": {
+  "path": "harness/notes/verified_connectivity_21.0.671.json",
+  "houdini_version": "21.0.671",
+  "blake2b": "c213570959156138a7cda52936fcd2c1"
+ },
+ "summary": {
+  "total_sites": 150,
+  "critical": 0,
+  "by_kind": {
+   "dynamic-index": 3,
+   "index-within-arity": 113,
+   "label-claim-verified": 3,
+   "unresolved-receiver": 31
+  }
+ },
+ "findings": [
+  {
+   "file": "python/synapse/host/graph_builder.py",
+   "line": 157,
+   "call": "setInput",
+   "receiver": "tgt",
+   "receiver_type": null,
+   "index": null,
+   "index_expr": "e.target_input_index",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/panel/system_prompt.py",
+   "line": 107,
+   "call": "setInput",
+   "receiver": "node",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/panel/system_prompt.py",
+   "line": 143,
+   "call": "setInput",
+   "receiver": "new_node",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/panel/system_prompt.py",
+   "line": 144,
+   "call": "setInput",
+   "receiver": "display_node",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 287,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "vellumsolver",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'vellumsolver'",
+   "candidate_keys": [
+    "Dop/vellumsolver",
+    "Sop/vellumsolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 288,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "vellumsolver",
+   "index": 1,
+   "index_expr": "1",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 1 within max_inputs for 'vellumsolver'",
+   "candidate_keys": [
+    "Dop/vellumsolver",
+    "Sop/vellumsolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 300,
+   "call": "setInput",
+   "receiver": "drape",
+   "receiver_type": "vellumdrape",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'vellumdrape'",
+   "candidate_keys": [
+    "Sop/vellumdrape"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 314,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "vellumsolver",
+   "index": 2,
+   "index_expr": "2",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 2 within max_inputs for 'vellumsolver'",
+   "candidate_keys": [
+    "Dop/vellumsolver",
+    "Sop/vellumsolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 328,
+   "call": "setInput",
+   "receiver": "wind",
+   "receiver_type": "vellumconstraintproperty",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'vellumconstraintproperty'",
+   "candidate_keys": [
+    "Dop/vellumconstraintproperty",
+    "Sop/vellumconstraintproperty"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 341,
+   "call": "setInput",
+   "receiver": "cache",
+   "receiver_type": "filecache",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'filecache'",
+   "candidate_keys": [
+    "Lop/filecache",
+    "Sop/filecache",
+    "Sop/filecache::2.0",
+    "Sop/labs::filecache::1.0",
+    "Sop/labs::filecache::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 368,
+   "call": "setInput",
+   "receiver": "asm",
+   "receiver_type": "assemble",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'assemble'",
+   "candidate_keys": [
+    "Sop/assemble"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 370,
+   "call": "setInput",
+   "receiver": "cons",
+   "receiver_type": "rbdconstraintsfromrules",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'rbdconstraintsfromrules'",
+   "candidate_keys": [
+    "Sop/rbdconstraintsfromrules"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 374,
+   "call": "setInput",
+   "receiver": "props",
+   "receiver_type": "rbdconstraintproperties",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'rbdconstraintproperties'",
+   "candidate_keys": [
+    "Sop/rbdconstraintproperties",
+    "Sop/rbdconstraintproperties::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 376,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "rbdbulletsolver",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'rbdbulletsolver'",
+   "candidate_keys": [
+    "Sop/rbdbulletsolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 377,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "rbdbulletsolver",
+   "index": 1,
+   "index_expr": "1",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 1 within max_inputs for 'rbdbulletsolver'",
+   "candidate_keys": [
+    "Sop/rbdbulletsolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 391,
+   "call": "setInput",
+   "receiver": "debris",
+   "receiver_type": "debrissource",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'debrissource'",
+   "candidate_keys": [
+    "Sop/debrissource",
+    "Sop/debrissource::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 404,
+   "call": "setInput",
+   "receiver": "pyro",
+   "receiver_type": "pyrosolver",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pyrosolver'",
+   "candidate_keys": [
+    "Dop/pyrosolver",
+    "Dop/pyrosolver::2.0",
+    "Sop/pyrosolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 417,
+   "call": "setInput",
+   "receiver": "cache",
+   "receiver_type": "filecache",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'filecache'",
+   "candidate_keys": [
+    "Lop/filecache",
+    "Sop/filecache",
+    "Sop/filecache::2.0",
+    "Sop/labs::filecache::1.0",
+    "Sop/labs::filecache::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 540,
+   "call": "setInput",
+   "receiver": "evl",
+   "receiver_type": "oceanevaluate",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'oceanevaluate'",
+   "candidate_keys": [
+    "Sop/oceanevaluate",
+    "Sop/oceanevaluate::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 556,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "flipsolver",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'flipsolver'",
+   "candidate_keys": [
+    "Dop/flipsolver",
+    "Dop/flipsolver::2.0",
+    "Sop/flipsolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 568,
+   "call": "setInput",
+   "receiver": "ww_solve",
+   "receiver_type": "whitewatersolver",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'whitewatersolver'",
+   "candidate_keys": [
+    "Dop/whitewatersolver",
+    "Dop/whitewatersolver::2.0",
+    "Sop/whitewatersolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 570,
+   "call": "setInput",
+   "receiver": "ww_src",
+   "receiver_type": "whitewatersource",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'whitewatersource'",
+   "candidate_keys": [
+    "Sop/whitewatersource",
+    "Sop/whitewatersource::2.0",
+    "Sop/whitewatersource::3.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 597,
+   "call": "setInput",
+   "receiver": "wrangle",
+   "receiver_type": "attribwrangle",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'attribwrangle'",
+   "candidate_keys": [
+    "Lop/attribwrangle",
+    "Sop/attribwrangle"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 600,
+   "call": "setInput",
+   "receiver": "rast",
+   "receiver_type": "volumerasterizeattributes",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'volumerasterizeattributes'",
+   "candidate_keys": [
+    "Sop/volumerasterizeattributes"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 603,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "pyrosolver",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pyrosolver'",
+   "candidate_keys": [
+    "Dop/pyrosolver",
+    "Dop/pyrosolver::2.0",
+    "Sop/pyrosolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 606,
+   "call": "setInput",
+   "receiver": "cache",
+   "receiver_type": "filecache",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'filecache'",
+   "candidate_keys": [
+    "Lop/filecache",
+    "Sop/filecache",
+    "Sop/filecache::2.0",
+    "Sop/labs::filecache::1.0",
+    "Sop/labs::filecache::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 652,
+   "call": "setInput",
+   "receiver": "matlib",
+   "receiver_type": "materiallibrary",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'materiallibrary'",
+   "candidate_keys": [
+    "Lop/materiallibrary"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 655,
+   "call": "setInput",
+   "receiver": "assign",
+   "receiver_type": "assignmaterial",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'assignmaterial'",
+   "candidate_keys": [
+    "Lop/assignmaterial"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 664,
+   "call": "setInput",
+   "receiver": "cam",
+   "receiver_type": "camera",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'camera'",
+   "candidate_keys": [
+    "Lop/camera"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 673,
+   "call": "setInput",
+   "receiver": "key",
+   "receiver_type": "light",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'light'",
+   "candidate_keys": [
+    "Cop/light",
+    "Cop2/light",
+    "Lop/light",
+    "Lop/light::2.0",
+    "Object/light",
+    "VopNet/light"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 676,
+   "call": "setInput",
+   "receiver": "fill",
+   "receiver_type": "light",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'light'",
+   "candidate_keys": [
+    "Cop/light",
+    "Cop2/light",
+    "Lop/light",
+    "Lop/light::2.0",
+    "Object/light",
+    "VopNet/light"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 679,
+   "call": "setInput",
+   "receiver": "rim",
+   "receiver_type": "light",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'light'",
+   "candidate_keys": [
+    "Cop/light",
+    "Cop2/light",
+    "Lop/light",
+    "Lop/light::2.0",
+    "Object/light",
+    "VopNet/light"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 687,
+   "call": "setInput",
+   "receiver": "light",
+   "receiver_type": "light",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'light'",
+   "candidate_keys": [
+    "Cop/light",
+    "Cop2/light",
+    "Lop/light",
+    "Lop/light::2.0",
+    "Object/light",
+    "VopNet/light"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 696,
+   "call": "setInput",
+   "receiver": "rs",
+   "receiver_type": "karmarenderproperties",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'karmarenderproperties'",
+   "candidate_keys": [
+    "Lop/karmarenderproperties"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 699,
+   "call": "setInput",
+   "receiver": "karma",
+   "receiver_type": "karma",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'karma'",
+   "candidate_keys": [
+    "Driver/karma",
+    "Lop/karma",
+    "Lop/labs::karma::1.0",
+    "Lop/labs::karma::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/planner.py",
+   "line": 707,
+   "call": "setInput",
+   "receiver": "out",
+   "receiver_type": "null",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'null'",
+   "candidate_keys": [
+    "Chop/null",
+    "Cop/null",
+    "Cop2/null",
+    "Dop/null",
+    "Driver/null",
+    "Lop/null",
+    "Object/null",
+    "Sop/null",
+    "Top/null",
+    "Vop/null"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 84,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "vellumsolver",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [
+    "Vellum Geometry"
+   ],
+   "severity": "INFO",
+   "kind": "label-claim-verified",
+   "detail": "comment label claim matches catalog label at index 0",
+   "candidate_keys": [
+    "Dop/vellumsolver",
+    "Sop/vellumsolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 86,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "vellumsolver",
+   "index": 1,
+   "index_expr": "1",
+   "claimed_labels": [
+    "Constraint Geometry"
+   ],
+   "severity": "INFO",
+   "kind": "label-claim-verified",
+   "detail": "comment label claim matches catalog label at index 1",
+   "candidate_keys": [
+    "Dop/vellumsolver",
+    "Sop/vellumsolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 90,
+   "call": "setInput",
+   "receiver": "cache",
+   "receiver_type": "filecache",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'filecache'",
+   "candidate_keys": [
+    "Lop/filecache",
+    "Sop/filecache",
+    "Sop/filecache::2.0",
+    "Sop/labs::filecache::1.0",
+    "Sop/labs::filecache::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 133,
+   "call": "setInput",
+   "receiver": "asm",
+   "receiver_type": "assemble",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'assemble'",
+   "candidate_keys": [
+    "Sop/assemble"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 136,
+   "call": "setInput",
+   "receiver": "cons",
+   "receiver_type": "rbdconstraintsfromrules",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'rbdconstraintsfromrules'",
+   "candidate_keys": [
+    "Sop/rbdconstraintsfromrules"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 141,
+   "call": "setInput",
+   "receiver": "props",
+   "receiver_type": "rbdconstraintproperties",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'rbdconstraintproperties'",
+   "candidate_keys": [
+    "Sop/rbdconstraintproperties",
+    "Sop/rbdconstraintproperties::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 144,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "rbdbulletsolver",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'rbdbulletsolver'",
+   "candidate_keys": [
+    "Sop/rbdbulletsolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 146,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "rbdbulletsolver",
+   "index": 1,
+   "index_expr": "1",
+   "claimed_labels": [
+    "Constraint Geometry"
+   ],
+   "severity": "INFO",
+   "kind": "label-claim-verified",
+   "detail": "comment label claim matches catalog label at index 1",
+   "candidate_keys": [
+    "Sop/rbdbulletsolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 150,
+   "call": "setInput",
+   "receiver": "cache",
+   "receiver_type": "filecache",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'filecache'",
+   "candidate_keys": [
+    "Lop/filecache",
+    "Sop/filecache",
+    "Sop/filecache::2.0",
+    "Sop/labs::filecache::1.0",
+    "Sop/labs::filecache::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 193,
+   "call": "setInput",
+   "receiver": "evl",
+   "receiver_type": "oceanevaluate",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'oceanevaluate'",
+   "candidate_keys": [
+    "Sop/oceanevaluate",
+    "Sop/oceanevaluate::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 196,
+   "call": "setInput",
+   "receiver": "out",
+   "receiver_type": "null",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'null'",
+   "candidate_keys": [
+    "Chop/null",
+    "Cop/null",
+    "Cop2/null",
+    "Dop/null",
+    "Driver/null",
+    "Lop/null",
+    "Object/null",
+    "Sop/null",
+    "Top/null",
+    "Vop/null"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 243,
+   "call": "setInput",
+   "receiver": "wrangle",
+   "receiver_type": "attribwrangle",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'attribwrangle'",
+   "candidate_keys": [
+    "Lop/attribwrangle",
+    "Sop/attribwrangle"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 248,
+   "call": "setInput",
+   "receiver": "rast",
+   "receiver_type": "volumerasterizeattributes",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'volumerasterizeattributes'",
+   "candidate_keys": [
+    "Sop/volumerasterizeattributes"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 254,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "pyrosolver",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pyrosolver'",
+   "candidate_keys": [
+    "Dop/pyrosolver",
+    "Dop/pyrosolver::2.0",
+    "Sop/pyrosolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 258,
+   "call": "setInput",
+   "receiver": "cache",
+   "receiver_type": "filecache",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'filecache'",
+   "candidate_keys": [
+    "Lop/filecache",
+    "Sop/filecache",
+    "Sop/filecache::2.0",
+    "Sop/labs::filecache::1.0",
+    "Sop/labs::filecache::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 300,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "vellumsolver",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'vellumsolver'",
+   "candidate_keys": [
+    "Dop/vellumsolver",
+    "Sop/vellumsolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 301,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "vellumsolver",
+   "index": 1,
+   "index_expr": "1",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 1 within max_inputs for 'vellumsolver'",
+   "candidate_keys": [
+    "Dop/vellumsolver",
+    "Sop/vellumsolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 305,
+   "call": "setInput",
+   "receiver": "cache",
+   "receiver_type": "filecache",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'filecache'",
+   "candidate_keys": [
+    "Lop/filecache",
+    "Sop/filecache",
+    "Sop/filecache::2.0",
+    "Sop/labs::filecache::1.0",
+    "Sop/labs::filecache::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 355,
+   "call": "setInput",
+   "receiver": "merge",
+   "receiver_type": "merge",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'merge'",
+   "candidate_keys": [
+    "Chop/merge",
+    "Cop2/merge",
+    "Dop/merge",
+    "Driver/merge",
+    "Lop/merge",
+    "Sop/merge",
+    "Top/merge"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 358,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "rigidbodysolver",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'rigidbodysolver'",
+   "candidate_keys": [
+    "Dop/rigidbodysolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 359,
+   "call": "setInput",
+   "receiver": "solver",
+   "receiver_type": "rigidbodysolver",
+   "index": 1,
+   "index_expr": "1",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 1 within max_inputs for 'rigidbodysolver'",
+   "candidate_keys": [
+    "Dop/rigidbodysolver"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/fx_recipes.py",
+   "line": 363,
+   "call": "setInput",
+   "receiver": "out",
+   "receiver_type": "output",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'output'",
+   "candidate_keys": [
+    "Chop/output",
+    "Cop/output",
+    "Dop/output",
+    "Lop/output",
+    "Sop/output",
+    "Top/output",
+    "Vop/output"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 115,
+   "call": "setInput",
+   "receiver": "cache",
+   "receiver_type": "filecache",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'filecache'",
+   "candidate_keys": [
+    "Lop/filecache",
+    "Sop/filecache",
+    "Sop/filecache::2.0",
+    "Sop/labs::filecache::1.0",
+    "Sop/labs::filecache::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 181,
+   "call": "setInput",
+   "receiver": "output_null",
+   "receiver_type": "null",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'null'",
+   "candidate_keys": [
+    "Chop/null",
+    "Cop/null",
+    "Cop2/null",
+    "Dop/null",
+    "Driver/null",
+    "Lop/null",
+    "Object/null",
+    "Sop/null",
+    "Top/null",
+    "Vop/null"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 184,
+   "call": "setInput",
+   "receiver": "input_null",
+   "receiver_type": "null",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'null'",
+   "candidate_keys": [
+    "Chop/null",
+    "Cop/null",
+    "Cop2/null",
+    "Dop/null",
+    "Driver/null",
+    "Lop/null",
+    "Object/null",
+    "Sop/null",
+    "Top/null",
+    "Vop/null"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 307,
+   "call": "setInput",
+   "receiver": "edit_props",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 310,
+   "call": "setInput",
+   "receiver": "config_prim",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 414,
+   "call": "setInput",
+   "receiver": "karma_props",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 425,
+   "call": "setInput",
+   "receiver": "edit_res",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 698,
+   "call": "setInput",
+   "receiver": "wrangle",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 703,
+   "call": "setInput",
+   "receiver": "output_null",
+   "receiver_type": "null",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'null'",
+   "candidate_keys": [
+    "Chop/null",
+    "Cop/null",
+    "Cop2/null",
+    "Dop/null",
+    "Driver/null",
+    "Lop/null",
+    "Object/null",
+    "Sop/null",
+    "Top/null",
+    "Vop/null"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 706,
+   "call": "setInput",
+   "receiver": "input_null",
+   "receiver_type": "null",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'null'",
+   "candidate_keys": [
+    "Chop/null",
+    "Cop/null",
+    "Cop2/null",
+    "Dop/null",
+    "Driver/null",
+    "Lop/null",
+    "Object/null",
+    "Sop/null",
+    "Top/null",
+    "Vop/null"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 832,
+   "call": "setInput",
+   "receiver": "matlib",
+   "receiver_type": "materiallibrary",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'materiallibrary'",
+   "candidate_keys": [
+    "Lop/materiallibrary"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 847,
+   "call": "setInput",
+   "receiver": "skin_out",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 859,
+   "call": "setInput",
+   "receiver": "cloth_out",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 870,
+   "call": "setInput",
+   "receiver": "hair_out",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 877,
+   "call": "setInput",
+   "receiver": "cloth_import",
+   "receiver_type": "sopimport",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'sopimport'",
+   "candidate_keys": [
+    "Cop/sopimport",
+    "Cop2/sopimport",
+    "Lop/sopimport"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 883,
+   "call": "setInput",
+   "receiver": "rendergeo",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 899,
+   "call": "setInput",
+   "receiver": "configure",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 962,
+   "call": "setInput",
+   "receiver": "shot_layer",
+   "receiver_type": "sublayer",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'sublayer'",
+   "candidate_keys": [
+    "Lop/sublayer"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 972,
+   "call": "setInput",
+   "receiver": "cam",
+   "receiver_type": "camera",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'camera'",
+   "candidate_keys": [
+    "Lop/camera"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 977,
+   "call": "setInput",
+   "receiver": "light_layer",
+   "receiver_type": "sublayer",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'sublayer'",
+   "candidate_keys": [
+    "Lop/sublayer"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 992,
+   "call": "setInput",
+   "receiver": "light_merge",
+   "receiver_type": "merge",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'merge'",
+   "candidate_keys": [
+    "Chop/merge",
+    "Cop2/merge",
+    "Dop/merge",
+    "Driver/merge",
+    "Lop/merge",
+    "Sop/merge",
+    "Top/merge"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 993,
+   "call": "setInput",
+   "receiver": "light_merge",
+   "receiver_type": "merge",
+   "index": 1,
+   "index_expr": "1",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 1 within max_inputs for 'merge'",
+   "candidate_keys": [
+    "Chop/merge",
+    "Cop2/merge",
+    "Dop/merge",
+    "Driver/merge",
+    "Lop/merge",
+    "Sop/merge",
+    "Top/merge"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 999,
+   "call": "setInput",
+   "receiver": "rs",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 1005,
+   "call": "setInput",
+   "receiver": "karma",
+   "receiver_type": "karma",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'karma'",
+   "candidate_keys": [
+    "Driver/karma",
+    "Lop/karma",
+    "Lop/labs::karma::1.0",
+    "Lop/labs::karma::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 1158,
+   "call": "setInput",
+   "receiver": "grade",
+   "receiver_type": "colorcorrect",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'colorcorrect'",
+   "candidate_keys": [
+    "Cop/colorcorrect",
+    "Cop2/colorcorrect"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 1168,
+   "call": "setInput",
+   "receiver": "tonemap",
+   "receiver_type": "tonemap",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'tonemap'",
+   "candidate_keys": [
+    "Cop/tonemap"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/pipeline_recipes.py",
+   "line": 1173,
+   "call": "setInput",
+   "receiver": "rop_out",
+   "receiver_type": "rop_comp",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'rop_comp'",
+   "candidate_keys": [
+    "Cop2/rop_comp"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/render_recipes.py",
+   "line": 578,
+   "call": "setInput",
+   "receiver": "merge",
+   "receiver_type": "merge",
+   "index": null,
+   "index_expr": "i",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "dynamic-index",
+   "detail": "input index 'i' is not a literal — not provable statically",
+   "candidate_keys": [
+    "Chop/merge",
+    "Cop2/merge",
+    "Dop/merge",
+    "Driver/merge",
+    "Lop/merge",
+    "Sop/merge",
+    "Top/merge"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/render_recipes.py",
+   "line": 583,
+   "call": "setInput",
+   "receiver": "rs",
+   "receiver_type": "karmarenderproperties",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'karmarenderproperties'",
+   "candidate_keys": [
+    "Lop/karmarenderproperties"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/render_recipes.py",
+   "line": 597,
+   "call": "setInput",
+   "receiver": "karma",
+   "receiver_type": "karma",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'karma'",
+   "candidate_keys": [
+    "Driver/karma",
+    "Lop/karma",
+    "Lop/labs::karma::1.0",
+    "Lop/labs::karma::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/render_recipes.py",
+   "line": 706,
+   "call": "setInput",
+   "receiver": "merge",
+   "receiver_type": "merge",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'merge'",
+   "candidate_keys": [
+    "Chop/merge",
+    "Cop2/merge",
+    "Dop/merge",
+    "Driver/merge",
+    "Lop/merge",
+    "Sop/merge",
+    "Top/merge"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/render_recipes.py",
+   "line": 707,
+   "call": "setInput",
+   "receiver": "merge",
+   "receiver_type": "merge",
+   "index": 1,
+   "index_expr": "1",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 1 within max_inputs for 'merge'",
+   "candidate_keys": [
+    "Chop/merge",
+    "Cop2/merge",
+    "Dop/merge",
+    "Driver/merge",
+    "Lop/merge",
+    "Sop/merge",
+    "Top/merge"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/render_recipes.py",
+   "line": 708,
+   "call": "setInput",
+   "receiver": "merge",
+   "receiver_type": "merge",
+   "index": 2,
+   "index_expr": "2",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 2 within max_inputs for 'merge'",
+   "candidate_keys": [
+    "Chop/merge",
+    "Cop2/merge",
+    "Dop/merge",
+    "Driver/merge",
+    "Lop/merge",
+    "Sop/merge",
+    "Top/merge"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/render_recipes.py",
+   "line": 709,
+   "call": "setInput",
+   "receiver": "merge",
+   "receiver_type": "merge",
+   "index": 3,
+   "index_expr": "3",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 3 within max_inputs for 'merge'",
+   "candidate_keys": [
+    "Chop/merge",
+    "Cop2/merge",
+    "Dop/merge",
+    "Driver/merge",
+    "Lop/merge",
+    "Sop/merge",
+    "Top/merge"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/render_recipes.py",
+   "line": 715,
+   "call": "setInput",
+   "receiver": "rs",
+   "receiver_type": "karmarenderproperties",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'karmarenderproperties'",
+   "candidate_keys": [
+    "Lop/karmarenderproperties"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/render_recipes.py",
+   "line": 730,
+   "call": "setInput",
+   "receiver": "karma",
+   "receiver_type": "karma",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'karma'",
+   "candidate_keys": [
+    "Driver/karma",
+    "Lop/karma",
+    "Lop/labs::karma::1.0",
+    "Lop/labs::karma::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/render_recipes.py",
+   "line": 892,
+   "call": "setInput",
+   "receiver": "merge",
+   "receiver_type": "merge",
+   "index": null,
+   "index_expr": "i",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "dynamic-index",
+   "detail": "input index 'i' is not a literal — not provable statically",
+   "candidate_keys": [
+    "Chop/merge",
+    "Cop2/merge",
+    "Dop/merge",
+    "Driver/merge",
+    "Lop/merge",
+    "Sop/merge",
+    "Top/merge"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/render_recipes.py",
+   "line": 897,
+   "call": "setInput",
+   "receiver": "rs",
+   "receiver_type": "karmarenderproperties",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'karmarenderproperties'",
+   "candidate_keys": [
+    "Lop/karmarenderproperties"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/render_recipes.py",
+   "line": 905,
+   "call": "setInput",
+   "receiver": "karma",
+   "receiver_type": "karma",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'karma'",
+   "candidate_keys": [
+    "Driver/karma",
+    "Lop/karma",
+    "Lop/labs::karma::1.0",
+    "Lop/labs::karma::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/scene_recipes.py",
+   "line": 392,
+   "call": "setInput",
+   "receiver": "noise",
+   "receiver_type": "heightfield_noise",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'heightfield_noise'",
+   "candidate_keys": [
+    "Sop/heightfield_noise"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/scene_recipes.py",
+   "line": 397,
+   "call": "setInput",
+   "receiver": "erode",
+   "receiver_type": "heightfield_erode",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'heightfield_erode'",
+   "candidate_keys": [
+    "Sop/heightfield_erode",
+    "Sop/heightfield_erode::2.0",
+    "Sop/heightfield_erode::3.0"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/scene_recipes.py",
+   "line": 400,
+   "call": "setInput",
+   "receiver": "out",
+   "receiver_type": "null",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'null'",
+   "candidate_keys": [
+    "Chop/null",
+    "Cop/null",
+    "Cop2/null",
+    "Dop/null",
+    "Driver/null",
+    "Lop/null",
+    "Object/null",
+    "Sop/null",
+    "Top/null",
+    "Vop/null"
+   ]
+  },
+  {
+   "file": "python/synapse/routing/recipes/scene_recipes.py",
+   "line": 593,
+   "call": "setInput",
+   "receiver": "wrangle",
+   "receiver_type": "attribwrangle",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'attribwrangle'",
+   "candidate_keys": [
+    "Lop/attribwrangle",
+    "Sop/attribwrangle"
+   ]
+  },
+  {
+   "file": "python/synapse/server/api_adapter.py",
+   "line": 206,
+   "call": "setInput",
+   "receiver": "target_node",
+   "receiver_type": null,
+   "index": null,
+   "index_expr": "int(target_input",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/guards.py",
+   "line": 76,
+   "call": "setInput",
+   "receiver": "target",
+   "receiver_type": null,
+   "index": null,
+   "index_expr": "target_input",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/guards.py",
+   "line": 78,
+   "call": "setInput",
+   "receiver": "target",
+   "receiver_type": null,
+   "index": null,
+   "index_expr": "len(target.inputs(",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/guards.py",
+   "line": 91,
+   "call": "setInput",
+   "receiver": "target",
+   "receiver_type": null,
+   "index": null,
+   "index_expr": "idx",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/guards.py",
+   "line": 113,
+   "call": "setInput",
+   "receiver": "merge",
+   "receiver_type": null,
+   "index": null,
+   "index_expr": "idx",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/handlers.py",
+   "line": 1187,
+   "call": "setInput",
+   "receiver": "wrangle",
+   "receiver_type": "attribwrangle",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'attribwrangle'",
+   "candidate_keys": [
+    "Lop/attribwrangle",
+    "Sop/attribwrangle"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 330,
+   "call": "setInput",
+   "receiver": "target",
+   "receiver_type": null,
+   "index": null,
+   "index_expr": "target_input",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 605,
+   "call": "setInput",
+   "receiver": "merge_node",
+   "receiver_type": "over",
+   "index": null,
+   "index_expr": "i",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "dynamic-index",
+   "detail": "input index 'i' is not a literal — not provable statically",
+   "candidate_keys": [
+    "Cop2/over"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 825,
+   "call": "setInput",
+   "receiver": "block_end",
+   "receiver_type": "block_end",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'block_end'",
+   "candidate_keys": [
+    "Cop/block_end",
+    "Sop/block_end",
+    "Vop/block_end"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1020,
+   "call": "setInput",
+   "receiver": "dilate",
+   "receiver_type": "dilateerode",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'dilateerode'",
+   "candidate_keys": [
+    "Cop/dilateerode",
+    "Cop2/dilateerode"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1027,
+   "call": "setInput",
+   "receiver": "blur",
+   "receiver_type": "blur",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'blur'",
+   "candidate_keys": [
+    "Cop/blur",
+    "Cop2/blur",
+    "Data/cop/convolve3::sidefx::blur"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1033,
+   "call": "setInput",
+   "receiver": "thresh",
+   "receiver_type": "limit",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'limit'",
+   "candidate_keys": [
+    "Chop/limit",
+    "Cop2/limit"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1040,
+   "call": "setInput",
+   "receiver": "block_end",
+   "receiver_type": "block_end",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'block_end'",
+   "candidate_keys": [
+    "Cop/block_end",
+    "Sop/block_end",
+    "Vop/block_end"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1046,
+   "call": "setInput",
+   "receiver": "block_begin",
+   "receiver_type": "block_begin",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'block_begin'",
+   "candidate_keys": [
+    "Cop/block_begin",
+    "Sop/block_begin",
+    "Vop/block_begin"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1142,
+   "call": "setInput",
+   "receiver": "opencl_node",
+   "receiver_type": "vopcop2gen",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'vopcop2gen'",
+   "candidate_keys": [
+    "Cop2/vopcop2gen"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1161,
+   "call": "setInput",
+   "receiver": "block_end",
+   "receiver_type": "block_end",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'block_end'",
+   "candidate_keys": [
+    "Cop/block_end",
+    "Sop/block_end",
+    "Vop/block_end"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1249,
+   "call": "setInput",
+   "receiver": "sort_node",
+   "receiver_type": "vopcop2gen",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'vopcop2gen'",
+   "candidate_keys": [
+    "Cop2/vopcop2gen"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1365,
+   "call": "setInput",
+   "receiver": "halftone",
+   "receiver_type": "vopcop2gen",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'vopcop2gen'",
+   "candidate_keys": [
+    "Cop2/vopcop2gen"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1384,
+   "call": "setInput",
+   "receiver": "first_node",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1479,
+   "call": "setInput",
+   "receiver": "blur_node",
+   "receiver_type": "blur",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'blur'",
+   "candidate_keys": [
+    "Cop/blur",
+    "Cop2/blur",
+    "Data/cop/convolve3::sidefx::blur"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1494,
+   "call": "setInput",
+   "receiver": "decay_node",
+   "receiver_type": "colorcorrect",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'colorcorrect'",
+   "candidate_keys": [
+    "Cop/colorcorrect",
+    "Cop2/colorcorrect"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1497,
+   "call": "setInput",
+   "receiver": "block_end",
+   "receiver_type": "block_end",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'block_end'",
+   "candidate_keys": [
+    "Cop/block_end",
+    "Sop/block_end",
+    "Vop/block_end"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_cops.py",
+   "line": 1743,
+   "call": "setInput",
+   "receiver": "scatter_node",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/handlers_hda.py",
+   "line": 445,
+   "call": "setInput",
+   "receiver": "dst_node",
+   "receiver_type": null,
+   "index": null,
+   "index_expr": "dst_input",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/handlers_material.py",
+   "line": 235,
+   "call": "setInput",
+   "receiver": "matlib",
+   "receiver_type": "materiallibrary",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'materiallibrary'",
+   "candidate_keys": [
+    "Lop/materiallibrary"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_material.py",
+   "line": 315,
+   "call": "setInput",
+   "receiver": "assign_node",
+   "receiver_type": "assignmaterial",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'assignmaterial'",
+   "candidate_keys": [
+    "Lop/assignmaterial"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_material.py",
+   "line": 506,
+   "call": "setInput",
+   "receiver": "matlib",
+   "receiver_type": "materiallibrary",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'materiallibrary'",
+   "candidate_keys": [
+    "Lop/materiallibrary"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_material.py",
+   "line": 633,
+   "call": "setInput",
+   "receiver": "assign_node",
+   "receiver_type": "assignmaterial",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'assignmaterial'",
+   "candidate_keys": [
+    "Lop/assignmaterial"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_node.py",
+   "line": 162,
+   "call": "setInput",
+   "receiver": "target_node",
+   "receiver_type": null,
+   "index": null,
+   "index_expr": "int(target_input",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/handlers_render.py",
+   "line": 1282,
+   "call": "setInput",
+   "receiver": "py_lop",
+   "receiver_type": "pythonscript",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pythonscript'",
+   "candidate_keys": [
+    "Lop/pythonscript",
+    "Object/pythonscript",
+    "Top/pythonscript"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_solaris_assemble.py",
+   "line": 357,
+   "call": "setInput",
+   "receiver": "node",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/handlers_solaris_graph.py",
+   "line": 445,
+   "call": "setInput",
+   "receiver": "target",
+   "receiver_type": null,
+   "index": null,
+   "index_expr": "input_idx",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/handlers_tops/render_sequence.py",
+   "line": 455,
+   "call": "setInput",
+   "receiver": "rop_fetch",
+   "receiver_type": "ropfetch",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'ropfetch'",
+   "candidate_keys": [
+    "Top/ropfetch"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_tops/render_sequence.py",
+   "line": 478,
+   "call": "setInput",
+   "receiver": "partition",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/handlers_tops/render_sequence.py",
+   "line": 489,
+   "call": "setInput",
+   "receiver": "encode_node",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/handlers_usd.py",
+   "line": 405,
+   "call": "setInput",
+   "receiver": "py_lop",
+   "receiver_type": "pythonscript",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pythonscript'",
+   "candidate_keys": [
+    "Lop/pythonscript",
+    "Object/pythonscript",
+    "Top/pythonscript"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_usd.py",
+   "line": 501,
+   "call": "setInput",
+   "receiver": "py_lop",
+   "receiver_type": "pythonscript",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pythonscript'",
+   "candidate_keys": [
+    "Lop/pythonscript",
+    "Object/pythonscript",
+    "Top/pythonscript"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_usd.py",
+   "line": 582,
+   "call": "setInput",
+   "receiver": "py_lop",
+   "receiver_type": "pythonscript",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pythonscript'",
+   "candidate_keys": [
+    "Lop/pythonscript",
+    "Object/pythonscript",
+    "Top/pythonscript"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_usd.py",
+   "line": 655,
+   "call": "setInput",
+   "receiver": "py_lop",
+   "receiver_type": "pythonscript",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pythonscript'",
+   "candidate_keys": [
+    "Lop/pythonscript",
+    "Object/pythonscript",
+    "Top/pythonscript"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_usd.py",
+   "line": 794,
+   "call": "setInput",
+   "receiver": "node",
+   "receiver_type": "reference",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'reference'",
+   "candidate_keys": [
+    "Cop2/reference",
+    "Lop/reference",
+    "Lop/reference::2.0"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_usd.py",
+   "line": 824,
+   "call": "setInput",
+   "receiver": "kv_lop",
+   "receiver_type": null,
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/server/handlers_usd.py",
+   "line": 1059,
+   "call": "setInput",
+   "receiver": "py_lop",
+   "receiver_type": "pythonscript",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pythonscript'",
+   "candidate_keys": [
+    "Lop/pythonscript",
+    "Object/pythonscript",
+    "Top/pythonscript"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_usd.py",
+   "line": 1111,
+   "call": "setInput",
+   "receiver": "py_lop",
+   "receiver_type": "pythonscript",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pythonscript'",
+   "candidate_keys": [
+    "Lop/pythonscript",
+    "Object/pythonscript",
+    "Top/pythonscript"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_usd.py",
+   "line": 1257,
+   "call": "setInput",
+   "receiver": "py_lop",
+   "receiver_type": "pythonscript",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pythonscript'",
+   "candidate_keys": [
+    "Lop/pythonscript",
+    "Object/pythonscript",
+    "Top/pythonscript"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_usd.py",
+   "line": 1334,
+   "call": "setInput",
+   "receiver": "py_lop",
+   "receiver_type": "pythonscript",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pythonscript'",
+   "candidate_keys": [
+    "Lop/pythonscript",
+    "Object/pythonscript",
+    "Top/pythonscript"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_usd.py",
+   "line": 1442,
+   "call": "setInput",
+   "receiver": "py_lop",
+   "receiver_type": "pythonscript",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pythonscript'",
+   "candidate_keys": [
+    "Lop/pythonscript",
+    "Object/pythonscript",
+    "Top/pythonscript"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_usd.py",
+   "line": 1757,
+   "call": "setInput",
+   "receiver": "py_lop",
+   "receiver_type": "pythonscript",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pythonscript'",
+   "candidate_keys": [
+    "Lop/pythonscript",
+    "Object/pythonscript",
+    "Top/pythonscript"
+   ]
+  },
+  {
+   "file": "python/synapse/server/handlers_usd.py",
+   "line": 1848,
+   "call": "setInput",
+   "receiver": "py_lop",
+   "receiver_type": "pythonscript",
+   "index": 0,
+   "index_expr": "0",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "index-within-arity",
+   "detail": "input index 0 within max_inputs for 'pythonscript'",
+   "candidate_keys": [
+    "Lop/pythonscript",
+    "Object/pythonscript",
+    "Top/pythonscript"
+   ]
+  },
+  {
+   "file": "python/synapse/server/solaris_compose.py",
+   "line": 140,
+   "call": "setInput",
+   "receiver": "node",
+   "receiver_type": null,
+   "index": null,
+   "index_expr": "input_index",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  }
+ ]
+}

--- a/.claude/flywheel_u1_findings.json
+++ b/.claude/flywheel_u1_findings.json
@@ -7,16 +7,42 @@
   "blake2b": "c213570959156138a7cda52936fcd2c1"
  },
  "summary": {
-  "total_sites": 150,
+  "total_sites": 147,
   "critical": 0,
   "by_kind": {
    "dynamic-index": 3,
-   "index-within-arity": 113,
+   "index-within-arity": 108,
    "label-claim-verified": 3,
-   "unresolved-receiver": 31
+   "unresolved-receiver": 33
   }
  },
  "findings": [
+  {
+   "file": "python/synapse/core/wiring.py",
+   "line": 163,
+   "call": "setInput",
+   "receiver": "node",
+   "receiver_type": null,
+   "index": null,
+   "index_expr": "index",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
+  {
+   "file": "python/synapse/core/wiring.py",
+   "line": 166,
+   "call": "setInput",
+   "receiver": "node",
+   "receiver_type": null,
+   "index": null,
+   "index_expr": "resolved",
+   "claimed_labels": [],
+   "severity": "INFO",
+   "kind": "unresolved-receiver",
+   "detail": "receiver's node type not lexically resolvable (runtime object)"
+  },
   {
    "file": "python/synapse/host/graph_builder.py",
    "line": 157,
@@ -71,41 +97,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 287,
-   "call": "setInput",
-   "receiver": "solver",
-   "receiver_type": "vellumsolver",
-   "index": 0,
-   "index_expr": "0",
-   "claimed_labels": [],
-   "severity": "INFO",
-   "kind": "index-within-arity",
-   "detail": "input index 0 within max_inputs for 'vellumsolver'",
-   "candidate_keys": [
-    "Dop/vellumsolver",
-    "Sop/vellumsolver"
-   ]
-  },
-  {
-   "file": "python/synapse/routing/planner.py",
-   "line": 288,
-   "call": "setInput",
-   "receiver": "solver",
-   "receiver_type": "vellumsolver",
-   "index": 1,
-   "index_expr": "1",
-   "claimed_labels": [],
-   "severity": "INFO",
-   "kind": "index-within-arity",
-   "detail": "input index 1 within max_inputs for 'vellumsolver'",
-   "candidate_keys": [
-    "Dop/vellumsolver",
-    "Sop/vellumsolver"
-   ]
-  },
-  {
-   "file": "python/synapse/routing/planner.py",
-   "line": 300,
+   "line": 302,
    "call": "setInput",
    "receiver": "drape",
    "receiver_type": "vellumdrape",
@@ -121,24 +113,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 314,
-   "call": "setInput",
-   "receiver": "solver",
-   "receiver_type": "vellumsolver",
-   "index": 2,
-   "index_expr": "2",
-   "claimed_labels": [],
-   "severity": "INFO",
-   "kind": "index-within-arity",
-   "detail": "input index 2 within max_inputs for 'vellumsolver'",
-   "candidate_keys": [
-    "Dop/vellumsolver",
-    "Sop/vellumsolver"
-   ]
-  },
-  {
-   "file": "python/synapse/routing/planner.py",
-   "line": 328,
+   "line": 331,
    "call": "setInput",
    "receiver": "wind",
    "receiver_type": "vellumconstraintproperty",
@@ -155,7 +130,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 341,
+   "line": 344,
    "call": "setInput",
    "receiver": "cache",
    "receiver_type": "filecache",
@@ -175,7 +150,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 368,
+   "line": 371,
    "call": "setInput",
    "receiver": "asm",
    "receiver_type": "assemble",
@@ -191,7 +166,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 370,
+   "line": 373,
    "call": "setInput",
    "receiver": "cons",
    "receiver_type": "rbdconstraintsfromrules",
@@ -207,7 +182,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 374,
+   "line": 377,
    "call": "setInput",
    "receiver": "props",
    "receiver_type": "rbdconstraintproperties",
@@ -224,39 +199,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 376,
-   "call": "setInput",
-   "receiver": "solver",
-   "receiver_type": "rbdbulletsolver",
-   "index": 0,
-   "index_expr": "0",
-   "claimed_labels": [],
-   "severity": "INFO",
-   "kind": "index-within-arity",
-   "detail": "input index 0 within max_inputs for 'rbdbulletsolver'",
-   "candidate_keys": [
-    "Sop/rbdbulletsolver"
-   ]
-  },
-  {
-   "file": "python/synapse/routing/planner.py",
-   "line": 377,
-   "call": "setInput",
-   "receiver": "solver",
-   "receiver_type": "rbdbulletsolver",
-   "index": 1,
-   "index_expr": "1",
-   "claimed_labels": [],
-   "severity": "INFO",
-   "kind": "index-within-arity",
-   "detail": "input index 1 within max_inputs for 'rbdbulletsolver'",
-   "candidate_keys": [
-    "Sop/rbdbulletsolver"
-   ]
-  },
-  {
-   "file": "python/synapse/routing/planner.py",
-   "line": 391,
+   "line": 396,
    "call": "setInput",
    "receiver": "debris",
    "receiver_type": "debrissource",
@@ -273,7 +216,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 404,
+   "line": 409,
    "call": "setInput",
    "receiver": "pyro",
    "receiver_type": "pyrosolver",
@@ -291,7 +234,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 417,
+   "line": 422,
    "call": "setInput",
    "receiver": "cache",
    "receiver_type": "filecache",
@@ -311,7 +254,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 540,
+   "line": 545,
    "call": "setInput",
    "receiver": "evl",
    "receiver_type": "oceanevaluate",
@@ -328,7 +271,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 556,
+   "line": 561,
    "call": "setInput",
    "receiver": "solver",
    "receiver_type": "flipsolver",
@@ -346,7 +289,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 568,
+   "line": 573,
    "call": "setInput",
    "receiver": "ww_solve",
    "receiver_type": "whitewatersolver",
@@ -364,7 +307,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 570,
+   "line": 575,
    "call": "setInput",
    "receiver": "ww_src",
    "receiver_type": "whitewatersource",
@@ -382,7 +325,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 597,
+   "line": 602,
    "call": "setInput",
    "receiver": "wrangle",
    "receiver_type": "attribwrangle",
@@ -399,7 +342,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 600,
+   "line": 605,
    "call": "setInput",
    "receiver": "rast",
    "receiver_type": "volumerasterizeattributes",
@@ -415,7 +358,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 603,
+   "line": 608,
    "call": "setInput",
    "receiver": "solver",
    "receiver_type": "pyrosolver",
@@ -433,7 +376,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 606,
+   "line": 611,
    "call": "setInput",
    "receiver": "cache",
    "receiver_type": "filecache",
@@ -453,7 +396,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 652,
+   "line": 657,
    "call": "setInput",
    "receiver": "matlib",
    "receiver_type": "materiallibrary",
@@ -469,7 +412,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 655,
+   "line": 660,
    "call": "setInput",
    "receiver": "assign",
    "receiver_type": "assignmaterial",
@@ -485,7 +428,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 664,
+   "line": 669,
    "call": "setInput",
    "receiver": "cam",
    "receiver_type": "camera",
@@ -501,7 +444,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 673,
+   "line": 678,
    "call": "setInput",
    "receiver": "key",
    "receiver_type": "light",
@@ -522,7 +465,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 676,
+   "line": 681,
    "call": "setInput",
    "receiver": "fill",
    "receiver_type": "light",
@@ -543,7 +486,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 679,
+   "line": 684,
    "call": "setInput",
    "receiver": "rim",
    "receiver_type": "light",
@@ -564,7 +507,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 687,
+   "line": 692,
    "call": "setInput",
    "receiver": "light",
    "receiver_type": "light",
@@ -585,7 +528,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 696,
+   "line": 701,
    "call": "setInput",
    "receiver": "rs",
    "receiver_type": "karmarenderproperties",
@@ -601,7 +544,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 699,
+   "line": 704,
    "call": "setInput",
    "receiver": "karma",
    "receiver_type": "karma",
@@ -620,7 +563,7 @@
   },
   {
    "file": "python/synapse/routing/planner.py",
-   "line": 707,
+   "line": 712,
    "call": "setInput",
    "receiver": "out",
    "receiver_type": "null",

--- a/.claude/flywheel_u1_findings.md
+++ b/.claude/flywheel_u1_findings.md
@@ -2,48 +2,48 @@
 
 Catalog: `harness/notes/verified_connectivity_21.0.671.json` (build 21.0.671, blake2b `c21357095915`)
 
-**0 CRITICAL** of 150 call sites. By kind: dynamic-index=3, index-within-arity=113, label-claim-verified=3, unresolved-receiver=31
+**0 CRITICAL** of 147 call sites. By kind: dynamic-index=3, index-within-arity=108, label-claim-verified=3, unresolved-receiver=33
 
-## INFO (150)
+## INFO (147)
 
+- `python/synapse/core/wiring.py:163` **unresolved-receiver** `node.setInput(index, ...)` type=None — receiver's node type not lexically resolvable (runtime object)
+- `python/synapse/core/wiring.py:166` **unresolved-receiver** `node.setInput(resolved, ...)` type=None — receiver's node type not lexically resolvable (runtime object)
 - `python/synapse/host/graph_builder.py:157` **unresolved-receiver** `tgt.setInput(e.target_input_index, ...)` type=None — receiver's node type not lexically resolvable (runtime object)
 - `python/synapse/panel/system_prompt.py:107` **unresolved-receiver** `node.setInput(0, ...)` type=None — receiver's node type not lexically resolvable (runtime object)
 - `python/synapse/panel/system_prompt.py:143` **unresolved-receiver** `new_node.setInput(0, ...)` type=None — receiver's node type not lexically resolvable (runtime object)
 - `python/synapse/panel/system_prompt.py:144` **unresolved-receiver** `display_node.setInput(0, ...)` type=None — receiver's node type not lexically resolvable (runtime object)
-- `python/synapse/routing/planner.py:287` **index-within-arity** `solver.setInput(0, ...)` type=vellumsolver — input index 0 within max_inputs for 'vellumsolver'
-- `python/synapse/routing/planner.py:288` **index-within-arity** `solver.setInput(1, ...)` type=vellumsolver — input index 1 within max_inputs for 'vellumsolver'
-- `python/synapse/routing/planner.py:300` **index-within-arity** `drape.setInput(0, ...)` type=vellumdrape — input index 0 within max_inputs for 'vellumdrape'
-- `python/synapse/routing/planner.py:314` **index-within-arity** `solver.setInput(2, ...)` type=vellumsolver — input index 2 within max_inputs for 'vellumsolver'
-- `python/synapse/routing/planner.py:328` **index-within-arity** `wind.setInput(0, ...)` type=vellumconstraintproperty — input index 0 within max_inputs for 'vellumconstraintproperty'
-- `python/synapse/routing/planner.py:341` **index-within-arity** `cache.setInput(0, ...)` type=filecache — input index 0 within max_inputs for 'filecache'
-- `python/synapse/routing/planner.py:368` **index-within-arity** `asm.setInput(0, ...)` type=assemble — input index 0 within max_inputs for 'assemble'
-- `python/synapse/routing/planner.py:370` **index-within-arity** `cons.setInput(0, ...)` type=rbdconstraintsfromrules — input index 0 within max_inputs for 'rbdconstraintsfromrules'
-- `python/synapse/routing/planner.py:374` **index-within-arity** `props.setInput(0, ...)` type=rbdconstraintproperties — input index 0 within max_inputs for 'rbdconstraintproperties'
-- `python/synapse/routing/planner.py:376` **index-within-arity** `solver.setInput(0, ...)` type=rbdbulletsolver — input index 0 within max_inputs for 'rbdbulletsolver'
-- `python/synapse/routing/planner.py:377` **index-within-arity** `solver.setInput(1, ...)` type=rbdbulletsolver — input index 1 within max_inputs for 'rbdbulletsolver'
-- `python/synapse/routing/planner.py:391` **index-within-arity** `debris.setInput(0, ...)` type=debrissource — input index 0 within max_inputs for 'debrissource'
-- `python/synapse/routing/planner.py:404` **index-within-arity** `pyro.setInput(0, ...)` type=pyrosolver — input index 0 within max_inputs for 'pyrosolver'
-- `python/synapse/routing/planner.py:417` **index-within-arity** `cache.setInput(0, ...)` type=filecache — input index 0 within max_inputs for 'filecache'
-- `python/synapse/routing/planner.py:540` **index-within-arity** `evl.setInput(0, ...)` type=oceanevaluate — input index 0 within max_inputs for 'oceanevaluate'
-- `python/synapse/routing/planner.py:556` **index-within-arity** `solver.setInput(0, ...)` type=flipsolver — input index 0 within max_inputs for 'flipsolver'
-- `python/synapse/routing/planner.py:568` **index-within-arity** `ww_solve.setInput(0, ...)` type=whitewatersolver — input index 0 within max_inputs for 'whitewatersolver'
-- `python/synapse/routing/planner.py:570` **index-within-arity** `ww_src.setInput(0, ...)` type=whitewatersource — input index 0 within max_inputs for 'whitewatersource'
-- `python/synapse/routing/planner.py:597` **index-within-arity** `wrangle.setInput(0, ...)` type=attribwrangle — input index 0 within max_inputs for 'attribwrangle'
-- `python/synapse/routing/planner.py:600` **index-within-arity** `rast.setInput(0, ...)` type=volumerasterizeattributes — input index 0 within max_inputs for 'volumerasterizeattributes'
-- `python/synapse/routing/planner.py:603` **index-within-arity** `solver.setInput(0, ...)` type=pyrosolver — input index 0 within max_inputs for 'pyrosolver'
-- `python/synapse/routing/planner.py:606` **index-within-arity** `cache.setInput(0, ...)` type=filecache — input index 0 within max_inputs for 'filecache'
-- `python/synapse/routing/planner.py:652` **index-within-arity** `matlib.setInput(0, ...)` type=materiallibrary — input index 0 within max_inputs for 'materiallibrary'
-- `python/synapse/routing/planner.py:655` **index-within-arity** `assign.setInput(0, ...)` type=assignmaterial — input index 0 within max_inputs for 'assignmaterial'
-- `python/synapse/routing/planner.py:664` **index-within-arity** `cam.setInput(0, ...)` type=camera — input index 0 within max_inputs for 'camera'
-- `python/synapse/routing/planner.py:673` **index-within-arity** `key.setInput(0, ...)` type=light — input index 0 within max_inputs for 'light'
-- `python/synapse/routing/planner.py:676` **index-within-arity** `fill.setInput(0, ...)` type=light — input index 0 within max_inputs for 'light'
-- `python/synapse/routing/planner.py:679` **index-within-arity** `rim.setInput(0, ...)` type=light — input index 0 within max_inputs for 'light'
-- `python/synapse/routing/planner.py:687` **index-within-arity** `light.setInput(0, ...)` type=light — input index 0 within max_inputs for 'light'
-- `python/synapse/routing/planner.py:696` **index-within-arity** `rs.setInput(0, ...)` type=karmarenderproperties — input index 0 within max_inputs for 'karmarenderproperties'
-- `python/synapse/routing/planner.py:699` **index-within-arity** `karma.setInput(0, ...)` type=karma — input index 0 within max_inputs for 'karma'
-- `python/synapse/routing/planner.py:707` **index-within-arity** `out.setInput(0, ...)` type=null — input index 0 within max_inputs for 'null'
+- `python/synapse/routing/planner.py:302` **index-within-arity** `drape.setInput(0, ...)` type=vellumdrape — input index 0 within max_inputs for 'vellumdrape'
+- `python/synapse/routing/planner.py:331` **index-within-arity** `wind.setInput(0, ...)` type=vellumconstraintproperty — input index 0 within max_inputs for 'vellumconstraintproperty'
+- `python/synapse/routing/planner.py:344` **index-within-arity** `cache.setInput(0, ...)` type=filecache — input index 0 within max_inputs for 'filecache'
+- `python/synapse/routing/planner.py:371` **index-within-arity** `asm.setInput(0, ...)` type=assemble — input index 0 within max_inputs for 'assemble'
+- `python/synapse/routing/planner.py:373` **index-within-arity** `cons.setInput(0, ...)` type=rbdconstraintsfromrules — input index 0 within max_inputs for 'rbdconstraintsfromrules'
+- `python/synapse/routing/planner.py:377` **index-within-arity** `props.setInput(0, ...)` type=rbdconstraintproperties — input index 0 within max_inputs for 'rbdconstraintproperties'
+- `python/synapse/routing/planner.py:396` **index-within-arity** `debris.setInput(0, ...)` type=debrissource — input index 0 within max_inputs for 'debrissource'
+- `python/synapse/routing/planner.py:409` **index-within-arity** `pyro.setInput(0, ...)` type=pyrosolver — input index 0 within max_inputs for 'pyrosolver'
+- `python/synapse/routing/planner.py:422` **index-within-arity** `cache.setInput(0, ...)` type=filecache — input index 0 within max_inputs for 'filecache'
+- `python/synapse/routing/planner.py:545` **index-within-arity** `evl.setInput(0, ...)` type=oceanevaluate — input index 0 within max_inputs for 'oceanevaluate'
+- `python/synapse/routing/planner.py:561` **index-within-arity** `solver.setInput(0, ...)` type=flipsolver — input index 0 within max_inputs for 'flipsolver'
+- `python/synapse/routing/planner.py:573` **index-within-arity** `ww_solve.setInput(0, ...)` type=whitewatersolver — input index 0 within max_inputs for 'whitewatersolver'
+- `python/synapse/routing/planner.py:575` **index-within-arity** `ww_src.setInput(0, ...)` type=whitewatersource — input index 0 within max_inputs for 'whitewatersource'
+- `python/synapse/routing/planner.py:602` **index-within-arity** `wrangle.setInput(0, ...)` type=attribwrangle — input index 0 within max_inputs for 'attribwrangle'
+- `python/synapse/routing/planner.py:605` **index-within-arity** `rast.setInput(0, ...)` type=volumerasterizeattributes — input index 0 within max_inputs for 'volumerasterizeattributes'
+- `python/synapse/routing/planner.py:608` **index-within-arity** `solver.setInput(0, ...)` type=pyrosolver — input index 0 within max_inputs for 'pyrosolver'
+- `python/synapse/routing/planner.py:611` **index-within-arity** `cache.setInput(0, ...)` type=filecache — input index 0 within max_inputs for 'filecache'
+- `python/synapse/routing/planner.py:657` **index-within-arity** `matlib.setInput(0, ...)` type=materiallibrary — input index 0 within max_inputs for 'materiallibrary'
+- `python/synapse/routing/planner.py:660` **index-within-arity** `assign.setInput(0, ...)` type=assignmaterial — input index 0 within max_inputs for 'assignmaterial'
+- `python/synapse/routing/planner.py:669` **index-within-arity** `cam.setInput(0, ...)` type=camera — input index 0 within max_inputs for 'camera'
+- `python/synapse/routing/planner.py:678` **index-within-arity** `key.setInput(0, ...)` type=light — input index 0 within max_inputs for 'light'
+- `python/synapse/routing/planner.py:681` **index-within-arity** `fill.setInput(0, ...)` type=light — input index 0 within max_inputs for 'light'
+- `python/synapse/routing/planner.py:684` **index-within-arity** `rim.setInput(0, ...)` type=light — input index 0 within max_inputs for 'light'
+- `python/synapse/routing/planner.py:692` **index-within-arity** `light.setInput(0, ...)` type=light — input index 0 within max_inputs for 'light'
+- `python/synapse/routing/planner.py:701` **index-within-arity** `rs.setInput(0, ...)` type=karmarenderproperties — input index 0 within max_inputs for 'karmarenderproperties'
+- `python/synapse/routing/planner.py:704` **index-within-arity** `karma.setInput(0, ...)` type=karma — input index 0 within max_inputs for 'karma'
+- `python/synapse/routing/planner.py:712` **index-within-arity** `out.setInput(0, ...)` type=null — input index 0 within max_inputs for 'null'
 - `python/synapse/routing/recipes/fx_recipes.py:84` **label-claim-verified** `solver.setInput(0, ...)` type=vellumsolver — comment label claim matches catalog label at index 0
 - `python/synapse/routing/recipes/fx_recipes.py:86` **label-claim-verified** `solver.setInput(1, ...)` type=vellumsolver — comment label claim matches catalog label at index 1
 - `python/synapse/routing/recipes/fx_recipes.py:90` **index-within-arity** `cache.setInput(0, ...)` type=filecache — input index 0 within max_inputs for 'filecache'
 - `python/synapse/routing/recipes/fx_recipes.py:133` **index-within-arity** `asm.setInput(0, ...)` type=assemble — input index 0 within max_inputs for 'assemble'
-- ... and 110 more (see JSON)
+- `python/synapse/routing/recipes/fx_recipes.py:136` **index-within-arity** `cons.setInput(0, ...)` type=rbdconstraintsfromrules — input index 0 within max_inputs for 'rbdconstraintsfromrules'
+- `python/synapse/routing/recipes/fx_recipes.py:141` **index-within-arity** `props.setInput(0, ...)` type=rbdconstraintproperties — input index 0 within max_inputs for 'rbdconstraintproperties'
+- `python/synapse/routing/recipes/fx_recipes.py:144` **index-within-arity** `solver.setInput(0, ...)` type=rbdbulletsolver — input index 0 within max_inputs for 'rbdbulletsolver'
+- ... and 107 more (see JSON)

--- a/.claude/flywheel_u1_findings.md
+++ b/.claude/flywheel_u1_findings.md
@@ -1,0 +1,49 @@
+# U.1 wiring review — findings (severity-ranked)
+
+Catalog: `harness/notes/verified_connectivity_21.0.671.json` (build 21.0.671, blake2b `c21357095915`)
+
+**0 CRITICAL** of 150 call sites. By kind: dynamic-index=3, index-within-arity=113, label-claim-verified=3, unresolved-receiver=31
+
+## INFO (150)
+
+- `python/synapse/host/graph_builder.py:157` **unresolved-receiver** `tgt.setInput(e.target_input_index, ...)` type=None — receiver's node type not lexically resolvable (runtime object)
+- `python/synapse/panel/system_prompt.py:107` **unresolved-receiver** `node.setInput(0, ...)` type=None — receiver's node type not lexically resolvable (runtime object)
+- `python/synapse/panel/system_prompt.py:143` **unresolved-receiver** `new_node.setInput(0, ...)` type=None — receiver's node type not lexically resolvable (runtime object)
+- `python/synapse/panel/system_prompt.py:144` **unresolved-receiver** `display_node.setInput(0, ...)` type=None — receiver's node type not lexically resolvable (runtime object)
+- `python/synapse/routing/planner.py:287` **index-within-arity** `solver.setInput(0, ...)` type=vellumsolver — input index 0 within max_inputs for 'vellumsolver'
+- `python/synapse/routing/planner.py:288` **index-within-arity** `solver.setInput(1, ...)` type=vellumsolver — input index 1 within max_inputs for 'vellumsolver'
+- `python/synapse/routing/planner.py:300` **index-within-arity** `drape.setInput(0, ...)` type=vellumdrape — input index 0 within max_inputs for 'vellumdrape'
+- `python/synapse/routing/planner.py:314` **index-within-arity** `solver.setInput(2, ...)` type=vellumsolver — input index 2 within max_inputs for 'vellumsolver'
+- `python/synapse/routing/planner.py:328` **index-within-arity** `wind.setInput(0, ...)` type=vellumconstraintproperty — input index 0 within max_inputs for 'vellumconstraintproperty'
+- `python/synapse/routing/planner.py:341` **index-within-arity** `cache.setInput(0, ...)` type=filecache — input index 0 within max_inputs for 'filecache'
+- `python/synapse/routing/planner.py:368` **index-within-arity** `asm.setInput(0, ...)` type=assemble — input index 0 within max_inputs for 'assemble'
+- `python/synapse/routing/planner.py:370` **index-within-arity** `cons.setInput(0, ...)` type=rbdconstraintsfromrules — input index 0 within max_inputs for 'rbdconstraintsfromrules'
+- `python/synapse/routing/planner.py:374` **index-within-arity** `props.setInput(0, ...)` type=rbdconstraintproperties — input index 0 within max_inputs for 'rbdconstraintproperties'
+- `python/synapse/routing/planner.py:376` **index-within-arity** `solver.setInput(0, ...)` type=rbdbulletsolver — input index 0 within max_inputs for 'rbdbulletsolver'
+- `python/synapse/routing/planner.py:377` **index-within-arity** `solver.setInput(1, ...)` type=rbdbulletsolver — input index 1 within max_inputs for 'rbdbulletsolver'
+- `python/synapse/routing/planner.py:391` **index-within-arity** `debris.setInput(0, ...)` type=debrissource — input index 0 within max_inputs for 'debrissource'
+- `python/synapse/routing/planner.py:404` **index-within-arity** `pyro.setInput(0, ...)` type=pyrosolver — input index 0 within max_inputs for 'pyrosolver'
+- `python/synapse/routing/planner.py:417` **index-within-arity** `cache.setInput(0, ...)` type=filecache — input index 0 within max_inputs for 'filecache'
+- `python/synapse/routing/planner.py:540` **index-within-arity** `evl.setInput(0, ...)` type=oceanevaluate — input index 0 within max_inputs for 'oceanevaluate'
+- `python/synapse/routing/planner.py:556` **index-within-arity** `solver.setInput(0, ...)` type=flipsolver — input index 0 within max_inputs for 'flipsolver'
+- `python/synapse/routing/planner.py:568` **index-within-arity** `ww_solve.setInput(0, ...)` type=whitewatersolver — input index 0 within max_inputs for 'whitewatersolver'
+- `python/synapse/routing/planner.py:570` **index-within-arity** `ww_src.setInput(0, ...)` type=whitewatersource — input index 0 within max_inputs for 'whitewatersource'
+- `python/synapse/routing/planner.py:597` **index-within-arity** `wrangle.setInput(0, ...)` type=attribwrangle — input index 0 within max_inputs for 'attribwrangle'
+- `python/synapse/routing/planner.py:600` **index-within-arity** `rast.setInput(0, ...)` type=volumerasterizeattributes — input index 0 within max_inputs for 'volumerasterizeattributes'
+- `python/synapse/routing/planner.py:603` **index-within-arity** `solver.setInput(0, ...)` type=pyrosolver — input index 0 within max_inputs for 'pyrosolver'
+- `python/synapse/routing/planner.py:606` **index-within-arity** `cache.setInput(0, ...)` type=filecache — input index 0 within max_inputs for 'filecache'
+- `python/synapse/routing/planner.py:652` **index-within-arity** `matlib.setInput(0, ...)` type=materiallibrary — input index 0 within max_inputs for 'materiallibrary'
+- `python/synapse/routing/planner.py:655` **index-within-arity** `assign.setInput(0, ...)` type=assignmaterial — input index 0 within max_inputs for 'assignmaterial'
+- `python/synapse/routing/planner.py:664` **index-within-arity** `cam.setInput(0, ...)` type=camera — input index 0 within max_inputs for 'camera'
+- `python/synapse/routing/planner.py:673` **index-within-arity** `key.setInput(0, ...)` type=light — input index 0 within max_inputs for 'light'
+- `python/synapse/routing/planner.py:676` **index-within-arity** `fill.setInput(0, ...)` type=light — input index 0 within max_inputs for 'light'
+- `python/synapse/routing/planner.py:679` **index-within-arity** `rim.setInput(0, ...)` type=light — input index 0 within max_inputs for 'light'
+- `python/synapse/routing/planner.py:687` **index-within-arity** `light.setInput(0, ...)` type=light — input index 0 within max_inputs for 'light'
+- `python/synapse/routing/planner.py:696` **index-within-arity** `rs.setInput(0, ...)` type=karmarenderproperties — input index 0 within max_inputs for 'karmarenderproperties'
+- `python/synapse/routing/planner.py:699` **index-within-arity** `karma.setInput(0, ...)` type=karma — input index 0 within max_inputs for 'karma'
+- `python/synapse/routing/planner.py:707` **index-within-arity** `out.setInput(0, ...)` type=null — input index 0 within max_inputs for 'null'
+- `python/synapse/routing/recipes/fx_recipes.py:84` **label-claim-verified** `solver.setInput(0, ...)` type=vellumsolver — comment label claim matches catalog label at index 0
+- `python/synapse/routing/recipes/fx_recipes.py:86` **label-claim-verified** `solver.setInput(1, ...)` type=vellumsolver — comment label claim matches catalog label at index 1
+- `python/synapse/routing/recipes/fx_recipes.py:90` **index-within-arity** `cache.setInput(0, ...)` type=filecache — input index 0 within max_inputs for 'filecache'
+- `python/synapse/routing/recipes/fx_recipes.py:133` **index-within-arity** `asm.setInput(0, ...)` type=assemble — input index 0 within max_inputs for 'assemble'
+- ... and 110 more (see JSON)

--- a/harness/notes/spec-U1-wiring-flywheel.md
+++ b/harness/notes/spec-U1-wiring-flywheel.md
@@ -1,0 +1,84 @@
+# Spec U.1 — Utility Flywheel, Cycle 1: Network-Wiring Truth
+
+**Status:** ratified (this build) · **Layer:** utility · **Mode:** A (runs now on H21.0.671)
+**Task id:** `U.1` in `harness/tasks.json` · **Queue:** `harness/state/flywheel_queue.json`
+
+## Why this cycle exists
+
+Yesterday's delta probe surfaced the pattern: SYNAPSE emits `setInput(index, ...)` wiring
+from *remembered* input indices, and memory drifts. The two known-true regression seeds
+(both fixed on the release train, both previously miswired):
+
+- `vellumsolver` inputs are **0 = Vellum Geometry / 1 = Constraint Geometry / 2 = Collision Geometry**
+- `rbdbulletsolver` constraint geometry goes to **input 1** (not 2)
+
+Wiring truth is probeable the exact same way node-type truth was
+(`host/introspect_nodetypes.py`): instantiate headless, read the live surface, commit the
+catalog, gate the code against it. This cycle turns that one-off fix into a flywheel.
+
+## The cycle contract (EXPLORE → REVIEW → SCAFFOLD)
+
+Each utility cycle runs the same three phases; each phase produces committed artifacts the
+next phase consumes. Nothing enters the live path on memory alone.
+
+1. **EXPLORE — probe truth.** `host/introspect_connectivity.py` (zero-`synapse`-import,
+   `hou` inside functions, mirrors the nodetype probe) instantiates every SYNAPSE-emitted
+   node type PLUS all Sop types matching `solver|merge|switch|blend`, and records per
+   resolved (category, type): `min_inputs`, `max_inputs`, ordered `input_labels`
+   (instance-level `hou.Node.inputLabels()` — type-level labels are PHANTOM in 21.0.671),
+   `output_count`, `output_labels`. Output:
+   `harness/notes/verified_connectivity_21.0.671.json` (schema `verified_connectivity/v2`),
+   deterministic (second run byte-identical; no wall-clock stamp), v1 keys the probe cannot
+   re-derive folded in under `v1_preserved` with provenance markers.
+
+2. **REVIEW — diff + deposit + queue-append.** `scripts/flywheel_review_wiring.py`
+   (pure python + the catalog) sweeps `python/synapse/**` for `setInput(`/`insertInput(`
+   call sites, resolves each receiver's node type (createNode assignment or created-name
+   registry), and classifies: literal index within catalog `max_inputs`? does a nearby
+   comment/label claim match the catalog label at that index? Emits
+   `.claude/flywheel_u1_findings.json` + `.md` (severity-ranked: CRITICAL = provable
+   miswire, INFO = unresolvable/dynamic). Verified finding classes are deposited to the
+   Ledger via `synapse.science.deposit.LedgerDeposit` (Confirmation for clean classes,
+   DeadEnd for confirmed miswire classes; live build stamp when `hou` is present;
+   `--deposit` opt-in so the check verb doesn't re-deposit every sprint). New probeable
+   truth classes the sweep surfaces are appended to the queue as evidence-linked U.2+
+   candidates (status `candidate`, `ratified: false`).
+
+3. **SCAFFOLD — wire into the live path + pin.**
+   - `python/synapse/core/wiring.py` — `wire_by_label(node, label, source, catalog=None)`:
+     resolves the input index from the packaged catalog
+     (`python/synapse/cognitive/tools/data/connectivity_21.json`, the scout symbol-table
+     pattern: per-major committed authority + blake2b integrity), case-insensitive exact
+     label match, `WiringError` fail-loud on unknown label/type, index fallback ONLY with
+     explicit `allow_index=True`. Adopted at the `vellumsolver` + `rbdbulletsolver` sites
+     in `routing/planner.py` (behavior-identical).
+   - `cognitive/graph_validator.py` P3: when the catalog knows the type, the validator
+     rejects an edge into an index ≥ `max_inputs` and (when the proposal names a target
+     input label) a label that resolves to a different index — additive, never weakens
+     the oracle-backed checks.
+   - `tests/test_wiring_flywheel.py` pins: catalog determinism, the `wire_by_label` unit
+     matrix, and the three golden miswire fixtures (vellumsolver constraint→2/collision→1
+     swap, rbdbulletsolver constraint→2, out-of-range index) REJECTED while the corrected
+     forms pass.
+   - `harness/verify/checks.py` verbs: `connectivity_catalog_fresh`,
+     `wiring_conformance`, `validator_catches_miswire` (ADAPT-marker style).
+
+## Anti-runaway anchors
+
+- **Human ratifies new cycle classes.** The queue's `ratified` flag is flipped by a human
+  only. An unratified candidate is a proposal, never a work order — no agent may start
+  building U.N+1 because the queue mentions it.
+- **Evidence-linked queue entries only.** Every queue entry carries `evidence` (artifact
+  paths — probe outputs, findings files, test pins). An entry without evidence is invalid
+  and must be rejected at review.
+- **Guardrails every sprint.** The cross-cutting guardrails in `harness/tasks.json`
+  (`scout_no_apex_corpus`, `no_rigging_drift`, `provenance_not_bypassed`) run on every
+  U-cycle sprint exactly as on every other task; a utility cycle never gets a guardrail
+  waiver.
+- **Probe truth > pinned constants** (standing harness convention): where the catalog and
+  a code comment disagree, the catalog wins; the code and its comment are the bug.
+
+## Exit gate for U.1
+
+Full `python -m pytest tests/ -q` green (modulo pre-existing release-train failures,
+reported as a delta) AND `harness/verify/checks.py --task U.1` PASS.

--- a/harness/notes/verified_connectivity_21.0.671.json
+++ b/harness/notes/verified_connectivity_21.0.671.json
@@ -1,42 +1,4982 @@
 {
-  "_doc": "Mile-2 §2.5 preflight — IConnectivityOracle backing symbols, dir()-confirmed against LIVE Houdini 21.0.671 (headless hython, HYTHON=Houdini 21.0.671). Read-only: a throwaway /obj net was built in an isolated hython process; the user's session was untouched. Cross-checked against the committed scout symbol table (python/synapse/cognitive/tools/data/h21_symbol_table.json, houdini_version 21.0.671). Reproduce: harness/notes/mile2_2_5_introspect.py.",
-  "houdini_version": "21.0.671",
-  "symbols_present": {
-    "hou.node": true,
-    "hou.nodeType": true,
-    "hou.nodeTypeCategories": true,
-    "hou.NodeType.maxNumInputs": true,
-    "hou.NodeType.minNumInputs": true,
-    "hou.NodeType.maxNumOutputs": true,
-    "hou.NodeType.name": true,
-    "hou.NodeType.category": true,
-    "hou.NodeType.nameComponents": true,
-    "hou.Node.type": true,
-    "hou.Node.inputs": true,
-    "hou.Node.inputConnections": true,
-    "hou.Node.inputLabels": true,
-    "hou.NodeConnection.inputIndex": true,
-    "hou.NodeTypeCategory.name": true,
-    "hou.VopNode.inputDataTypes": true,
-    "hou.VopNode.outputDataTypes": true
+ "blake2b": "c213570959156138a7cda52936fcd2c1",
+ "entries": {
+  "Chop/cop2net": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
   },
+  "Chop/dopnet": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Chop/file": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:file"
+   ],
+   "type_name": "file"
+  },
+  "Chop/limit": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:limit"
+   ],
+   "type_name": "limit"
+  },
+  "Chop/lopnet": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Chop/merge": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:merge"
+   ],
+   "type_name": "merge"
+  },
+  "Chop/noise": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:noise"
+   ],
+   "type_name": "noise"
+  },
+  "Chop/null": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Chop/output": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Chop/subnet": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Chop/topnet": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Cop/block_begin": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:block_begin"
+   ],
+   "type_name": "block_begin"
+  },
+  "Cop/block_end": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:block_end"
+   ],
+   "type_name": "block_end"
+  },
+  "Cop/blur": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "size"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "blur"
+   ],
+   "sources": [
+    "emitted:blur"
+   ],
+   "type_name": "blur"
+  },
+  "Cop/bright": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "bright",
+    "shift",
+    "mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "bright"
+   ],
+   "sources": [
+    "emitted:bright"
+   ],
+   "type_name": "bright"
+  },
+  "Cop/colorcorrect": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "correct"
+   ],
+   "sources": [
+    "emitted:colorcorrect"
+   ],
+   "type_name": "colorcorrect"
+  },
+  "Cop/dilateerode": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "radius",
+    "mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "dilate"
+   ],
+   "sources": [
+    "emitted:dilateerode"
+   ],
+   "type_name": "dilateerode"
+  },
+  "Cop/dopnet": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Cop/edgedetect": {
+   "category": "Cop",
+   "input_labels": [
+    "source"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "edge"
+   ],
+   "sources": [
+    "emitted:edgedetect"
+   ],
+   "type_name": "edgedetect"
+  },
+  "Cop/file": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:file"
+   ],
+   "type_name": "file"
+  },
+  "Cop/light": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "N",
+    "mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "lit"
+   ],
+   "sources": [
+    "emitted:light"
+   ],
+   "type_name": "light"
+  },
+  "Cop/lopnet": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Cop/null": {
+   "category": "Cop",
+   "input_labels": [
+    "input1"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [
+    "output1"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Cop/opencl": {
+   "category": "Cop",
+   "input_labels": [
+    "src"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [
+    "dst"
+   ],
+   "sources": [
+    "emitted:opencl"
+   ],
+   "type_name": "opencl"
+  },
+  "Cop/output": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Cop/quantize": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "quantize"
+   ],
+   "sources": [
+    "emitted:quantize"
+   ],
+   "type_name": "quantize"
+  },
+  "Cop/sopimport": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "geometry"
+   ],
+   "sources": [
+    "emitted:sopimport"
+   ],
+   "type_name": "sopimport"
+  },
+  "Cop/subnet": {
+   "category": "Cop",
+   "input_labels": [
+    "src"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [
+    "dst"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Cop/tonemap": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "tonemap"
+   ],
+   "sources": [
+    "emitted:tonemap"
+   ],
+   "type_name": "tonemap"
+  },
+  "Cop/topnet": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Cop2/blur": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Blur",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:blur"
+   ],
+   "type_name": "blur"
+  },
+  "Cop2/bright": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Brighten",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:bright"
+   ],
+   "type_name": "bright"
+  },
+  "Cop2/colorcorrect": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Correct",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:colorcorrect"
+   ],
+   "type_name": "colorcorrect"
+  },
+  "Cop2/composite": {
+   "category": "Cop2",
+   "input_labels": [
+    "Foreground",
+    "Background",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:composite"
+   ],
+   "type_name": "composite"
+  },
+  "Cop2/cop2net": {
+   "category": "Cop2",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Cop2/dilateerode": {
+   "category": "Cop2",
+   "input_labels": [
+    "Matte to Expand",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:dilateerode"
+   ],
+   "type_name": "dilateerode"
+  },
+  "Cop2/dopnet": {
+   "category": "Cop2",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Cop2/edge": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Edge Detect",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:edge"
+   ],
+   "type_name": "edge"
+  },
+  "Cop2/file": {
+   "category": "Cop2",
+   "input_labels": [
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:file"
+   ],
+   "type_name": "file"
+  },
+  "Cop2/light": {
+   "category": "Cop2",
+   "input_labels": [
+    "Input 1",
+    "Input 2",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:light"
+   ],
+   "type_name": "light"
+  },
+  "Cop2/limit": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Limit",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:limit"
+   ],
+   "type_name": "limit"
+  },
+  "Cop2/lopnet": {
+   "category": "Cop2",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Cop2/merge": {
+   "category": "Cop2",
+   "input_labels": [
+    "Images to Merge"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:merge"
+   ],
+   "type_name": "merge"
+  },
+  "Cop2/noise": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Add To",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:noise"
+   ],
+   "type_name": "noise"
+  },
+  "Cop2/null": {
+   "category": "Cop2",
+   "input_labels": [
+    "Source Image"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Cop2/over": {
+   "category": "Cop2",
+   "input_labels": [
+    "Foreground",
+    "Background",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:over"
+   ],
+   "type_name": "over"
+  },
+  "Cop2/quantize": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Quantize",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:quantize"
+   ],
+   "type_name": "quantize"
+  },
+  "Cop2/reference": {
+   "category": "Cop2",
+   "input_labels": [
+    "Source Image"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:reference"
+   ],
+   "type_name": "reference"
+  },
+  "Cop2/rop_comp": {
+   "category": "Cop2",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:rop_comp"
+   ],
+   "type_name": "rop_comp"
+  },
+  "Cop2/sopimport": {
+   "category": "Cop2",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:sopimport"
+   ],
+   "type_name": "sopimport"
+  },
+  "Cop2/subnet": {
+   "category": "Cop2",
+   "input_labels": [
+    "Sub-Network Input #1",
+    "Sub-Network Input #2",
+    "Sub-Network Input #3",
+    "Sub-Network Input #4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Cop2/topnet": {
+   "category": "Cop2",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Cop2/vopcop2gen": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Add Planes To",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:vopcop2gen"
+   ],
+   "type_name": "vopcop2gen"
+  },
+  "Data/cop/convolve3::sidefx::blur": {
+   "category": "Data",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:blur"
+   ],
+   "type_name": "cop/convolve3::sidefx::blur"
+  },
+  "Dop/cop2net": {
+   "category": "Dop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Dop/dopnet": {
+   "category": "Dop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Dop/file": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects to use when not reading from file"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:file"
+   ],
+   "type_name": "file"
+  },
+  "Dop/flipsolver": {
+   "category": "Dop",
+   "input_labels": [
+    "Fluid to Solve",
+    "Particle Velocity",
+    "Volume Velocity",
+    "Sourcing (post-solve)"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Sub-Network Output #1"
+   ],
+   "sources": [
+    "emitted:flipsolver"
+   ],
+   "type_name": "flipsolver"
+  },
+  "Dop/flipsolver::2.0": {
+   "category": "Dop",
+   "input_labels": [
+    "Fluid to Solve",
+    "Particle Velocity",
+    "Volume Velocity",
+    "Sourcing (post-solve)"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Sub-Network Output #1"
+   ],
+   "sources": [
+    "emitted:flipsolver"
+   ],
+   "type_name": "flipsolver::2.0"
+  },
+  "Dop/gravity": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects to be processed",
+    "Data to attach\n\nAccepts any number of:\n    Mask Field\n    Noise Field"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:gravity"
+   ],
+   "type_name": "gravity"
+  },
+  "Dop/lopnet": {
+   "category": "Dop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Dop/merge": {
+   "category": "Dop",
+   "input_labels": [
+    "Any node type"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:merge"
+   ],
+   "type_name": "merge"
+  },
+  "Dop/noise": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects to be processed"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:noise"
+   ],
+   "type_name": "noise"
+  },
+  "Dop/null": {
+   "category": "Dop",
+   "input_labels": [
+    "Input 0"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Dop/output": {
+   "category": "Dop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Dop/pyrosolver": {
+   "category": "Dop",
+   "input_labels": [
+    "Object",
+    "Pre-solve",
+    "Velocity Update",
+    "Advection",
+    "Sourcing (post-solve)"
+   ],
+   "instantiated": true,
+   "max_inputs": 5,
+   "min_inputs": 1,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:pyrosolver"
+   ],
+   "type_name": "pyrosolver"
+  },
+  "Dop/pyrosolver::2.0": {
+   "category": "Dop",
+   "input_labels": [
+    "Object",
+    "Pre-solve",
+    "Velocity Update",
+    "Advection",
+    "Sourcing (post-solve)"
+   ],
+   "instantiated": true,
+   "max_inputs": 5,
+   "min_inputs": 1,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:pyrosolver"
+   ],
+   "type_name": "pyrosolver::2.0"
+  },
+  "Dop/rbdpackedobject": {
+   "category": "Dop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:rbdpackedobject"
+   ],
+   "type_name": "rbdpackedobject"
+  },
+  "Dop/rigidbodysolver": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects",
+    "Pre-Solve",
+    "Post-Solve"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:rigidbodysolver"
+   ],
+   "type_name": "rigidbodysolver"
+  },
+  "Dop/subnet": {
+   "category": "Dop",
+   "input_labels": [
+    "Input 1",
+    "Input 2",
+    "Input 3",
+    "Input 4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Dop/topnet": {
+   "category": "Dop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Dop/vellumconstraintproperty": {
+   "category": "Dop",
+   "input_labels": [
+    "Sub-Network Input #1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:vellumconstraintproperty"
+   ],
+   "type_name": "vellumconstraintproperty"
+  },
+  "Dop/vellumconstraints": {
+   "category": "Dop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:vellumconstraints"
+   ],
+   "type_name": "vellumconstraints"
+  },
+  "Dop/vellumsolver": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects to Solve",
+    "Particle Forces",
+    "Post-Solve"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:vellumsolver"
+   ],
+   "type_name": "vellumsolver"
+  },
+  "Dop/whitewatersolver": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects to Solve",
+    "Extra Sources",
+    "Particle Forces",
+    "Post-Solve"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:whitewatersolver"
+   ],
+   "type_name": "whitewatersolver"
+  },
+  "Dop/whitewatersolver::2.0": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects to Solve",
+    "Extra Sources",
+    "Particle Forces",
+    "Post-Solve"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:whitewatersolver"
+   ],
+   "type_name": "whitewatersolver::2.0"
+  },
+  "Driver/cop2net": {
+   "category": "Driver",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Driver/dopnet": {
+   "category": "Driver",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Driver/karma": {
+   "category": "Driver",
+   "input_labels": [
+    "Input #1"
+   ],
+   "instantiated": true,
+   "max_inputs": 999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:karma"
+   ],
+   "type_name": "karma"
+  },
+  "Driver/lopnet": {
+   "category": "Driver",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Driver/merge": {
+   "category": "Driver",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:merge"
+   ],
+   "type_name": "merge"
+  },
+  "Driver/null": {
+   "category": "Driver",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Driver/subnet": {
+   "category": "Driver",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 31,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Driver/topnet": {
+   "category": "Driver",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Driver/wedge": {
+   "category": "Driver",
+   "input_labels": [
+    "ROP to Wedge"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:wedge"
+   ],
+   "type_name": "wedge"
+  },
+  "Lop/assignmaterial": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:assignmaterial"
+   ],
+   "type_name": "assignmaterial"
+  },
+  "Lop/attribwrangle": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Input 2",
+    "Input 3",
+    "Input 4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:attribwrangle"
+   ],
+   "type_name": "attribwrangle"
+  },
+  "Lop/camera": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:camera"
+   ],
+   "type_name": "camera"
+  },
+  "Lop/componentgeometry": {
+   "category": "Lop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:componentgeometry"
+   ],
+   "type_name": "componentgeometry"
+  },
+  "Lop/componentoutput": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Thumbnail Scene"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:componentoutput"
+   ],
+   "type_name": "componentoutput"
+  },
+  "Lop/cop2net": {
+   "category": "Lop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Lop/domelight": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:domelight"
+   ],
+   "type_name": "domelight"
+  },
+  "Lop/domelight::2.0": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:domelight"
+   ],
+   "type_name": "domelight::2.0"
+  },
+  "Lop/domelight::3.0": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:domelight"
+   ],
+   "type_name": "domelight::3.0"
+  },
+  "Lop/dopnet": {
+   "category": "Lop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Lop/duplicate": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:duplicate"
+   ],
+   "type_name": "duplicate"
+  },
+  "Lop/extractinstances": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:extractinstances"
+   ],
+   "type_name": "extractinstances"
+  },
+  "Lop/filecache": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:filecache"
+   ],
+   "type_name": "filecache"
+  },
+  "Lop/instancer": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Possible Prototype Source"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:instancer"
+   ],
+   "type_name": "instancer"
+  },
+  "Lop/karma": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Additional Render Products"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:karma"
+   ],
+   "type_name": "karma"
+  },
+  "Lop/karmarenderproperties": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Additional Render Vars"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:karmarenderproperties"
+   ],
+   "type_name": "karmarenderproperties"
+  },
+  "Lop/labs::karma::1.0": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Additional Render Products"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:karma"
+   ],
+   "type_name": "labs::karma::1.0"
+  },
+  "Lop/labs::karma::2.0": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Additional Render Products"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:karma"
+   ],
+   "type_name": "labs::karma::2.0"
+  },
+  "Lop/layout": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:layout"
+   ],
+   "type_name": "layout"
+  },
+  "Lop/light": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:light"
+   ],
+   "type_name": "light"
+  },
+  "Lop/light::2.0": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:light"
+   ],
+   "type_name": "light::2.0"
+  },
+  "Lop/lopnet": {
+   "category": "Lop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Lop/materiallibrary": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:materiallibrary"
+   ],
+   "type_name": "materiallibrary"
+  },
+  "Lop/merge": {
+   "category": "Lop",
+   "input_labels": [
+    "Merge Stage Layers"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:merge"
+   ],
+   "type_name": "merge"
+  },
+  "Lop/mergepointinstancers": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:mergepointinstancers"
+   ],
+   "type_name": "mergepointinstancers"
+  },
+  "Lop/modifypointinstances": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:modifypointinstances"
+   ],
+   "type_name": "modifypointinstances"
+  },
+  "Lop/null": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Lop/output": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Lop/pythonscript": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:pythonscript"
+   ],
+   "type_name": "pythonscript"
+  },
+  "Lop/reference": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Add As Reference"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:reference"
+   ],
+   "type_name": "reference"
+  },
+  "Lop/reference::2.0": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Add As Reference"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:reference"
+   ],
+   "type_name": "reference::2.0"
+  },
+  "Lop/sopimport": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:sopimport"
+   ],
+   "type_name": "sopimport"
+  },
+  "Lop/splitpointinstancers": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:splitpointinstancers"
+   ],
+   "type_name": "splitpointinstancers"
+  },
+  "Lop/sublayer": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Add As Sublayer"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:sublayer"
+   ],
+   "type_name": "sublayer"
+  },
+  "Lop/subnet": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Input 2",
+    "Input 3",
+    "Input 4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 10,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Lop/topnet": {
+   "category": "Lop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Object/cam": {
+   "category": "Object",
+   "input_labels": [
+    "parent"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:cam"
+   ],
+   "type_name": "cam"
+  },
+  "Object/cop2net": {
+   "category": "Object",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Object/dopnet": {
+   "category": "Object",
+   "input_labels": [
+    "parent"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Object/geo": {
+   "category": "Object",
+   "input_labels": [
+    "parent"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:geo"
+   ],
+   "type_name": "geo"
+  },
+  "Object/light": {
+   "category": "Object",
+   "input_labels": [
+    "parent"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:light"
+   ],
+   "type_name": "light"
+  },
+  "Object/lopnet": {
+   "category": "Object",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Object/null": {
+   "category": "Object",
+   "input_labels": [
+    "parent"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Object/pythonscript": {
+   "category": "Object",
+   "input_labels": [
+    "parent"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:pythonscript"
+   ],
+   "type_name": "pythonscript"
+  },
+  "Object/subnet": {
+   "category": "Object",
+   "input_labels": [
+    "Sub-Network Input #1",
+    "Sub-Network Input #2",
+    "Sub-Network Input #3",
+    "Sub-Network Input #4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Object/topnet": {
+   "category": "Object",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Shop/cop2net": {
+   "category": "Shop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Shop/dopnet": {
+   "category": "Shop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Shop/lopnet": {
+   "category": "Shop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Shop/topnet": {
+   "category": "Shop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Sop/apex::autorigbuilder": {
+   "category": "Sop",
+   "input_labels": [
+    "CharacterStream",
+    "Rig Template"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "CharacterStream",
+    "Rig Template"
+   ],
+   "sources": [
+    "emitted:apex::autorigbuilder"
+   ],
+   "type_name": "apex::autorigbuilder"
+  },
+  "Sop/apex::autorigcomponent": {
+   "category": "Sop",
+   "input_labels": [
+    "CharacterStream",
+    "Component Script"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "CharacterStream",
+    "Component Script"
+   ],
+   "sources": [
+    "emitted:apex::autorigcomponent"
+   ],
+   "type_name": "apex::autorigcomponent"
+  },
+  "Sop/apex::autorigcomponent::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "CharacterStream",
+    "ComponentScript"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "CharacterStream",
+    "ComponentScript"
+   ],
+   "sources": [
+    "emitted:apex::autorigcomponent"
+   ],
+   "type_name": "apex::autorigcomponent::2.0"
+  },
+  "Sop/apex::autorigcomponent::3.0": {
+   "category": "Sop",
+   "input_labels": [
+    "CharacterStream",
+    "Component Script"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "CharacterStream",
+    "Component Script"
+   ],
+   "sources": [
+    "emitted:apex::autorigcomponent"
+   ],
+   "type_name": "apex::autorigcomponent::3.0"
+  },
+  "Sop/apex::buildfkgraph": {
+   "category": "Sop",
+   "input_labels": [
+    "Sub-Network Input #1",
+    "Sub-Network Input #2"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:apex::buildfkgraph"
+   ],
+   "type_name": "apex::buildfkgraph"
+  },
+  "Sop/apex::configurecontrols": {
+   "category": "Sop",
+   "input_labels": [
+    "CharacterStream",
+    "Shape Library"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "CharacterStream"
+   ],
+   "sources": [
+    "emitted:apex::configurecontrols"
+   ],
+   "type_name": "apex::configurecontrols"
+  },
+  "Sop/apex::configuregraph": {
+   "category": "Sop",
+   "input_labels": [
+    "Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output"
+   ],
+   "sources": [
+    "emitted:apex::configuregraph"
+   ],
+   "type_name": "apex::configuregraph"
+  },
+  "Sop/apex::controlextract": {
+   "category": "Sop",
+   "input_labels": [
+    "Scene/Character/Rig"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 2,
+   "output_labels": [
+    "Control Constraint Graph",
+    "Control Skeleton"
+   ],
+   "sources": [
+    "emitted:apex::controlextract"
+   ],
+   "type_name": "apex::controlextract"
+  },
+  "Sop/apex::graph": {
+   "category": "Sop",
+   "input_labels": [
+    "Sub-Network Input #1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:apex::graph"
+   ],
+   "type_name": "apex::graph"
+  },
+  "Sop/apex::invokegraph": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:apex::invokegraph"
+   ],
+   "type_name": "apex::invokegraph"
+  },
+  "Sop/apex::mapcharacter": {
+   "category": "Sop",
+   "input_labels": [
+    "Scene/Character"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Scene/Character"
+   ],
+   "sources": [
+    "emitted:apex::mapcharacter"
+   ],
+   "type_name": "apex::mapcharacter"
+  },
+  "Sop/apex::mergegraph": {
+   "category": "Sop",
+   "input_labels": [
+    "Sub-Network Input #1",
+    "Sub-Network Input #2"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "apex::mergegraph"
+  },
+  "Sop/apex::packcharacter": {
+   "category": "Sop",
+   "input_labels": [
+    "Character/Scene",
+    "Rest Geometry",
+    "Capture Pose",
+    "Animated Pose"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Character/Scene"
+   ],
+   "sources": [
+    "emitted:apex::packcharacter"
+   ],
+   "type_name": "apex::packcharacter"
+  },
+  "Sop/apex::sceneinvoke": {
+   "category": "Sop",
+   "input_labels": [
+    "Scene"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 1,
+   "output_count": 2,
+   "output_labels": [
+    "Scene Outputs"
+   ],
+   "sources": [
+    "emitted:apex::sceneinvoke"
+   ],
+   "type_name": "apex::sceneinvoke"
+  },
+  "Sop/apex::sceneinvoke::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Scene"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Scene Outputs"
+   ],
+   "sources": [
+    "emitted:apex::sceneinvoke"
+   ],
+   "type_name": "apex::sceneinvoke::2.0"
+  },
+  "Sop/assemble": {
+   "category": "Sop",
+   "input_labels": [
+    "Polygons to Assemble into Pieces"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:assemble"
+   ],
+   "type_name": "assemble"
+  },
+  "Sop/attribwrangle": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Process with Wrangle",
+    "Ancillary Input, point(1, ...) to Access",
+    "Ancillary Input, point(2, ...) to Access",
+    "Ancillary Input, point(3, ...) to Access"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:attribwrangle"
+   ],
+   "type_name": "attribwrangle"
+  },
+  "Sop/beta::tissuesolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Tissue",
+    "Fascia",
+    "Target Constraint Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Tissue Output"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "beta::tissuesolver"
+  },
+  "Sop/blendshapes": {
+   "category": "Sop",
+   "input_labels": [
+    "Blend Source",
+    "Blend Source"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "blendshapes"
+  },
+  "Sop/blendshapes::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Blend Source",
+    "Blend Source"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "blendshapes::2.0"
+  },
+  "Sop/block_begin": {
+   "category": "Sop",
+   "input_labels": [
+    "Initial Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:block_begin"
+   ],
+   "type_name": "block_begin"
+  },
+  "Sop/block_end": {
+   "category": "Sop",
+   "input_labels": [
+    "Nodes to Iterate Over",
+    "Geometry Pieces to Loop Over"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:block_end"
+   ],
+   "type_name": "block_end"
+  },
+  "Sop/cop2net": {
+   "category": "Sop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Sop/debrissource": {
+   "category": "Sop",
+   "input_labels": [
+    "Simulated or Rest Geometry",
+    "Simulation Points when using Rest Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Source Points"
+   ],
+   "sources": [
+    "emitted:debrissource"
+   ],
+   "type_name": "debrissource"
+  },
+  "Sop/debrissource::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Simulated or Rest Geometry",
+    "Simulation Points when using Rest Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Source Points"
+   ],
+   "sources": [
+    "emitted:debrissource"
+   ],
+   "type_name": "debrissource::2.0"
+  },
+  "Sop/dopnet": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2",
+    "Input 3",
+    "Input 4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Sop/duplicate": {
+   "category": "Sop",
+   "input_labels": [
+    "Source geometry to duplicate"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:duplicate"
+   ],
+   "type_name": "duplicate"
+  },
+  "Sop/fasciasolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Fascia",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Solved Fascia"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "fasciasolver"
+  },
+  "Sop/feathersurfaceblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Feathers",
+    "Skin",
+    "VDB",
+    "Target Surface"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Feathers",
+    "Skin",
+    "VDB"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "feathersurfaceblend"
+  },
+  "Sop/file": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:file"
+   ],
+   "type_name": "file"
+  },
+  "Sop/filecache": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Cache to Disk"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Cached Geometry"
+   ],
+   "sources": [
+    "emitted:filecache"
+   ],
+   "type_name": "filecache"
+  },
+  "Sop/filecache::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Cache to Disk"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Cached Geometry"
+   ],
+   "sources": [
+    "emitted:filecache"
+   ],
+   "type_name": "filecache::2.0"
+  },
+  "Sop/filemerge": {
+   "category": "Sop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "filemerge"
+  },
+  "Sop/filemerge::2.0": {
+   "category": "Sop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "filemerge::2.0"
+  },
+  "Sop/flipsolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Sources",
+    "Container",
+    "Collisions",
+    "Boundary Flow"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 3,
+   "output_count": 3,
+   "output_labels": [
+    "Fluid Particles",
+    "Container",
+    "Collisions"
+   ],
+   "sources": [
+    "emitted:flipsolver",
+    "sop_pattern"
+   ],
+   "type_name": "flipsolver"
+  },
+  "Sop/groomblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Guides A",
+    "Skin A",
+    "Skin VDB",
+    "Guides B",
+    "Skin B"
+   ],
+   "instantiated": true,
+   "max_inputs": 5,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Guides B",
+    "Skin",
+    "Skin VDB"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "groomblend"
+  },
+  "Sop/groomswitch": {
+   "category": "Sop",
+   "input_labels": [
+    "Guides A",
+    "Skin A",
+    "Skin VDB A",
+    "Guides B",
+    "Skin B",
+    "Skin VDB B"
+   ],
+   "instantiated": true,
+   "max_inputs": 6,
+   "min_inputs": 6,
+   "output_count": 3,
+   "output_labels": [
+    "Guides",
+    "Skin",
+    "Skin VDB"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "groomswitch"
+  },
+  "Sop/heightfield": {
+   "category": "Sop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Sub-Network Output #1"
+   ],
+   "sources": [
+    "emitted:heightfield"
+   ],
+   "type_name": "heightfield"
+  },
+  "Sop/heightfield_erode": {
+   "category": "Sop",
+   "input_labels": [
+    "Terrain to Erode",
+    "Masks"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Eroded Terrain"
+   ],
+   "sources": [
+    "emitted:heightfield_erode"
+   ],
+   "type_name": "heightfield_erode"
+  },
+  "Sop/heightfield_erode::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Terrain to Erode",
+    "Masks"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Sub-Network Output #1"
+   ],
+   "sources": [
+    "emitted:heightfield_erode"
+   ],
+   "type_name": "heightfield_erode::2.0"
+  },
+  "Sop/heightfield_erode::3.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Terrain to Erode",
+    "Masks"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Eroded Terrain"
+   ],
+   "sources": [
+    "emitted:heightfield_erode"
+   ],
+   "type_name": "heightfield_erode::3.0"
+  },
+  "Sop/heightfield_noise": {
+   "category": "Sop",
+   "input_labels": [
+    "Terrain",
+    "Mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:heightfield_noise"
+   ],
+   "type_name": "heightfield_noise"
+  },
+  "Sop/kinefx::characterblendshapechannels": {
+   "category": "Sop",
+   "input_labels": [
+    "Skeleton",
+    "Mesh"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Skeleton"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::characterblendshapechannels"
+  },
+  "Sop/kinefx::characterblendshapes": {
+   "category": "Sop",
+   "input_labels": [
+    "Rest Geometry",
+    "Capture Pose",
+    "Animated Pose"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 3,
+   "output_count": 3,
+   "output_labels": [
+    "Rest Geometry",
+    "Capture Pose",
+    "Animated Pose"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::characterblendshapes"
+  },
+  "Sop/kinefx::characterblendshapesadd": {
+   "category": "Sop",
+   "input_labels": [
+    "Mesh",
+    "Packed Blendshapes"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::characterblendshapesadd"
+  },
+  "Sop/kinefx::characterblendshapescore": {
+   "category": "Sop",
+   "input_labels": [
+    "Input Geometry",
+    "Animated Pose"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::characterblendshapescore"
+  },
+  "Sop/kinefx::characterblendshapesextract": {
+   "category": "Sop",
+   "input_labels": [
+    "Mesh"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Blend Shape"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::characterblendshapesextract"
+  },
+  "Sop/kinefx::motionclipblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Base",
+    "Layer"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "MotionClip"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::motionclipblend"
+  },
+  "Sop/kinefx::motionclipblend::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Base",
+    "Layer"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "MotionClip"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::motionclipblend::2.0"
+  },
+  "Sop/kinefx::motionclipmerge": {
+   "category": "Sop",
+   "input_labels": [
+    "Motion Clips",
+    "Motion Clip to Merge"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::motionclipmerge"
+  },
+  "Sop/kinefx::ragdollsolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Skeleton",
+    "Collision Shapes",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 2,
+   "output_labels": [
+    "Skeleton"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::ragdollsolver"
+  },
+  "Sop/kinefx::ragdollsolver::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Skeleton",
+    "Collision Shapes",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Skeleton"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::ragdollsolver::2.0"
+  },
+  "Sop/kinefx::rigdoctor": {
+   "category": "Sop",
+   "input_labels": [
+    "Poly Lines"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Skeleton"
+   ],
+   "sources": [
+    "emitted:kinefx::rigdoctor"
+   ],
+   "type_name": "kinefx::rigdoctor"
+  },
+  "Sop/kinefx::skeletonblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::skeletonblend"
+  },
+  "Sop/kinefx::skeletonblend::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::skeletonblend::2.0"
+  },
+  "Sop/kinefx::skeletonblend::3.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::skeletonblend::3.0"
+  },
+  "Sop/labs::color_blend": {
+   "category": "Sop",
+   "input_labels": [
+    "Input Mesh",
+    "Additional Mesh",
+    "(Optional) Mask Mesh"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "labs::color_blend"
+  },
+  "Sop/labs::filecache::1.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Cache to Disk"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Cached Geometry"
+   ],
+   "sources": [
+    "emitted:filecache"
+   ],
+   "type_name": "labs::filecache::1.0"
+  },
+  "Sop/labs::filecache::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Cache to Disk"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Cached Geometry"
+   ],
+   "sources": [
+    "emitted:filecache"
+   ],
+   "type_name": "labs::filecache::2.0"
+  },
+  "Sop/labs::merge_small_islands": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry with UVs"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "labs::merge_small_islands"
+  },
+  "Sop/labs::merge_small_islands::1.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry with UVs"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "labs::merge_small_islands::1.0"
+  },
+  "Sop/labs::merge_splines::1.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Polylines to Merge"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 2,
+   "output_labels": [
+    "Output",
+    "Guide Visual Output"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "labs::merge_splines::1.0"
+  },
+  "Sop/linearsolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Matrix/Decomposition (&Vectors)",
+    "Known Vector",
+    "Unknown Vector"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "linearsolver"
+  },
+  "Sop/lopnet": {
+   "category": "Sop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Sop/merge": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:merge",
+    "sop_pattern"
+   ],
+   "type_name": "merge"
+  },
+  "Sop/mergepacked": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "mergepacked"
+  },
+  "Sop/mpmsolver": {
+   "category": "Sop",
+   "input_labels": [
+    "MPM Sources",
+    "MPM Colliders",
+    "MPM Container"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "MPM Output Particles"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "mpmsolver"
+  },
+  "Sop/musclemerge": {
+   "category": "Sop",
+   "input_labels": [
+    "Sub-Network Input #1",
+    "Sub-Network Input #2",
+    "Sub-Network Input #3",
+    "Sub-Network Input #4",
+    "Input #5",
+    "Input #6"
+   ],
+   "instantiated": true,
+   "max_inputs": 6,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "musclemerge"
+  },
+  "Sop/musclesolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Muscles",
+    "Bones",
+    "Muscle Tension Ref"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Solved Muscles"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "musclesolver"
+  },
+  "Sop/musclesolverfem": {
+   "category": "Sop",
+   "input_labels": [
+    "Muscles",
+    "Bones",
+    "Muscle Tension Ref"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Solved Muscles"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "musclesolverfem"
+  },
+  "Sop/musclesolvervellum": {
+   "category": "Sop",
+   "input_labels": [
+    "Muscles",
+    "Bones",
+    "Activation Attribute Reference"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Solved Muscles"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "musclesolvervellum"
+  },
+  "Sop/null": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Sop/object_merge": {
+   "category": "Sop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "object_merge"
+  },
+  "Sop/oceanevaluate": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Deform",
+    "Ocean Spectrum"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Sub-Network Output #1"
+   ],
+   "sources": [
+    "emitted:oceanevaluate"
+   ],
+   "type_name": "oceanevaluate"
+  },
+  "Sop/oceanevaluate::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Deform",
+    "Ocean Spectrum"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Sub-Network Output #1"
+   ],
+   "sources": [
+    "emitted:oceanevaluate"
+   ],
+   "type_name": "oceanevaluate::2.0"
+  },
+  "Sop/oceansource": {
+   "category": "Sop",
+   "input_labels": [
+    "Ocean Spectrum",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Initial",
+    "Maintain"
+   ],
+   "sources": [
+    "emitted:oceansource"
+   ],
+   "type_name": "oceansource"
+  },
+  "Sop/oceansource::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Ocean Spectrum",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "Initial",
+    "Maintain"
+   ],
+   "sources": [
+    "emitted:oceansource"
+   ],
+   "type_name": "oceansource::2.0"
+  },
+  "Sop/oceanspectrum": {
+   "category": "Sop",
+   "input_labels": [
+    "Wave Instancing Points",
+    "Mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Spectrum Layer"
+   ],
+   "sources": [
+    "emitted:oceanspectrum"
+   ],
+   "type_name": "oceanspectrum"
+  },
+  "Sop/opencl": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2",
+    "Input 3",
+    "Input 4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:opencl"
+   ],
+   "type_name": "opencl"
+  },
+  "Sop/otissolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 2,
+   "output_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "otissolver"
+  },
+  "Sop/output": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Sop/pyrosolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Sources",
+    "Collision Geometry/Volumes"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Simulated Fields"
+   ],
+   "sources": [
+    "emitted:pyrosolver",
+    "sop_pattern"
+   ],
+   "type_name": "pyrosolver"
+  },
+  "Sop/rbdbulletsolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry",
+    "Collision Geometry",
+    "Guide Sim"
+   ],
+   "instantiated": true,
+   "max_inputs": 5,
+   "min_inputs": 1,
+   "output_count": 4,
+   "output_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry",
+    "Simulation Points"
+   ],
+   "sources": [
+    "emitted:rbdbulletsolver",
+    "sop_pattern"
+   ],
+   "type_name": "rbdbulletsolver"
+  },
+  "Sop/rbdconstraintproperties": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "sources": [
+    "emitted:rbdconstraintproperties"
+   ],
+   "type_name": "rbdconstraintproperties"
+  },
+  "Sop/rbdconstraintproperties::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "sources": [
+    "emitted:rbdconstraintproperties"
+   ],
+   "type_name": "rbdconstraintproperties::2.0"
+  },
+  "Sop/rbdconstraintsfromrules": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry",
+    "Bounding Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "sources": [
+    "emitted:rbdconstraintsfromrules"
+   ],
+   "type_name": "rbdconstraintsfromrules"
+  },
+  "Sop/rbdmaterialfracture": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry",
+    "Extra Voronoi Points (Concrete) / Impact Points (Glass) / Cutter Geometry (Custom)"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "sources": [
+    "emitted:rbdmaterialfracture"
+   ],
+   "type_name": "rbdmaterialfracture"
+  },
+  "Sop/rbdmaterialfracture::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry",
+    "Extra Voronoi Points (Concrete) / Impact Points (Glass)"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry"
+   ],
+   "sources": [
+    "emitted:rbdmaterialfracture"
+   ],
+   "type_name": "rbdmaterialfracture::2.0"
+  },
+  "Sop/rbdmaterialfracture::3.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry",
+    "Extra Voronoi Points (Concrete) / Impact Points (Glass) / Cutter Geometry (Custom)"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "sources": [
+    "emitted:rbdmaterialfracture"
+   ],
+   "type_name": "rbdmaterialfracture::3.0"
+  },
+  "Sop/ripplesolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Rest Geometry",
+    "Displaced Geometry",
+    "Collide Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Geometry with Simulated Ripples"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "ripplesolver"
+  },
+  "Sop/sblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Blend Source"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "sblend"
+  },
+  "Sop/sblend::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Blend Source"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "sblend::2.0"
+  },
+  "Sop/scatter": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to scatter points onto"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:scatter"
+   ],
+   "type_name": "scatter"
+  },
+  "Sop/scatter::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to scatter points onto"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:scatter"
+   ],
+   "type_name": "scatter::2.0"
+  },
+  "Sop/shallowwatersolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Height Fields"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Height Fields with Simulated Water"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "shallowwatersolver"
+  },
+  "Sop/skinsolvervellum": {
+   "category": "Sop",
+   "input_labels": [
+    "Tissue",
+    "Internal Attach Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Tissue Output"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "skinsolvervellum"
+  },
+  "Sop/solver": {
+   "category": "Sop",
+   "input_labels": [
+    "Initial Geometry",
+    "Auxillary #1",
+    "Auxillary #2",
+    "Auxillary #3"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "solver"
+  },
+  "Sop/subnet": {
+   "category": "Sop",
+   "input_labels": [
+    "Sub-Network Input #1",
+    "Sub-Network Input #2",
+    "Sub-Network Input #3",
+    "Sub-Network Input #4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 11,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Sop/switch": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "switch"
+  },
+  "Sop/switchif": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "switchif"
+  },
+  "Sop/timeblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Evaluate at Another Time"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "timeblend"
+  },
+  "Sop/timeblend::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Evaluate at Another Time"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "timeblend::2.0"
+  },
+  "Sop/tissuesolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Skin",
+    "Animated Muscles",
+    "Static Muscles",
+    "Animated Bones",
+    "Static Bones"
+   ],
+   "instantiated": true,
+   "max_inputs": 5,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "Solver Output"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "tissuesolver"
+  },
+  "Sop/tissuesolvervellum": {
+   "category": "Sop",
+   "input_labels": [
+    "Tissue",
+    "Internal Attach Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Tissue Output"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "tissuesolvervellum"
+  },
+  "Sop/topnet": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Sop/vdbmerge": {
+   "category": "Sop",
+   "input_labels": [
+    "VDBs To Merge"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "vdbmerge"
+  },
+  "Sop/vdbvectormerge": {
+   "category": "Sop",
+   "input_labels": [
+    "Scalar VDBs to merge into vector"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "vdbvectormerge"
+  },
+  "Sop/vellumconstraintproperty": {
+   "category": "Sop",
+   "input_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 3,
+   "output_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "sources": [
+    "emitted:vellumconstraintproperty"
+   ],
+   "type_name": "vellumconstraintproperty"
+  },
+  "Sop/vellumconstraints": {
+   "category": "Sop",
+   "input_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "sources": [
+    "emitted:vellumconstraints"
+   ],
+   "type_name": "vellumconstraints"
+  },
+  "Sop/vellumdrape": {
+   "category": "Sop",
+   "input_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 3,
+   "output_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "sources": [
+    "emitted:vellumdrape"
+   ],
+   "type_name": "vellumdrape"
+  },
+  "Sop/vellumrestblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraints",
+    "Collisions",
+    "Rest Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 2,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry",
+    "Constraints",
+    "Collisions"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "vellumrestblend"
+  },
+  "Sop/vellumsolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 3,
+   "output_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "sources": [
+    "emitted:vellumsolver",
+    "sop_pattern"
+   ],
+   "type_name": "vellumsolver"
+  },
+  "Sop/volumemerge": {
+   "category": "Sop",
+   "input_labels": [
+    "Base Volume",
+    "Volumes to Merge in"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "volumemerge"
+  },
+  "Sop/volumerasterizeattributes": {
+   "category": "Sop",
+   "input_labels": [
+    "Points to Rasterize"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "VDBs"
+   ],
+   "sources": [
+    "emitted:volumerasterizeattributes"
+   ],
+   "type_name": "volumerasterizeattributes"
+  },
+  "Sop/whitewatersolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Emission and Fluid Fields",
+    "Container",
+    "Collisions"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 3,
+   "output_count": 3,
+   "output_labels": [
+    "Whitewater Particles",
+    "Container",
+    "Collisions"
+   ],
+   "sources": [
+    "emitted:whitewatersolver",
+    "sop_pattern"
+   ],
+   "type_name": "whitewatersolver"
+  },
+  "Sop/whitewatersource": {
+   "category": "Sop",
+   "input_labels": [
+    "Liquid Simulation",
+    "Container",
+    "Collisions",
+    "Extra Sources"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Volumes",
+    "Container",
+    "Collisions",
+    "Visualization Particles"
+   ],
+   "sources": [
+    "emitted:whitewatersource"
+   ],
+   "type_name": "whitewatersource"
+  },
+  "Sop/whitewatersource::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Liquid Simulation",
+    "Extra Source Points",
+    "Emission Mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Volumes"
+   ],
+   "sources": [
+    "emitted:whitewatersource"
+   ],
+   "type_name": "whitewatersource::2.0"
+  },
+  "Sop/whitewatersource::3.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Liquid Simulation",
+    "Container",
+    "Collisions",
+    "Extra Sources"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 4,
+   "output_labels": [
+    "Volumes",
+    "Container",
+    "Collisions",
+    "Visualization Particles"
+   ],
+   "sources": [
+    "emitted:whitewatersource"
+   ],
+   "type_name": "whitewatersource::3.0"
+  },
+  "Sop/wireblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Blend Source"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "wireblend"
+  },
+  "Top/cop2net": {
+   "category": "Top",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Top/dopnet": {
+   "category": "Top",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Top/ffmpegencodevideo": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:ffmpegencodevideo"
+   ],
+   "type_name": "ffmpegencodevideo"
+  },
+  "Top/genericgenerator": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:genericgenerator"
+   ],
+   "type_name": "genericgenerator"
+  },
+  "Top/labs::wedge::1.0": {
+   "category": "Top",
+   "input_labels": [
+    "Work-Items to wedge"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Wedged Work-Items"
+   ],
+   "sources": [
+    "emitted:wedge"
+   ],
+   "type_name": "labs::wedge::1.0"
+  },
+  "Top/localscheduler": {
+   "category": "Top",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:localscheduler"
+   ],
+   "type_name": "localscheduler"
+  },
+  "Top/lopnet": {
+   "category": "Top",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Top/merge": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:merge"
+   ],
+   "type_name": "merge"
+  },
+  "Top/null": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Top/output": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Top/partitionbyattribute": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:partitionbyattribute"
+   ],
+   "type_name": "partitionbyattribute"
+  },
+  "Top/pythonscript": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:pythonscript"
+   ],
+   "type_name": "pythonscript"
+  },
+  "Top/ropfetch": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:ropfetch"
+   ],
+   "type_name": "ropfetch"
+  },
+  "Top/subnet": {
+   "category": "Top",
+   "input_labels": [
+    "Input 1",
+    "Input 2",
+    "Input 3",
+    "Input 4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Top/topnet": {
+   "category": "Top",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Top/wedge": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:wedge"
+   ],
+   "type_name": "wedge"
+  },
+  "TopNet/topnet": {
+   "category": "TopNet",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Vop/block_begin": {
+   "category": "Vop",
+   "input_labels": [
+    "Next (Any Type)"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:block_begin"
+   ],
+   "type_name": "block_begin"
+  },
+  "Vop/block_end": {
+   "category": "Vop",
+   "input_labels": [
+    "Next (Any Type)"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:block_end"
+   ],
+   "type_name": "block_end"
+  },
+  "Vop/composite": {
+   "category": "Vop",
+   "input_labels": [
+    "Operation",
+    "A",
+    "A Alpha",
+    "B",
+    "B Alpha"
+   ],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "Resulting Color",
+    "Resulting Alpha"
+   ],
+   "sources": [
+    "emitted:composite"
+   ],
+   "type_name": "composite"
+  },
+  "Vop/file": {
+   "category": "Vop",
+   "input_labels": [
+    "File",
+    "Frame Offset",
+    "Motion Blur Style",
+    "Use Velocity Motion Blur",
+    "Blur File",
+    "Shutter",
+    "Material Archive",
+    "Share Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Geometry"
+   ],
+   "sources": [
+    "emitted:file"
+   ],
+   "type_name": "file"
+  },
+  "Vop/kinefx::blendtransforms": {
+   "category": "Vop",
+   "input_labels": [
+    "Transform 1",
+    "Transform 2",
+    "Components",
+    "Bias"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Transform"
+   ],
+   "sources": [
+    "emitted:kinefx::blendtransforms"
+   ],
+   "type_name": "kinefx::blendtransforms"
+  },
+  "Vop/kinefx::twoboneik": {
+   "category": "Vop",
+   "input_labels": [
+    "Root",
+    "Mid",
+    "Tip",
+    "Root Driver",
+    "Twist",
+    "Goal",
+    "Stretch",
+    "Twist Offset",
+    "Blend",
+    "Orient Tip to Goal"
+   ],
+   "instantiated": true,
+   "max_inputs": 10,
+   "min_inputs": 0,
+   "output_count": 3,
+   "output_labels": [
+    "Root",
+    "Mid",
+    "Tip"
+   ],
+   "sources": [
+    "emitted:kinefx::twoboneik"
+   ],
+   "type_name": "kinefx::twoboneik"
+  },
+  "Vop/null": {
+   "category": "Vop",
+   "input_labels": [
+    "Next Input (all types allowed)"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Vop/output": {
+   "category": "Vop",
+   "input_labels": [
+    "Surface Color",
+    "Surface Opacity",
+    "Surface Alpha",
+    "Surface Normal",
+    "BSDF"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Vop/subnet": {
+   "category": "Vop",
+   "input_labels": [
+    "Next Input (all types allowed)"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "VopNet/light": {
+   "category": "VopNet",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:light"
+   ],
+   "type_name": "light"
+  },
+  "VopNet/subnet": {
+   "category": "VopNet",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  }
+ },
+ "generated": {
+  "by": "host/introspect_connectivity.py",
+  "from": "python/synapse/cognitive/tools/data/emitted_node_types.json",
+  "note": "deterministic: no wall-clock stamp — a second run on the same build must be byte-identical (the U.1 determinism pin)"
+ },
+ "houdini_version": "21.0.671",
+ "probe_errors": [],
+ "schema": "verified_connectivity/v2",
+ "v1_preserved": {
+  "_doc": "Mile-2 §2.5 preflight — IConnectivityOracle backing symbols, dir()-confirmed against LIVE Houdini 21.0.671 (headless hython, HYTHON=Houdini 21.0.671). Read-only: a throwaway /obj net was built in an isolated hython process; the user's session was untouched. Cross-checked against the committed scout symbol table (python/synapse/cognitive/tools/data/h21_symbol_table.json, houdini_version 21.0.671). Reproduce: harness/notes/mile2_2_5_introspect.py.",
+  "_provenance": "carried verbatim from verified_connectivity v1 (Mile-2 §2.5 preflight, dir()-confirmed on live 21.0.671; harness/notes/mile2_2_5_introspect.py) — NOT re-derived by host/introspect_connectivity.py",
   "symbols_PHANTOM_do_not_use": {
-    "hou.NodeType.inputLabels": "ABSENT in 21.0.671 dir(hou.NodeType) — input labels are INSTANCE-level only (hou.Node.inputLabels). Type-level label lookup degrades to []. P3c is advisory, so this is graceful.",
-    "hou.NodeType.outputLabels": "ABSENT — same as inputLabels.",
-    "hou.NodeType.inputNames": "ABSENT in 21.0.671."
+   "hou.NodeType.inputLabels": "ABSENT in 21.0.671 dir(hou.NodeType) — input labels are INSTANCE-level only (hou.Node.inputLabels). Type-level label lookup degrades to []. P3c is advisory, so this is graceful.",
+   "hou.NodeType.inputNames": "ABSENT in 21.0.671.",
+   "hou.NodeType.outputLabels": "ABSENT — same as inputLabels."
+  },
+  "symbols_present": {
+   "hou.Node.inputConnections": true,
+   "hou.Node.inputLabels": true,
+   "hou.Node.inputs": true,
+   "hou.Node.type": true,
+   "hou.NodeConnection.inputIndex": true,
+   "hou.NodeType.category": true,
+   "hou.NodeType.maxNumInputs": true,
+   "hou.NodeType.maxNumOutputs": true,
+   "hou.NodeType.minNumInputs": true,
+   "hou.NodeType.name": true,
+   "hou.NodeType.nameComponents": true,
+   "hou.NodeTypeCategory.name": true,
+   "hou.VopNode.inputDataTypes": true,
+   "hou.VopNode.outputDataTypes": true,
+   "hou.node": true,
+   "hou.nodeType": true,
+   "hou.nodeTypeCategories": true
   },
   "verified_values": {
-    "category_keys": ["Chop", "ChopNet", "Cop", "Cop2", "CopNet", "Data", "Director", "Dop", "Driver", "Lop", "Manager", "Object", "Shop", "Sop", "Top", "TopNet", "Vop", "VopNet"],
-    "arity_min_max_outs": {
-      "Sop/box": [0, 1, 1],
-      "Sop/xform": [1, 1, 1],
-      "Sop/merge": [0, 9999, 1],
-      "Vop/add": [1, 2048, 1],
-      "Vop/constant": [0, 0, 1]
-    },
-    "variadic_sentinel_note": "Variadic max inputs reported as a large finite cap (Sop/merge=9999, Vop/add=2048), NOT -1. The validator must treat 'index < max' generically; the in-repo MOCK uses -1 as its own unlimited sentinel, so the validator also treats max<0 as unlimited. Both map to 'no overflow'.",
-    "occupied_input_logic": "merge with box wired to input0 -> inputConnections() yields one NodeConnection with inputIndex()==0. input_is_occupied(path, i) := any(c.inputIndex()==i for c in node.inputConnections()).",
-    "resolve_node_type_logic": "hou.node(path).type() -> (.name(), .category().name()); box -> ('box','Sop').",
-    "vop_datatypes_precook": "VopNode.inputDataTypes()/outputDataTypes() read ['undef'] on a fresh uncooked node -> NO reliable non-mutating type-level wire-compat oracle in 21.0.671. types_compatible() degrades; is_typed_category() still honest (Vop/Chop/Shop)."
+   "arity_min_max_outs": {
+    "Sop/box": [
+     0,
+     1,
+     1
+    ],
+    "Sop/merge": [
+     0,
+     9999,
+     1
+    ],
+    "Sop/xform": [
+     1,
+     1,
+     1
+    ],
+    "Vop/add": [
+     1,
+     2048,
+     1
+    ],
+    "Vop/constant": [
+     0,
+     0,
+     1
+    ]
+   },
+   "category_keys": [
+    "Chop",
+    "ChopNet",
+    "Cop",
+    "Cop2",
+    "CopNet",
+    "Data",
+    "Director",
+    "Dop",
+    "Driver",
+    "Lop",
+    "Manager",
+    "Object",
+    "Shop",
+    "Sop",
+    "Top",
+    "TopNet",
+    "Vop",
+    "VopNet"
+   ],
+   "occupied_input_logic": "merge with box wired to input0 -> inputConnections() yields one NodeConnection with inputIndex()==0. input_is_occupied(path, i) := any(c.inputIndex()==i for c in node.inputConnections()).",
+   "resolve_node_type_logic": "hou.node(path).type() -> (.name(), .category().name()); box -> ('box','Sop').",
+   "variadic_sentinel_note": "Variadic max inputs reported as a large finite cap (Sop/merge=9999, Vop/add=2048), NOT -1. The validator must treat 'index < max' generically; the in-repo MOCK uses -1 as its own unlimited sentinel, so the validator also treats max<0 as unlimited. Both map to 'no overflow'.",
+   "vop_datatypes_precook": "VopNode.inputDataTypes()/outputDataTypes() read ['undef'] on a fresh uncooked node -> NO reliable non-mutating type-level wire-compat oracle in 21.0.671. types_compatible() degrades; is_typed_category() still honest (Vop/Chop/Shop)."
   }
+ }
 }

--- a/harness/run.ts
+++ b/harness/run.ts
@@ -110,6 +110,13 @@ function runAgent(systemPrompt: string, userMsg: string, cwd: string): string {
         shell: process.platform === "win32",
         input: userMsg,                 // prompt via stdin — keeps it off the command line
         maxBuffer: 64 * 1024 * 1024,
+        // Worktree-shadowing guard (flywheel U.1 meta-finding): the agent's bare
+        // `pytest` would resolve `synapse` from the MAIN checkout via a dev-machine
+        // editable install — pin this worktree's package first for all children.
+        env: {
+          ...process.env,
+          PYTHONPATH: `${cwd.replace(/\\/g, "/")}/python${process.platform === "win32" ? ";" : ":"}${process.env.PYTHONPATH ?? ""}`,
+        },
       }
     );
     if (r.status !== 0) log(`${c.warn}  agent exited ${r.status}: ${(r.stderr || "").slice(0, 400)}${c.off}`);

--- a/harness/state/flywheel_queue.json
+++ b/harness/state/flywheel_queue.json
@@ -1,0 +1,18 @@
+{
+  "schema": "flywheel_queue/v1",
+  "_doc": "Utility-flywheel cycle queue. status: building | candidate | done. ratified is flipped by a HUMAN only (anti-runaway anchor, spec-U1-wiring-flywheel.md); an unratified candidate is a proposal, never a work order. Every entry must carry evidence (artifact paths) — evidence-free entries are invalid.",
+  "cycles": [
+    {
+      "id": "U.1",
+      "title": "Network-wiring truth: connectivity catalog -> review sweep -> wire_by_label + validator pin",
+      "status": "building",
+      "evidence": [
+        "harness/notes/spec-U1-wiring-flywheel.md",
+        "harness/notes/verified_connectivity_21.0.671.json",
+        "python/synapse/routing/planner.py",
+        "python/synapse/routing/recipes/fx_recipes.py"
+      ],
+      "ratified": true
+    }
+  ]
+}

--- a/harness/state/flywheel_queue.json
+++ b/harness/state/flywheel_queue.json
@@ -13,6 +13,42 @@
         "python/synapse/routing/recipes/fx_recipes.py"
       ],
       "ratified": true
+    },
+    {
+      "id": "U.2",
+      "title": "Parameter-name truth: gate emitted parm()/setParm literals against the nodetype catalog's live parm fingerprints",
+      "status": "candidate",
+      "evidence": [
+        "harness/notes/verified_nodetype_catalog_21.0.671.json",
+        ".claude/flywheel_u1_findings.json",
+        "python/synapse/routing/planner.py",
+        "python/synapse/routing/recipes/fx_recipes.py"
+      ],
+      "ratified": false,
+      "note": "The nodetype catalog already carries ordered [(parm, type, default)] per resolved type — the same sweep pattern (createNode var map -> parm('x') literals) closes the loop nobody gates today."
+    },
+    {
+      "id": "U.3",
+      "title": "Source-output-index truth: validate setInput's third arg against catalog output_count/output_labels",
+      "status": "candidate",
+      "evidence": [
+        "harness/notes/verified_connectivity_21.0.671.json",
+        ".claude/flywheel_u1_findings.json"
+      ],
+      "ratified": false,
+      "note": "v2 catalog now carries output_count + ordered output_labels (e.g. vellumconstraints out 1 = Constraint Geometry, relied on by solver.setInput(1, cloth, 1)); the U.1 sweep only proves the TARGET side."
+    },
+    {
+      "id": "U.4",
+      "title": "Wire-time arity guard at the dynamic-index API boundary (handlers_node/api_adapter setInput passthroughs)",
+      "status": "candidate",
+      "evidence": [
+        ".claude/flywheel_u1_findings.json",
+        "python/synapse/server/api_adapter.py",
+        "python/synapse/server/handlers_node.py"
+      ],
+      "ratified": false,
+      "note": "The sweep's dynamic-index INFO sites are runtime passthroughs with no catalog check; wiring.wire_by_label/catalog lookup can gate them at call time."
     }
   ]
 }

--- a/harness/tasks.json
+++ b/harness/tasks.json
@@ -7,7 +7,8 @@
     "nodes_appear", "ledger", "revert_clean", "render", "theme_ok",
     "mcp_surface_probe", "mcp_registered", "mcp_truth_contract",
     "scout_federates", "scout_no_apex_corpus", "no_rigging_drift",
-    "provenance_not_bypassed"
+    "provenance_not_bypassed",
+    "connectivity_catalog_fresh", "wiring_conformance", "validator_catches_miswire"
   ],
   "guardrails": {
     "_comment": "Run on EVERY sprint by checks.py, in addition to the task's own verify list. A guardrail with ok:false ⇒ deterministic FAIL (run.ts short-circuits before the Evaluator and writes a repair ticket). A guardrail with ok:null ⇒ not yet wired ⇒ WARN, never blocks. These enforce SYNAPSE_H22_BOUNDARY.md's non-goals so no Generator round can silently erode the moat: no APEX corpus in scout, no rigging-authoring drift, no mutation that bypasses the ledger.",
@@ -123,6 +124,24 @@
       "refs": ["DEMO_SCRIPT.md"],
       "verify": ["mcp_registered", "ledger"],
       "note": "Prove leg. Show the boundary live: Synapse calls the native MCP as one source, the call is truth-contract-wrapped and recorded in agent.usd, and is reversible. The receipts are the one thing the native MCP can't do alone — that's the whole pitch." },
-    { "id": "3.4", "mode": "B", "blocked_on": "drop", "crit": false, "title": "Capsule the ship state", "human_gate": { "decision": "manual" }, "verify": [] }
+    { "id": "3.4", "mode": "B", "blocked_on": "drop", "crit": false, "title": "Capsule the ship state", "human_gate": { "decision": "manual" }, "verify": [] },
+
+    {
+      "id": "U.1", "phase": "utility", "mode": "A", "crit": false, "layer": "utility",
+      "title": "Utility flywheel cycle 1 — network-wiring truth (connectivity catalog -> review sweep -> wire_by_label + validator pin)",
+      "refs": [
+        "harness/notes/spec-U1-wiring-flywheel.md",
+        "harness/state/flywheel_queue.json",
+        "host/introspect_connectivity.py",
+        "harness/notes/verified_connectivity_21.0.671.json",
+        "scripts/flywheel_review_wiring.py",
+        "python/synapse/core/wiring.py",
+        "python/synapse/cognitive/tools/data/connectivity_21.json",
+        "python/synapse/cognitive/graph_validator.py",
+        "tests/test_wiring_flywheel.py"
+      ],
+      "verify": ["connectivity_catalog_fresh", "wiring_conformance", "validator_catches_miswire"],
+      "note": "Cycle contract in spec-U1-wiring-flywheel.md. Anti-runaway anchors: human ratifies new cycle classes (flywheel_queue.json 'ratified'), evidence-linked queue entries only, guardrails every sprint."
+    }
   ]
 }

--- a/harness/verify/checks.py
+++ b/harness/verify/checks.py
@@ -469,6 +469,15 @@ def main():
     ap.add_argument("--mode", default="A")
     a = ap.parse_args()
 
+    # Worktree-shadowing guard (flywheel U.1 meta-finding): a dev-machine
+    # editable install (__editable__.synapse-*.pth) resolves `synapse` to the
+    # MAIN checkout — for this process AND bare children — so a worktree gate
+    # can green-light code it never imported. Pin the WORKTREE's package first
+    # for both resolution paths.
+    _wt_py = str(Path(a.worktree).resolve() / "python")
+    sys.path.insert(0, _wt_py)
+    os.environ["PYTHONPATH"] = _wt_py + os.pathsep + os.environ.get("PYTHONPATH", "")
+
     doc = json.loads((Path(__file__).resolve().parents[1] / "tasks.json").read_text())
     tasks = doc["tasks"]
     guardrail_names = (doc.get("guardrails") or {}).get("checks", [])

--- a/harness/verify/checks.py
+++ b/harness/verify/checks.py
@@ -15,13 +15,22 @@ Usage (called by run.ts):
 import argparse, json, os, subprocess, sys, tempfile
 from pathlib import Path
 
-def sh(cmd, cwd=None, timeout=900):
+def sh(cmd, cwd=None, timeout=900, env=None):
     try:
         p = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout,
-                            shell=(os.name == "nt"))
+                            shell=(os.name == "nt"), env=env)
         return p.returncode, p.stdout or "", p.stderr or ""
     except Exception as e:
         return 1, "", f"{type(e).__name__}: {e}"
+
+
+def _wt_env(ctx):
+    """Env for stock-python subprocesses with the WORKTREE's synapse package
+    first on the path — a dev machine may carry an editable install pointing at
+    the main checkout, which would silently test the wrong code."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(Path(ctx["wt"]) / "python") + os.pathsep + env.get("PYTHONPATH", "")
+    return env
 
 def hython(hython_bin, script, cwd):
     """Run a python snippet inside Houdini's interpreter."""
@@ -352,6 +361,76 @@ def check_scout_no_apex_corpus(ctx):
             return {"ok": False, "detail": f"scout_sources.json unreadable: {str(e)[:200]}"}
     return {"ok": None, "detail": "no APEX corpus found; scout source-registry not wired yet (python/synapse/server/scout_sources.json missing)"}
 
+def check_connectivity_catalog_fresh(ctx):
+    # U.1: the packaged connectivity catalog (the wire_by_label / P3e authority) must be
+    # (a) internally sound — schema v2 + blake2b recomputes over its entries,
+    # (b) byte-identical to the harness probe artifact it claims to be a copy of, and
+    # (c) stamped with the live build when hython is available (stamp==build or the check
+    #     FAILS explicitly — a stale catalog is a phantom-wiring vector, never silent).
+    wt = Path(ctx["wt"])
+    pkg = wt / "python/synapse/cognitive/tools/data/connectivity_21.json"
+    if not pkg.exists():
+        return {"ok": False, "detail": "packaged connectivity_21.json missing"}
+    try:
+        import hashlib
+        data = json.loads(pkg.read_text(encoding="utf-8"))
+        if data.get("schema") != "verified_connectivity/v2":
+            return {"ok": False, "detail": f"schema={data.get('schema')} != verified_connectivity/v2"}
+        digest = hashlib.blake2b(
+            json.dumps(data.get("entries", {}), sort_keys=True, ensure_ascii=False).encode("utf-8"),
+            digest_size=16).hexdigest()
+        if digest != data.get("blake2b"):
+            return {"ok": False, "detail": "packaged catalog blake2b mismatch (corrupt/hand-edited)"}
+        stamp = data.get("houdini_version", "")
+        harness_fp = wt / "harness" / "notes" / f"verified_connectivity_{stamp}.json"
+        if not harness_fp.exists() or harness_fp.read_bytes() != pkg.read_bytes():
+            return {"ok": False, "detail": f"packaged copy != {harness_fp.name} (re-run "
+                                           "host/introspect_connectivity.py + re-copy)"}
+    except Exception as e:
+        return {"ok": False, "detail": f"catalog unreadable: {str(e)[:300]}"}
+    if ctx["hython"]:
+        code = "import hou\nprint('BUILD', hou.applicationVersionString())"
+        rc, out, err = hython(ctx["hython"], code, ctx["wt"])
+        live = next((l.split(" ", 1)[1] for l in out.splitlines() if l.startswith("BUILD ")), None)
+        if live is None:
+            return {"ok": False, "detail": f"could not read live build: {(err or out).strip()[:200]}"}
+        if live != stamp:
+            return {"ok": False, "detail": f"catalog stamp {stamp} != live build {live} — STALE; "
+                                           "regenerate via host/introspect_connectivity.py"}
+        return {"ok": True, "detail": f"catalog sound, byte-matched, stamp==live build {live}"}
+    return {"ok": True, "detail": f"catalog sound + byte-matched (stamp {stamp}; live-build "
+                                  "comparison skipped — HYTHON unset)"}
+
+def check_wiring_conformance(ctx):
+    # U.1: the REVIEW sweep re-runs clean — scripts/flywheel_review_wiring.py exits 0 with
+    # zero CRITICAL findings (index-out-of-arity / label-claim-mismatch vs the catalog).
+    # Runs WITHOUT --deposit / --queue-append: the Ledger deposit and queue append are the
+    # Stage-3 opt-ins, never an every-sprint side effect.
+    rc, out, err = sh([sys.executable, "scripts/flywheel_review_wiring.py"],
+                      cwd=ctx["wt"], env=_wt_env(ctx))
+    p = Path(ctx["wt"]) / ".claude/flywheel_u1_findings.json"
+    if not p.exists():
+        return {"ok": False, "detail": (out or err).strip()[:400] or "sweep produced no findings file"}
+    try:
+        crit = json.loads(p.read_text(encoding="utf-8"))["summary"]["critical"]
+    except Exception as e:
+        return {"ok": False, "detail": f"findings unreadable: {str(e)[:200]}"}
+    head = (out or err).strip().splitlines()
+    return {"ok": rc == 0 and crit == 0,
+            "detail": f"rc={rc} critical={crit}; {head[0][:300] if head else ''}"}
+
+def check_validator_catches_miswire(ctx):
+    # U.1: the golden miswire fixtures (vellumsolver constraint->2 / collision->1 swap,
+    # rbdbulletsolver constraint->2, out-of-range index) are REJECTED by GraphValidator P3e
+    # while the corrected forms pass — pinned in tests/test_wiring_flywheel.py. Runs the
+    # pinned assertions directly (stock python; the fixtures are pure + packaged-catalog-backed).
+    rc, out, err = sh([sys.executable, "-m", "pytest",
+                       "tests/test_wiring_flywheel.py", "-q"],
+                      cwd=ctx["wt"], env=_wt_env(ctx))
+    tail = (out or err).strip().splitlines()
+    return {"ok": rc == 0, "detail": (tail[-1] if tail else "no pytest output")[:400]}
+
+
 def run_one(name, task, ctx):
     fn = DISPATCH.get(name)
     if not fn:
@@ -376,6 +455,10 @@ DISPATCH = {
     # v2 — guardrails
     "scout_no_apex_corpus": check_scout_no_apex_corpus, "no_rigging_drift": check_no_rigging_drift,
     "provenance_not_bypassed": check_provenance_not_bypassed,
+    # U.1 — utility flywheel: network-wiring truth
+    "connectivity_catalog_fresh": check_connectivity_catalog_fresh,
+    "wiring_conformance": check_wiring_conformance,
+    "validator_catches_miswire": check_validator_catches_miswire,
 }
 
 def main():

--- a/host/introspect_connectivity.py
+++ b/host/introspect_connectivity.py
@@ -1,0 +1,357 @@
+"""
+host/introspect_connectivity.py  —  U.1 probe: network-wiring truth (HOST LAYER)
+================================================================================
+
+Utility-flywheel cycle U.1, EXPLORE phase (``harness/notes/
+spec-U1-wiring-flywheel.md``). For every node-type string SYNAPSE emits
+(``python/synapse/cognitive/tools/data/emitted_node_types.json``) PLUS every
+Sop type whose name matches ``solver|merge|switch|blend``, resolve it against
+the live catalog and record the wiring surface per resolved (category, type):
+
+    min_inputs / max_inputs      — type-level (hou.NodeType.minNumInputs/
+                                   maxNumInputs; variadic reports a large
+                                   finite cap, e.g. Sop/merge=9999, NOT -1)
+    output_count                 — type-level (hou.NodeType.maxNumOutputs)
+    input_labels / output_labels — INSTANCE-level only in 21.0.671
+                                   (hou.Node.inputLabels()/outputLabels();
+                                   the type-level accessors are PHANTOM —
+                                   see verified_connectivity v1). The probe
+                                   instantiates one throwaway node per type
+                                   in a category-appropriate container,
+                                   reads the labels, destroys the node.
+
+All three probe APIs scout-verified against the introspected 21.0.671 symbol
+table (exists_in_runtime=true): hou.Node.inputLabels, hou.Node.outputLabels,
+hou.NodeType.{minNumInputs,maxNumInputs,maxNumOutputs}.
+
+RUN IT INSIDE THE TARGET BUILD:
+
+    "C:/Program Files/Side Effects Software/Houdini 21.0.671/bin/hython.exe" \
+        host/introspect_connectivity.py
+
+Writes ``harness/notes/verified_connectivity_<build>.json`` with schema
+``verified_connectivity/v2``. The v1 payload (Mile-2 §2.5 preflight: symbol
+presence, phantom list, spot-checked arity values) is PRESERVED under
+``v1_preserved`` with a provenance marker — the probe does not re-derive
+dir()-membership facts, so it never discards them.
+
+DETERMINISM: a second run on the same build is byte-identical — entries and
+keys are sorted, and there is NO wall-clock stamp (``generated`` describes the
+generator, not the moment). The blake2b stamp covers the sorted entries.
+
+Zero-``synapse``-import, like host/introspect_nodetypes.py — the host layer
+never imports the package. ``hou`` is imported inside functions so this module
+also imports cleanly on stock Python for the pure test suite.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+SCHEMA = "verified_connectivity/v2"
+_REPO = Path(__file__).resolve().parents[1]
+EMITTED_JSON = (_REPO / "python" / "synapse" / "cognitive" / "tools" / "data"
+                / "emitted_node_types.json")
+NOTES_DIR = _REPO / "harness" / "notes"
+
+# Sop pattern expansion: wiring bugs cluster on multi-input types.
+SOP_NAME_PATTERN = re.compile(r"solver|merge|switch|blend", re.IGNORECASE)
+
+_VERSION_COMPONENT = re.compile(r"^[0-9][0-9.]*$")
+
+
+def _strip_version(full_name: str) -> str:
+    parts = full_name.split("::")
+    if len(parts) > 1 and _VERSION_COMPONENT.match(parts[-1]):
+        return "::".join(parts[:-1])
+    return full_name
+
+
+def _matches(emitted: str, full_name: str) -> bool:
+    """Does catalog ``full_name`` satisfy the emitted spelling? Lockstep with
+    host/introspect_nodetypes._matches (what createNode(emitted) accepts)."""
+    if full_name == emitted:
+        return True
+    base = _strip_version(full_name)
+    if base == emitted:
+        return True
+    if "::" not in emitted and base.split("::")[-1] == emitted:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Containers — one throwaway parent per category, created lazily, destroyed
+# at the end. Headless-safe: this runs in an isolated hython process; the
+# user's session is never touched (same posture as the nodetype probe).
+# ---------------------------------------------------------------------------
+
+def _make_container(hou, cat_name: str):
+    """A parent network that can host nodes of category ``cat_name``, or None."""
+    if cat_name == "Object":
+        return hou.node("/obj")
+    if cat_name == "Lop":
+        return hou.node("/stage")
+    if cat_name == "Driver":
+        return hou.node("/out")
+    if cat_name == "Sop":
+        return hou.node("/obj").createNode("geo", "u1_probe_sop")
+    if cat_name == "Dop":
+        return hou.node("/obj").createNode("dopnet", "u1_probe_dop")
+    if cat_name == "Cop":
+        return hou.node("/obj").createNode("copnet", "u1_probe_cop")
+    if cat_name == "Cop2":
+        img = hou.node("/img")
+        return img.createNode("img", "u1_probe_cop2") if img else None
+    if cat_name == "Top":
+        return hou.node("/obj").createNode("topnet", "u1_probe_top")
+    if cat_name == "Vop":
+        return hou.node("/mat")
+    return None  # Chop/Shop/Manager/...: not needed by the emitted surface
+
+
+class _Containers:
+    def __init__(self, hou):
+        self._hou = hou
+        self._cache: dict = {}
+        self._created: list = []
+
+    def get(self, cat_name: str):
+        if cat_name not in self._cache:
+            try:
+                parent = _make_container(self._hou, cat_name)
+            except Exception:  # noqa: BLE001 — container is best-effort
+                parent = None
+            self._cache[cat_name] = parent
+            if parent is not None and parent.path().startswith("/obj/u1_probe"):
+                self._created.append(parent)
+        return self._cache[cat_name]
+
+    def teardown(self) -> None:
+        for node in self._created:
+            try:
+                node.destroy()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Per-type probe
+# ---------------------------------------------------------------------------
+
+def _probe_instance(hou, parent, full_name: str, errors: list) -> dict:
+    """Instantiate ``full_name`` under ``parent``, read the instance-level
+    wiring surface, destroy the node. Returns the instance fields."""
+    out = {"instantiated": False, "input_labels": None, "output_labels": None}
+    if parent is None:
+        out["note"] = "no container for this category"
+        return out
+    try:
+        node = parent.createNode(full_name)
+    except Exception as e:  # noqa: BLE001 — best-effort; recorded, not fatal
+        out["note"] = f"createNode failed: {type(e).__name__}"
+        return out
+    try:
+        out["instantiated"] = True
+        try:
+            out["input_labels"] = [str(l) for l in node.inputLabels()]
+        except Exception as e:  # noqa: BLE001
+            errors.append(f"inputLabels failed on {full_name}: {e}")
+        try:
+            out["output_labels"] = [str(l) for l in node.outputLabels()]
+        except Exception as e:  # noqa: BLE001
+            errors.append(f"outputLabels failed on {full_name}: {e}")
+    finally:
+        try:
+            node.destroy()
+        except Exception:  # noqa: BLE001
+            pass
+    return out
+
+
+def _type_entry(hou, node_type, cat_name: str, full_name: str,
+                sources: list, containers: _Containers, errors: list) -> dict:
+    entry = {
+        "category": cat_name,
+        "type_name": full_name,
+        "sources": sorted(set(sources)),
+        "min_inputs": None,
+        "max_inputs": None,
+        "output_count": None,
+    }
+    try:
+        entry["min_inputs"] = node_type.minNumInputs()
+        entry["max_inputs"] = node_type.maxNumInputs()
+    except Exception as e:  # noqa: BLE001
+        errors.append(f"arity read failed for {cat_name}/{full_name}: {e}")
+    try:
+        entry["output_count"] = node_type.maxNumOutputs()
+    except Exception as e:  # noqa: BLE001
+        errors.append(f"maxNumOutputs failed for {cat_name}/{full_name}: {e}")
+    entry.update(_probe_instance(hou, containers.get(cat_name), full_name, errors))
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Target collection: emitted types (all categories) + Sop pattern expansion
+# ---------------------------------------------------------------------------
+
+def _collect_targets(hou, emitted_path: Path, errors: list) -> dict:
+    """{(cat_name, full_name): {"node_type": ..., "sources": [...]}}"""
+    targets: dict = {}
+
+    def add(cat_name, full_name, node_type, source):
+        key = (cat_name, full_name)
+        if key not in targets:
+            targets[key] = {"node_type": node_type, "sources": []}
+        targets[key]["sources"].append(source)
+
+    emitted = json.loads(Path(emitted_path).read_text(encoding="utf-8"))
+    cats = hou.nodeTypeCategories()
+    for src in emitted["entries"]:
+        spelling = src["type_name"]
+        for cat_name in sorted(cats):
+            category = cats[cat_name]
+            hits = {}
+            try:
+                exact = hou.nodeType(category, spelling)
+            except Exception as e:  # noqa: BLE001
+                errors.append(f"nodeType({cat_name}, {spelling!r}) raised: {e}")
+                exact = None
+            if exact is not None:
+                hits[exact.name()] = exact
+            try:
+                for full_name, node_type in category.nodeTypes().items():
+                    if full_name not in hits and _matches(spelling, full_name):
+                        hits[full_name] = node_type
+            except Exception as e:  # noqa: BLE001
+                errors.append(f"nodeTypes() scan failed in {cat_name}: {e}")
+            for full_name, node_type in hits.items():
+                add(cat_name, full_name, node_type, f"emitted:{spelling}")
+
+    # Sop pattern expansion
+    sop_cat = cats.get("Sop")
+    if sop_cat is not None:
+        for full_name, node_type in sop_cat.nodeTypes().items():
+            if SOP_NAME_PATTERN.search(full_name):
+                add("Sop", full_name, node_type, "sop_pattern")
+    else:  # pragma: no cover — a Houdini without SOPs
+        errors.append("no Sop category in this build")
+    return targets
+
+
+# ---------------------------------------------------------------------------
+# Catalog assembly
+# ---------------------------------------------------------------------------
+
+def build_catalog(emitted_path: Path = EMITTED_JSON) -> dict:
+    import hou
+
+    errors: list = []
+    containers = _Containers(hou)
+    # Simulation guard (rag_dop_simulation_guard): instantiating DOP types must
+    # not cook a simulation mid-probe. hou.setSimulationEnabled is scout-verified
+    # (exists_in_runtime=true, documented) on 21.0.671.
+    sim_was = True
+    try:
+        sim_was = hou.simulationEnabled()
+        hou.setSimulationEnabled(False)
+    except Exception as e:  # noqa: BLE001 — guard is best-effort, surfaced
+        errors.append(f"simulation guard unavailable: {e}")
+    try:
+        targets = _collect_targets(hou, emitted_path, errors)
+        entries = {}
+        for (cat_name, full_name) in sorted(targets):
+            info = targets[(cat_name, full_name)]
+            entries[f"{cat_name}/{full_name}"] = _type_entry(
+                hou, info["node_type"], cat_name, full_name,
+                info["sources"], containers, errors)
+    finally:
+        containers.teardown()
+        try:
+            hou.setSimulationEnabled(sim_was)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Fold in every v1 key the probe cannot re-derive (dir()-membership facts,
+    # the phantom list, the §2.5 spot checks) — provenance-marked, not discarded.
+    v1_preserved = None
+    v1_fp = NOTES_DIR / f"verified_connectivity_{hou.applicationVersionString()}.json"
+    if v1_fp.exists():
+        try:
+            prior = json.loads(v1_fp.read_text(encoding="utf-8"))
+            if prior.get("schema") == SCHEMA:          # already v2 — keep its fold
+                v1_preserved = prior.get("v1_preserved")
+            else:                                       # genuine v1 payload
+                v1_preserved = {
+                    "_provenance": (
+                        "carried verbatim from verified_connectivity v1 (Mile-2 "
+                        "§2.5 preflight, dir()-confirmed on live 21.0.671; "
+                        "harness/notes/mile2_2_5_introspect.py) — NOT re-derived "
+                        "by host/introspect_connectivity.py"
+                    ),
+                    "_doc": prior.get("_doc"),
+                    "symbols_present": prior.get("symbols_present"),
+                    "symbols_PHANTOM_do_not_use": prior.get("symbols_PHANTOM_do_not_use"),
+                    "verified_values": prior.get("verified_values"),
+                }
+        except Exception as e:  # noqa: BLE001 — surface, don't silently drop v1
+            errors.append(f"could not fold prior file: {e}")
+
+    stamp = hashlib.blake2b(
+        json.dumps(entries, sort_keys=True, ensure_ascii=False).encode("utf-8"),
+        digest_size=16,
+    ).hexdigest()
+    return {
+        "schema": SCHEMA,
+        "houdini_version": hou.applicationVersionString(),
+        "blake2b": stamp,
+        "generated": {
+            "by": "host/introspect_connectivity.py",
+            "from": str(Path(emitted_path).relative_to(_REPO)).replace("\\", "/"),
+            "note": ("deterministic: no wall-clock stamp — a second run on the "
+                     "same build must be byte-identical (the U.1 determinism pin)"),
+        },
+        "entries": entries,
+        "v1_preserved": v1_preserved,
+        "probe_errors": sorted(errors),
+    }
+
+
+def main() -> int:
+    catalog = build_catalog()
+    build = catalog["houdini_version"]
+    out_fp = NOTES_DIR / f"verified_connectivity_{build}.json"
+    out_fp.parent.mkdir(parents=True, exist_ok=True)
+    out_fp.write_text(
+        json.dumps(catalog, sort_keys=True, ensure_ascii=False, indent=1) + "\n",
+        encoding="utf-8", newline="\n",
+    )
+
+    entries = catalog["entries"]
+    n_inst = sum(1 for e in entries.values() if e.get("instantiated"))
+    n_lab = sum(1 for e in entries.values() if e.get("input_labels"))
+    errors = catalog["probe_errors"]
+    sys.stdout.write(
+        f"CONNECTIVITY: build={build} types={len(entries)} instantiated={n_inst} "
+        f"with_input_labels={n_lab} probe_errors={len(errors)} "
+        f"blake2b={catalog['blake2b'][:12]} -> {out_fp}\n"
+    )
+    for err in errors:
+        sys.stdout.write(f"  ERROR: {err}\n")
+    for probe_key in ("Sop/vellumsolver", "Sop/rbdbulletsolver"):
+        e = entries.get(probe_key)
+        if e:
+            sys.stdout.write(
+                f"  {probe_key}: in[{e['min_inputs']},{e['max_inputs']}] "
+                f"out={e['output_count']} labels={e['input_labels']}\n"
+            )
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/synapse/cognitive/graph_proposal.py
+++ b/python/synapse/cognitive/graph_proposal.py
@@ -41,6 +41,11 @@ class ProposedEdge:
     target_input_index: int
     # Amendment 3: an existing node may be source OR target. Occupied-input guard
     # (P3d) applies to the TARGET side only — outputs fan out freely.
+    # U.1: OPTIONAL declared target-slot label. When set AND the connectivity
+    # catalog knows the target type, P3e verifies the label resolves to exactly
+    # target_input_index (case-insensitive) — the index stays authoritative for
+    # the build; the label is the checkable statement of intent.
+    target_input_label: str = ""
 
 
 @dataclass

--- a/python/synapse/cognitive/graph_validator.py
+++ b/python/synapse/cognitive/graph_validator.py
@@ -12,6 +12,12 @@ from .graph_proposal import (
 )
 from .interfaces import IConnectivityOracle, IExistenceOracle
 
+# U.1: the probe-verified connectivity catalog (packaged copy of the
+# host/introspect_connectivity.py output). Pure JSON, zero hou — loading it
+# keeps this layer host-agnostic. Missing/corrupt degrades to None and P3e
+# simply skips (the oracle-backed checks are never weakened).
+from ..core.wiring import load_connectivity_catalog, resolve_catalog_entry
+
 # network_type (GraphProposal.network_type) -> the node categories valid inside it.
 # Used by P4 for the node_category<->network_type consistency check. Unknown
 # network_types are skipped (no false reject). MAT nodes are VOPs or SHOPs; COP
@@ -33,6 +39,7 @@ class GraphValidator:
         connectivity: IConnectivityOracle,
         *,
         live_phases_enabled: bool = True,
+        connectivity_catalog: "dict | None" = None,
     ):
         self._exist = existence
         self._conn = connectivity
@@ -41,6 +48,11 @@ class GraphValidator:
         # symbol path (and inject a connectivity mock that refuses connectivity
         # calls) opt out explicitly with live_phases_enabled=False.
         self._live_phases_enabled = live_phases_enabled
+        # U.1 P3e: probe-verified slot semantics. Default = the packaged catalog
+        # (non-strict: unusable -> None -> P3e skips, nothing else changes).
+        # Injectable for tests / a future per-build override.
+        self._catalog = (connectivity_catalog if connectivity_catalog is not None
+                         else load_connectivity_catalog(strict=False))
 
     def validate(self, p: GraphProposal) -> ValidationReport:
         errors: list[ValidationIssue] = []
@@ -214,6 +226,63 @@ class GraphValidator:
                                f"'{tgt.scene_path}' is already occupied — wiring it "
                                f"would sever the artist's existing connection"),
                     ))
+
+            # --- 3e catalog slot semantics (U.1) — ADDITIVE, catalog-known types only ---
+            if tt is not None:
+                issues += self._catalog_slot_check(p, e, tgt, tt)
+        return issues
+
+    # ---- P3e — probe-verified slot semantics (U.1) ----
+    def _catalog_slot_check(self, p: GraphProposal, e, tgt, tt) -> list[ValidationIssue]:
+        # When the connectivity catalog (probe truth, not the live oracle) knows
+        # the target type: reject an edge into an index >= the probe-verified
+        # max_inputs, and — when the proposal NAMES a target slot label — reject
+        # a label that is unknown or resolves to a different index. Adds errors
+        # only; the oracle-backed 3a-3d above are untouched.
+        if self._catalog is None:
+            return []
+        entry = resolve_catalog_entry(self._catalog, tt[1], tt[0])
+        if entry is None:
+            return []
+        issues: list[ValidationIssue] = []
+        max_in = entry.get("max_inputs")
+        if max_in is not None and max_in >= 0 and (
+                e.target_input_index < 0 or e.target_input_index >= max_in):
+            issues.append(ValidationIssue(
+                where=tgt.node_id,
+                message=self._stamp(
+                    p, f"edge target '{tgt.node_id}' input index "
+                       f"{e.target_input_index} exceeds the probe-verified arity "
+                       f"(max inputs {max_in}) for type '{tt[0]}' "
+                       f"[connectivity catalog {self._catalog.get('houdini_version')}]"),
+            ))
+        label = getattr(e, "target_input_label", "") or ""
+        labels = entry.get("input_labels") or []
+        if label and labels:
+            wanted = label.strip().lower()
+            resolved = next((i for i, have in enumerate(labels)
+                             if str(have).strip().lower() == wanted), None)
+            if resolved is None:
+                issues.append(ValidationIssue(
+                    where=tgt.node_id,
+                    message=self._stamp(
+                        p, f"edge names target input label '{label}' but type "
+                           f"'{tt[0]}' has no such input — probe-verified labels "
+                           f"are {labels}"),
+                ))
+            elif resolved != e.target_input_index:
+                if 0 <= e.target_input_index < len(labels):
+                    wired_slot = f"'{labels[e.target_input_index]}'"
+                else:
+                    wired_slot = "out of the labeled range"
+                issues.append(ValidationIssue(
+                    where=tgt.node_id,
+                    message=self._stamp(
+                        p, f"edge names target input label '{label}' which lives "
+                           f"at index {resolved} of '{tt[0]}', but wires index "
+                           f"{e.target_input_index} ({wired_slot}) — "
+                           f"label-mismatched slot"),
+                ))
         return issues
 
     # ---- Phase 4 — structural, pure logic (MILE 2) ----

--- a/python/synapse/cognitive/tools/data/connectivity_21.json
+++ b/python/synapse/cognitive/tools/data/connectivity_21.json
@@ -1,0 +1,4982 @@
+{
+ "blake2b": "c213570959156138a7cda52936fcd2c1",
+ "entries": {
+  "Chop/cop2net": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Chop/dopnet": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Chop/file": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:file"
+   ],
+   "type_name": "file"
+  },
+  "Chop/limit": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:limit"
+   ],
+   "type_name": "limit"
+  },
+  "Chop/lopnet": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Chop/merge": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:merge"
+   ],
+   "type_name": "merge"
+  },
+  "Chop/noise": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:noise"
+   ],
+   "type_name": "noise"
+  },
+  "Chop/null": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Chop/output": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Chop/subnet": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Chop/topnet": {
+   "category": "Chop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Cop/block_begin": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:block_begin"
+   ],
+   "type_name": "block_begin"
+  },
+  "Cop/block_end": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:block_end"
+   ],
+   "type_name": "block_end"
+  },
+  "Cop/blur": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "size"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "blur"
+   ],
+   "sources": [
+    "emitted:blur"
+   ],
+   "type_name": "blur"
+  },
+  "Cop/bright": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "bright",
+    "shift",
+    "mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "bright"
+   ],
+   "sources": [
+    "emitted:bright"
+   ],
+   "type_name": "bright"
+  },
+  "Cop/colorcorrect": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "correct"
+   ],
+   "sources": [
+    "emitted:colorcorrect"
+   ],
+   "type_name": "colorcorrect"
+  },
+  "Cop/dilateerode": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "radius",
+    "mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "dilate"
+   ],
+   "sources": [
+    "emitted:dilateerode"
+   ],
+   "type_name": "dilateerode"
+  },
+  "Cop/dopnet": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Cop/edgedetect": {
+   "category": "Cop",
+   "input_labels": [
+    "source"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "edge"
+   ],
+   "sources": [
+    "emitted:edgedetect"
+   ],
+   "type_name": "edgedetect"
+  },
+  "Cop/file": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:file"
+   ],
+   "type_name": "file"
+  },
+  "Cop/light": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "N",
+    "mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "lit"
+   ],
+   "sources": [
+    "emitted:light"
+   ],
+   "type_name": "light"
+  },
+  "Cop/lopnet": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Cop/null": {
+   "category": "Cop",
+   "input_labels": [
+    "input1"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [
+    "output1"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Cop/opencl": {
+   "category": "Cop",
+   "input_labels": [
+    "src"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [
+    "dst"
+   ],
+   "sources": [
+    "emitted:opencl"
+   ],
+   "type_name": "opencl"
+  },
+  "Cop/output": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Cop/quantize": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "quantize"
+   ],
+   "sources": [
+    "emitted:quantize"
+   ],
+   "type_name": "quantize"
+  },
+  "Cop/sopimport": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "geometry"
+   ],
+   "sources": [
+    "emitted:sopimport"
+   ],
+   "type_name": "sopimport"
+  },
+  "Cop/subnet": {
+   "category": "Cop",
+   "input_labels": [
+    "src"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [
+    "dst"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Cop/tonemap": {
+   "category": "Cop",
+   "input_labels": [
+    "source",
+    "mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "tonemap"
+   ],
+   "sources": [
+    "emitted:tonemap"
+   ],
+   "type_name": "tonemap"
+  },
+  "Cop/topnet": {
+   "category": "Cop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Cop2/blur": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Blur",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:blur"
+   ],
+   "type_name": "blur"
+  },
+  "Cop2/bright": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Brighten",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:bright"
+   ],
+   "type_name": "bright"
+  },
+  "Cop2/colorcorrect": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Correct",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:colorcorrect"
+   ],
+   "type_name": "colorcorrect"
+  },
+  "Cop2/composite": {
+   "category": "Cop2",
+   "input_labels": [
+    "Foreground",
+    "Background",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:composite"
+   ],
+   "type_name": "composite"
+  },
+  "Cop2/cop2net": {
+   "category": "Cop2",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Cop2/dilateerode": {
+   "category": "Cop2",
+   "input_labels": [
+    "Matte to Expand",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:dilateerode"
+   ],
+   "type_name": "dilateerode"
+  },
+  "Cop2/dopnet": {
+   "category": "Cop2",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Cop2/edge": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Edge Detect",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:edge"
+   ],
+   "type_name": "edge"
+  },
+  "Cop2/file": {
+   "category": "Cop2",
+   "input_labels": [
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:file"
+   ],
+   "type_name": "file"
+  },
+  "Cop2/light": {
+   "category": "Cop2",
+   "input_labels": [
+    "Input 1",
+    "Input 2",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:light"
+   ],
+   "type_name": "light"
+  },
+  "Cop2/limit": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Limit",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:limit"
+   ],
+   "type_name": "limit"
+  },
+  "Cop2/lopnet": {
+   "category": "Cop2",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Cop2/merge": {
+   "category": "Cop2",
+   "input_labels": [
+    "Images to Merge"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:merge"
+   ],
+   "type_name": "merge"
+  },
+  "Cop2/noise": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Add To",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:noise"
+   ],
+   "type_name": "noise"
+  },
+  "Cop2/null": {
+   "category": "Cop2",
+   "input_labels": [
+    "Source Image"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Cop2/over": {
+   "category": "Cop2",
+   "input_labels": [
+    "Foreground",
+    "Background",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:over"
+   ],
+   "type_name": "over"
+  },
+  "Cop2/quantize": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Quantize",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:quantize"
+   ],
+   "type_name": "quantize"
+  },
+  "Cop2/reference": {
+   "category": "Cop2",
+   "input_labels": [
+    "Source Image"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:reference"
+   ],
+   "type_name": "reference"
+  },
+  "Cop2/rop_comp": {
+   "category": "Cop2",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:rop_comp"
+   ],
+   "type_name": "rop_comp"
+  },
+  "Cop2/sopimport": {
+   "category": "Cop2",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:sopimport"
+   ],
+   "type_name": "sopimport"
+  },
+  "Cop2/subnet": {
+   "category": "Cop2",
+   "input_labels": [
+    "Sub-Network Input #1",
+    "Sub-Network Input #2",
+    "Sub-Network Input #3",
+    "Sub-Network Input #4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Cop2/topnet": {
+   "category": "Cop2",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Cop2/vopcop2gen": {
+   "category": "Cop2",
+   "input_labels": [
+    "Image to Add Planes To",
+    "Mask Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:vopcop2gen"
+   ],
+   "type_name": "vopcop2gen"
+  },
+  "Data/cop/convolve3::sidefx::blur": {
+   "category": "Data",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:blur"
+   ],
+   "type_name": "cop/convolve3::sidefx::blur"
+  },
+  "Dop/cop2net": {
+   "category": "Dop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Dop/dopnet": {
+   "category": "Dop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Dop/file": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects to use when not reading from file"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:file"
+   ],
+   "type_name": "file"
+  },
+  "Dop/flipsolver": {
+   "category": "Dop",
+   "input_labels": [
+    "Fluid to Solve",
+    "Particle Velocity",
+    "Volume Velocity",
+    "Sourcing (post-solve)"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Sub-Network Output #1"
+   ],
+   "sources": [
+    "emitted:flipsolver"
+   ],
+   "type_name": "flipsolver"
+  },
+  "Dop/flipsolver::2.0": {
+   "category": "Dop",
+   "input_labels": [
+    "Fluid to Solve",
+    "Particle Velocity",
+    "Volume Velocity",
+    "Sourcing (post-solve)"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Sub-Network Output #1"
+   ],
+   "sources": [
+    "emitted:flipsolver"
+   ],
+   "type_name": "flipsolver::2.0"
+  },
+  "Dop/gravity": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects to be processed",
+    "Data to attach\n\nAccepts any number of:\n    Mask Field\n    Noise Field"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:gravity"
+   ],
+   "type_name": "gravity"
+  },
+  "Dop/lopnet": {
+   "category": "Dop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Dop/merge": {
+   "category": "Dop",
+   "input_labels": [
+    "Any node type"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:merge"
+   ],
+   "type_name": "merge"
+  },
+  "Dop/noise": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects to be processed"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:noise"
+   ],
+   "type_name": "noise"
+  },
+  "Dop/null": {
+   "category": "Dop",
+   "input_labels": [
+    "Input 0"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Dop/output": {
+   "category": "Dop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Dop/pyrosolver": {
+   "category": "Dop",
+   "input_labels": [
+    "Object",
+    "Pre-solve",
+    "Velocity Update",
+    "Advection",
+    "Sourcing (post-solve)"
+   ],
+   "instantiated": true,
+   "max_inputs": 5,
+   "min_inputs": 1,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:pyrosolver"
+   ],
+   "type_name": "pyrosolver"
+  },
+  "Dop/pyrosolver::2.0": {
+   "category": "Dop",
+   "input_labels": [
+    "Object",
+    "Pre-solve",
+    "Velocity Update",
+    "Advection",
+    "Sourcing (post-solve)"
+   ],
+   "instantiated": true,
+   "max_inputs": 5,
+   "min_inputs": 1,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:pyrosolver"
+   ],
+   "type_name": "pyrosolver::2.0"
+  },
+  "Dop/rbdpackedobject": {
+   "category": "Dop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:rbdpackedobject"
+   ],
+   "type_name": "rbdpackedobject"
+  },
+  "Dop/rigidbodysolver": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects",
+    "Pre-Solve",
+    "Post-Solve"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:rigidbodysolver"
+   ],
+   "type_name": "rigidbodysolver"
+  },
+  "Dop/subnet": {
+   "category": "Dop",
+   "input_labels": [
+    "Input 1",
+    "Input 2",
+    "Input 3",
+    "Input 4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Dop/topnet": {
+   "category": "Dop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Dop/vellumconstraintproperty": {
+   "category": "Dop",
+   "input_labels": [
+    "Sub-Network Input #1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:vellumconstraintproperty"
+   ],
+   "type_name": "vellumconstraintproperty"
+  },
+  "Dop/vellumconstraints": {
+   "category": "Dop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:vellumconstraints"
+   ],
+   "type_name": "vellumconstraints"
+  },
+  "Dop/vellumsolver": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects to Solve",
+    "Particle Forces",
+    "Post-Solve"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:vellumsolver"
+   ],
+   "type_name": "vellumsolver"
+  },
+  "Dop/whitewatersolver": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects to Solve",
+    "Extra Sources",
+    "Particle Forces",
+    "Post-Solve"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:whitewatersolver"
+   ],
+   "type_name": "whitewatersolver"
+  },
+  "Dop/whitewatersolver::2.0": {
+   "category": "Dop",
+   "input_labels": [
+    "Objects to Solve",
+    "Extra Sources",
+    "Particle Forces",
+    "Post-Solve"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:whitewatersolver"
+   ],
+   "type_name": "whitewatersolver::2.0"
+  },
+  "Driver/cop2net": {
+   "category": "Driver",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Driver/dopnet": {
+   "category": "Driver",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Driver/karma": {
+   "category": "Driver",
+   "input_labels": [
+    "Input #1"
+   ],
+   "instantiated": true,
+   "max_inputs": 999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:karma"
+   ],
+   "type_name": "karma"
+  },
+  "Driver/lopnet": {
+   "category": "Driver",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Driver/merge": {
+   "category": "Driver",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:merge"
+   ],
+   "type_name": "merge"
+  },
+  "Driver/null": {
+   "category": "Driver",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Driver/subnet": {
+   "category": "Driver",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 31,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Driver/topnet": {
+   "category": "Driver",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Driver/wedge": {
+   "category": "Driver",
+   "input_labels": [
+    "ROP to Wedge"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:wedge"
+   ],
+   "type_name": "wedge"
+  },
+  "Lop/assignmaterial": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:assignmaterial"
+   ],
+   "type_name": "assignmaterial"
+  },
+  "Lop/attribwrangle": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Input 2",
+    "Input 3",
+    "Input 4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:attribwrangle"
+   ],
+   "type_name": "attribwrangle"
+  },
+  "Lop/camera": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:camera"
+   ],
+   "type_name": "camera"
+  },
+  "Lop/componentgeometry": {
+   "category": "Lop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:componentgeometry"
+   ],
+   "type_name": "componentgeometry"
+  },
+  "Lop/componentoutput": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Thumbnail Scene"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:componentoutput"
+   ],
+   "type_name": "componentoutput"
+  },
+  "Lop/cop2net": {
+   "category": "Lop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Lop/domelight": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:domelight"
+   ],
+   "type_name": "domelight"
+  },
+  "Lop/domelight::2.0": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:domelight"
+   ],
+   "type_name": "domelight::2.0"
+  },
+  "Lop/domelight::3.0": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:domelight"
+   ],
+   "type_name": "domelight::3.0"
+  },
+  "Lop/dopnet": {
+   "category": "Lop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Lop/duplicate": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:duplicate"
+   ],
+   "type_name": "duplicate"
+  },
+  "Lop/extractinstances": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:extractinstances"
+   ],
+   "type_name": "extractinstances"
+  },
+  "Lop/filecache": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:filecache"
+   ],
+   "type_name": "filecache"
+  },
+  "Lop/instancer": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Possible Prototype Source"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:instancer"
+   ],
+   "type_name": "instancer"
+  },
+  "Lop/karma": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Additional Render Products"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:karma"
+   ],
+   "type_name": "karma"
+  },
+  "Lop/karmarenderproperties": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Additional Render Vars"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:karmarenderproperties"
+   ],
+   "type_name": "karmarenderproperties"
+  },
+  "Lop/labs::karma::1.0": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Additional Render Products"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:karma"
+   ],
+   "type_name": "labs::karma::1.0"
+  },
+  "Lop/labs::karma::2.0": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Additional Render Products"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:karma"
+   ],
+   "type_name": "labs::karma::2.0"
+  },
+  "Lop/layout": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:layout"
+   ],
+   "type_name": "layout"
+  },
+  "Lop/light": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:light"
+   ],
+   "type_name": "light"
+  },
+  "Lop/light::2.0": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:light"
+   ],
+   "type_name": "light::2.0"
+  },
+  "Lop/lopnet": {
+   "category": "Lop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Lop/materiallibrary": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:materiallibrary"
+   ],
+   "type_name": "materiallibrary"
+  },
+  "Lop/merge": {
+   "category": "Lop",
+   "input_labels": [
+    "Merge Stage Layers"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:merge"
+   ],
+   "type_name": "merge"
+  },
+  "Lop/mergepointinstancers": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:mergepointinstancers"
+   ],
+   "type_name": "mergepointinstancers"
+  },
+  "Lop/modifypointinstances": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:modifypointinstances"
+   ],
+   "type_name": "modifypointinstances"
+  },
+  "Lop/null": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Lop/output": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Lop/pythonscript": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:pythonscript"
+   ],
+   "type_name": "pythonscript"
+  },
+  "Lop/reference": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Add As Reference"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:reference"
+   ],
+   "type_name": "reference"
+  },
+  "Lop/reference::2.0": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Add As Reference"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:reference"
+   ],
+   "type_name": "reference::2.0"
+  },
+  "Lop/sopimport": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:sopimport"
+   ],
+   "type_name": "sopimport"
+  },
+  "Lop/splitpointinstancers": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:splitpointinstancers"
+   ],
+   "type_name": "splitpointinstancers"
+  },
+  "Lop/sublayer": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Add As Sublayer"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:sublayer"
+   ],
+   "type_name": "sublayer"
+  },
+  "Lop/subnet": {
+   "category": "Lop",
+   "input_labels": [
+    "Input Stage",
+    "Input 2",
+    "Input 3",
+    "Input 4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 10,
+   "output_labels": [
+    "Output Stage"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Lop/topnet": {
+   "category": "Lop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Object/cam": {
+   "category": "Object",
+   "input_labels": [
+    "parent"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:cam"
+   ],
+   "type_name": "cam"
+  },
+  "Object/cop2net": {
+   "category": "Object",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Object/dopnet": {
+   "category": "Object",
+   "input_labels": [
+    "parent"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Object/geo": {
+   "category": "Object",
+   "input_labels": [
+    "parent"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:geo"
+   ],
+   "type_name": "geo"
+  },
+  "Object/light": {
+   "category": "Object",
+   "input_labels": [
+    "parent"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:light"
+   ],
+   "type_name": "light"
+  },
+  "Object/lopnet": {
+   "category": "Object",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Object/null": {
+   "category": "Object",
+   "input_labels": [
+    "parent"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Object/pythonscript": {
+   "category": "Object",
+   "input_labels": [
+    "parent"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:pythonscript"
+   ],
+   "type_name": "pythonscript"
+  },
+  "Object/subnet": {
+   "category": "Object",
+   "input_labels": [
+    "Sub-Network Input #1",
+    "Sub-Network Input #2",
+    "Sub-Network Input #3",
+    "Sub-Network Input #4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Object/topnet": {
+   "category": "Object",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Shop/cop2net": {
+   "category": "Shop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Shop/dopnet": {
+   "category": "Shop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Shop/lopnet": {
+   "category": "Shop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Shop/topnet": {
+   "category": "Shop",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Sop/apex::autorigbuilder": {
+   "category": "Sop",
+   "input_labels": [
+    "CharacterStream",
+    "Rig Template"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "CharacterStream",
+    "Rig Template"
+   ],
+   "sources": [
+    "emitted:apex::autorigbuilder"
+   ],
+   "type_name": "apex::autorigbuilder"
+  },
+  "Sop/apex::autorigcomponent": {
+   "category": "Sop",
+   "input_labels": [
+    "CharacterStream",
+    "Component Script"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "CharacterStream",
+    "Component Script"
+   ],
+   "sources": [
+    "emitted:apex::autorigcomponent"
+   ],
+   "type_name": "apex::autorigcomponent"
+  },
+  "Sop/apex::autorigcomponent::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "CharacterStream",
+    "ComponentScript"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "CharacterStream",
+    "ComponentScript"
+   ],
+   "sources": [
+    "emitted:apex::autorigcomponent"
+   ],
+   "type_name": "apex::autorigcomponent::2.0"
+  },
+  "Sop/apex::autorigcomponent::3.0": {
+   "category": "Sop",
+   "input_labels": [
+    "CharacterStream",
+    "Component Script"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "CharacterStream",
+    "Component Script"
+   ],
+   "sources": [
+    "emitted:apex::autorigcomponent"
+   ],
+   "type_name": "apex::autorigcomponent::3.0"
+  },
+  "Sop/apex::buildfkgraph": {
+   "category": "Sop",
+   "input_labels": [
+    "Sub-Network Input #1",
+    "Sub-Network Input #2"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:apex::buildfkgraph"
+   ],
+   "type_name": "apex::buildfkgraph"
+  },
+  "Sop/apex::configurecontrols": {
+   "category": "Sop",
+   "input_labels": [
+    "CharacterStream",
+    "Shape Library"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "CharacterStream"
+   ],
+   "sources": [
+    "emitted:apex::configurecontrols"
+   ],
+   "type_name": "apex::configurecontrols"
+  },
+  "Sop/apex::configuregraph": {
+   "category": "Sop",
+   "input_labels": [
+    "Input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output"
+   ],
+   "sources": [
+    "emitted:apex::configuregraph"
+   ],
+   "type_name": "apex::configuregraph"
+  },
+  "Sop/apex::controlextract": {
+   "category": "Sop",
+   "input_labels": [
+    "Scene/Character/Rig"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 2,
+   "output_labels": [
+    "Control Constraint Graph",
+    "Control Skeleton"
+   ],
+   "sources": [
+    "emitted:apex::controlextract"
+   ],
+   "type_name": "apex::controlextract"
+  },
+  "Sop/apex::graph": {
+   "category": "Sop",
+   "input_labels": [
+    "Sub-Network Input #1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:apex::graph"
+   ],
+   "type_name": "apex::graph"
+  },
+  "Sop/apex::invokegraph": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:apex::invokegraph"
+   ],
+   "type_name": "apex::invokegraph"
+  },
+  "Sop/apex::mapcharacter": {
+   "category": "Sop",
+   "input_labels": [
+    "Scene/Character"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Scene/Character"
+   ],
+   "sources": [
+    "emitted:apex::mapcharacter"
+   ],
+   "type_name": "apex::mapcharacter"
+  },
+  "Sop/apex::mergegraph": {
+   "category": "Sop",
+   "input_labels": [
+    "Sub-Network Input #1",
+    "Sub-Network Input #2"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "apex::mergegraph"
+  },
+  "Sop/apex::packcharacter": {
+   "category": "Sop",
+   "input_labels": [
+    "Character/Scene",
+    "Rest Geometry",
+    "Capture Pose",
+    "Animated Pose"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Character/Scene"
+   ],
+   "sources": [
+    "emitted:apex::packcharacter"
+   ],
+   "type_name": "apex::packcharacter"
+  },
+  "Sop/apex::sceneinvoke": {
+   "category": "Sop",
+   "input_labels": [
+    "Scene"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 1,
+   "output_count": 2,
+   "output_labels": [
+    "Scene Outputs"
+   ],
+   "sources": [
+    "emitted:apex::sceneinvoke"
+   ],
+   "type_name": "apex::sceneinvoke"
+  },
+  "Sop/apex::sceneinvoke::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Scene"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Scene Outputs"
+   ],
+   "sources": [
+    "emitted:apex::sceneinvoke"
+   ],
+   "type_name": "apex::sceneinvoke::2.0"
+  },
+  "Sop/assemble": {
+   "category": "Sop",
+   "input_labels": [
+    "Polygons to Assemble into Pieces"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:assemble"
+   ],
+   "type_name": "assemble"
+  },
+  "Sop/attribwrangle": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Process with Wrangle",
+    "Ancillary Input, point(1, ...) to Access",
+    "Ancillary Input, point(2, ...) to Access",
+    "Ancillary Input, point(3, ...) to Access"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:attribwrangle"
+   ],
+   "type_name": "attribwrangle"
+  },
+  "Sop/beta::tissuesolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Tissue",
+    "Fascia",
+    "Target Constraint Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Tissue Output"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "beta::tissuesolver"
+  },
+  "Sop/blendshapes": {
+   "category": "Sop",
+   "input_labels": [
+    "Blend Source",
+    "Blend Source"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "blendshapes"
+  },
+  "Sop/blendshapes::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Blend Source",
+    "Blend Source"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "blendshapes::2.0"
+  },
+  "Sop/block_begin": {
+   "category": "Sop",
+   "input_labels": [
+    "Initial Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:block_begin"
+   ],
+   "type_name": "block_begin"
+  },
+  "Sop/block_end": {
+   "category": "Sop",
+   "input_labels": [
+    "Nodes to Iterate Over",
+    "Geometry Pieces to Loop Over"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:block_end"
+   ],
+   "type_name": "block_end"
+  },
+  "Sop/cop2net": {
+   "category": "Sop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Sop/debrissource": {
+   "category": "Sop",
+   "input_labels": [
+    "Simulated or Rest Geometry",
+    "Simulation Points when using Rest Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Source Points"
+   ],
+   "sources": [
+    "emitted:debrissource"
+   ],
+   "type_name": "debrissource"
+  },
+  "Sop/debrissource::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Simulated or Rest Geometry",
+    "Simulation Points when using Rest Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Source Points"
+   ],
+   "sources": [
+    "emitted:debrissource"
+   ],
+   "type_name": "debrissource::2.0"
+  },
+  "Sop/dopnet": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2",
+    "Input 3",
+    "Input 4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Sop/duplicate": {
+   "category": "Sop",
+   "input_labels": [
+    "Source geometry to duplicate"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:duplicate"
+   ],
+   "type_name": "duplicate"
+  },
+  "Sop/fasciasolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Fascia",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Solved Fascia"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "fasciasolver"
+  },
+  "Sop/feathersurfaceblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Feathers",
+    "Skin",
+    "VDB",
+    "Target Surface"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Feathers",
+    "Skin",
+    "VDB"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "feathersurfaceblend"
+  },
+  "Sop/file": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:file"
+   ],
+   "type_name": "file"
+  },
+  "Sop/filecache": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Cache to Disk"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Cached Geometry"
+   ],
+   "sources": [
+    "emitted:filecache"
+   ],
+   "type_name": "filecache"
+  },
+  "Sop/filecache::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Cache to Disk"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Cached Geometry"
+   ],
+   "sources": [
+    "emitted:filecache"
+   ],
+   "type_name": "filecache::2.0"
+  },
+  "Sop/filemerge": {
+   "category": "Sop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "filemerge"
+  },
+  "Sop/filemerge::2.0": {
+   "category": "Sop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "filemerge::2.0"
+  },
+  "Sop/flipsolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Sources",
+    "Container",
+    "Collisions",
+    "Boundary Flow"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 3,
+   "output_count": 3,
+   "output_labels": [
+    "Fluid Particles",
+    "Container",
+    "Collisions"
+   ],
+   "sources": [
+    "emitted:flipsolver",
+    "sop_pattern"
+   ],
+   "type_name": "flipsolver"
+  },
+  "Sop/groomblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Guides A",
+    "Skin A",
+    "Skin VDB",
+    "Guides B",
+    "Skin B"
+   ],
+   "instantiated": true,
+   "max_inputs": 5,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Guides B",
+    "Skin",
+    "Skin VDB"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "groomblend"
+  },
+  "Sop/groomswitch": {
+   "category": "Sop",
+   "input_labels": [
+    "Guides A",
+    "Skin A",
+    "Skin VDB A",
+    "Guides B",
+    "Skin B",
+    "Skin VDB B"
+   ],
+   "instantiated": true,
+   "max_inputs": 6,
+   "min_inputs": 6,
+   "output_count": 3,
+   "output_labels": [
+    "Guides",
+    "Skin",
+    "Skin VDB"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "groomswitch"
+  },
+  "Sop/heightfield": {
+   "category": "Sop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Sub-Network Output #1"
+   ],
+   "sources": [
+    "emitted:heightfield"
+   ],
+   "type_name": "heightfield"
+  },
+  "Sop/heightfield_erode": {
+   "category": "Sop",
+   "input_labels": [
+    "Terrain to Erode",
+    "Masks"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Eroded Terrain"
+   ],
+   "sources": [
+    "emitted:heightfield_erode"
+   ],
+   "type_name": "heightfield_erode"
+  },
+  "Sop/heightfield_erode::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Terrain to Erode",
+    "Masks"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Sub-Network Output #1"
+   ],
+   "sources": [
+    "emitted:heightfield_erode"
+   ],
+   "type_name": "heightfield_erode::2.0"
+  },
+  "Sop/heightfield_erode::3.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Terrain to Erode",
+    "Masks"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Eroded Terrain"
+   ],
+   "sources": [
+    "emitted:heightfield_erode"
+   ],
+   "type_name": "heightfield_erode::3.0"
+  },
+  "Sop/heightfield_noise": {
+   "category": "Sop",
+   "input_labels": [
+    "Terrain",
+    "Mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:heightfield_noise"
+   ],
+   "type_name": "heightfield_noise"
+  },
+  "Sop/kinefx::characterblendshapechannels": {
+   "category": "Sop",
+   "input_labels": [
+    "Skeleton",
+    "Mesh"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Skeleton"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::characterblendshapechannels"
+  },
+  "Sop/kinefx::characterblendshapes": {
+   "category": "Sop",
+   "input_labels": [
+    "Rest Geometry",
+    "Capture Pose",
+    "Animated Pose"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 3,
+   "output_count": 3,
+   "output_labels": [
+    "Rest Geometry",
+    "Capture Pose",
+    "Animated Pose"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::characterblendshapes"
+  },
+  "Sop/kinefx::characterblendshapesadd": {
+   "category": "Sop",
+   "input_labels": [
+    "Mesh",
+    "Packed Blendshapes"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::characterblendshapesadd"
+  },
+  "Sop/kinefx::characterblendshapescore": {
+   "category": "Sop",
+   "input_labels": [
+    "Input Geometry",
+    "Animated Pose"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::characterblendshapescore"
+  },
+  "Sop/kinefx::characterblendshapesextract": {
+   "category": "Sop",
+   "input_labels": [
+    "Mesh"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Blend Shape"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::characterblendshapesextract"
+  },
+  "Sop/kinefx::motionclipblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Base",
+    "Layer"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "MotionClip"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::motionclipblend"
+  },
+  "Sop/kinefx::motionclipblend::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Base",
+    "Layer"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "MotionClip"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::motionclipblend::2.0"
+  },
+  "Sop/kinefx::motionclipmerge": {
+   "category": "Sop",
+   "input_labels": [
+    "Motion Clips",
+    "Motion Clip to Merge"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::motionclipmerge"
+  },
+  "Sop/kinefx::ragdollsolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Skeleton",
+    "Collision Shapes",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 2,
+   "output_labels": [
+    "Skeleton"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::ragdollsolver"
+  },
+  "Sop/kinefx::ragdollsolver::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Skeleton",
+    "Collision Shapes",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Skeleton"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::ragdollsolver::2.0"
+  },
+  "Sop/kinefx::rigdoctor": {
+   "category": "Sop",
+   "input_labels": [
+    "Poly Lines"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Skeleton"
+   ],
+   "sources": [
+    "emitted:kinefx::rigdoctor"
+   ],
+   "type_name": "kinefx::rigdoctor"
+  },
+  "Sop/kinefx::skeletonblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::skeletonblend"
+  },
+  "Sop/kinefx::skeletonblend::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::skeletonblend::2.0"
+  },
+  "Sop/kinefx::skeletonblend::3.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "kinefx::skeletonblend::3.0"
+  },
+  "Sop/labs::color_blend": {
+   "category": "Sop",
+   "input_labels": [
+    "Input Mesh",
+    "Additional Mesh",
+    "(Optional) Mask Mesh"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "labs::color_blend"
+  },
+  "Sop/labs::filecache::1.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Cache to Disk"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Cached Geometry"
+   ],
+   "sources": [
+    "emitted:filecache"
+   ],
+   "type_name": "labs::filecache::1.0"
+  },
+  "Sop/labs::filecache::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Cache to Disk"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Cached Geometry"
+   ],
+   "sources": [
+    "emitted:filecache"
+   ],
+   "type_name": "labs::filecache::2.0"
+  },
+  "Sop/labs::merge_small_islands": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry with UVs"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "labs::merge_small_islands"
+  },
+  "Sop/labs::merge_small_islands::1.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry with UVs"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "labs::merge_small_islands::1.0"
+  },
+  "Sop/labs::merge_splines::1.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Polylines to Merge"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 2,
+   "output_labels": [
+    "Output",
+    "Guide Visual Output"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "labs::merge_splines::1.0"
+  },
+  "Sop/linearsolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Matrix/Decomposition (&Vectors)",
+    "Known Vector",
+    "Unknown Vector"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "linearsolver"
+  },
+  "Sop/lopnet": {
+   "category": "Sop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Sop/merge": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:merge",
+    "sop_pattern"
+   ],
+   "type_name": "merge"
+  },
+  "Sop/mergepacked": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "mergepacked"
+  },
+  "Sop/mpmsolver": {
+   "category": "Sop",
+   "input_labels": [
+    "MPM Sources",
+    "MPM Colliders",
+    "MPM Container"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "MPM Output Particles"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "mpmsolver"
+  },
+  "Sop/musclemerge": {
+   "category": "Sop",
+   "input_labels": [
+    "Sub-Network Input #1",
+    "Sub-Network Input #2",
+    "Sub-Network Input #3",
+    "Sub-Network Input #4",
+    "Input #5",
+    "Input #6"
+   ],
+   "instantiated": true,
+   "max_inputs": 6,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "musclemerge"
+  },
+  "Sop/musclesolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Muscles",
+    "Bones",
+    "Muscle Tension Ref"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Solved Muscles"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "musclesolver"
+  },
+  "Sop/musclesolverfem": {
+   "category": "Sop",
+   "input_labels": [
+    "Muscles",
+    "Bones",
+    "Muscle Tension Ref"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Solved Muscles"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "musclesolverfem"
+  },
+  "Sop/musclesolvervellum": {
+   "category": "Sop",
+   "input_labels": [
+    "Muscles",
+    "Bones",
+    "Activation Attribute Reference"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Solved Muscles"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "musclesolvervellum"
+  },
+  "Sop/null": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Sop/object_merge": {
+   "category": "Sop",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "object_merge"
+  },
+  "Sop/oceanevaluate": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Deform",
+    "Ocean Spectrum"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Sub-Network Output #1"
+   ],
+   "sources": [
+    "emitted:oceanevaluate"
+   ],
+   "type_name": "oceanevaluate"
+  },
+  "Sop/oceanevaluate::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Deform",
+    "Ocean Spectrum"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Sub-Network Output #1"
+   ],
+   "sources": [
+    "emitted:oceanevaluate"
+   ],
+   "type_name": "oceanevaluate::2.0"
+  },
+  "Sop/oceansource": {
+   "category": "Sop",
+   "input_labels": [
+    "Ocean Spectrum",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Initial",
+    "Maintain"
+   ],
+   "sources": [
+    "emitted:oceansource"
+   ],
+   "type_name": "oceansource"
+  },
+  "Sop/oceansource::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Ocean Spectrum",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "Initial",
+    "Maintain"
+   ],
+   "sources": [
+    "emitted:oceansource"
+   ],
+   "type_name": "oceansource::2.0"
+  },
+  "Sop/oceanspectrum": {
+   "category": "Sop",
+   "input_labels": [
+    "Wave Instancing Points",
+    "Mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Spectrum Layer"
+   ],
+   "sources": [
+    "emitted:oceanspectrum"
+   ],
+   "type_name": "oceanspectrum"
+  },
+  "Sop/opencl": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2",
+    "Input 3",
+    "Input 4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:opencl"
+   ],
+   "type_name": "opencl"
+  },
+  "Sop/otissolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 2,
+   "output_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "otissolver"
+  },
+  "Sop/output": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Sop/pyrosolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Sources",
+    "Collision Geometry/Volumes"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Simulated Fields"
+   ],
+   "sources": [
+    "emitted:pyrosolver",
+    "sop_pattern"
+   ],
+   "type_name": "pyrosolver"
+  },
+  "Sop/rbdbulletsolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry",
+    "Collision Geometry",
+    "Guide Sim"
+   ],
+   "instantiated": true,
+   "max_inputs": 5,
+   "min_inputs": 1,
+   "output_count": 4,
+   "output_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry",
+    "Simulation Points"
+   ],
+   "sources": [
+    "emitted:rbdbulletsolver",
+    "sop_pattern"
+   ],
+   "type_name": "rbdbulletsolver"
+  },
+  "Sop/rbdconstraintproperties": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "sources": [
+    "emitted:rbdconstraintproperties"
+   ],
+   "type_name": "rbdconstraintproperties"
+  },
+  "Sop/rbdconstraintproperties::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "sources": [
+    "emitted:rbdconstraintproperties"
+   ],
+   "type_name": "rbdconstraintproperties::2.0"
+  },
+  "Sop/rbdconstraintsfromrules": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry",
+    "Bounding Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "sources": [
+    "emitted:rbdconstraintsfromrules"
+   ],
+   "type_name": "rbdconstraintsfromrules"
+  },
+  "Sop/rbdmaterialfracture": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry",
+    "Extra Voronoi Points (Concrete) / Impact Points (Glass) / Cutter Geometry (Custom)"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "sources": [
+    "emitted:rbdmaterialfracture"
+   ],
+   "type_name": "rbdmaterialfracture"
+  },
+  "Sop/rbdmaterialfracture::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry",
+    "Extra Voronoi Points (Concrete) / Impact Points (Glass)"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry"
+   ],
+   "sources": [
+    "emitted:rbdmaterialfracture"
+   ],
+   "type_name": "rbdmaterialfracture::2.0"
+  },
+  "Sop/rbdmaterialfracture::3.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry",
+    "Extra Voronoi Points (Concrete) / Impact Points (Glass) / Cutter Geometry (Custom)"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry",
+    "Constraint Geometry",
+    "Proxy Geometry"
+   ],
+   "sources": [
+    "emitted:rbdmaterialfracture"
+   ],
+   "type_name": "rbdmaterialfracture::3.0"
+  },
+  "Sop/ripplesolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Rest Geometry",
+    "Displaced Geometry",
+    "Collide Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Geometry with Simulated Ripples"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "ripplesolver"
+  },
+  "Sop/sblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Blend Source"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "sblend"
+  },
+  "Sop/sblend::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Blend Source"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "sblend::2.0"
+  },
+  "Sop/scatter": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to scatter points onto"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:scatter"
+   ],
+   "type_name": "scatter"
+  },
+  "Sop/scatter::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to scatter points onto"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:scatter"
+   ],
+   "type_name": "scatter::2.0"
+  },
+  "Sop/shallowwatersolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Height Fields"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Height Fields with Simulated Water"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "shallowwatersolver"
+  },
+  "Sop/skinsolvervellum": {
+   "category": "Sop",
+   "input_labels": [
+    "Tissue",
+    "Internal Attach Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Tissue Output"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "skinsolvervellum"
+  },
+  "Sop/solver": {
+   "category": "Sop",
+   "input_labels": [
+    "Initial Geometry",
+    "Auxillary #1",
+    "Auxillary #2",
+    "Auxillary #3"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "solver"
+  },
+  "Sop/subnet": {
+   "category": "Sop",
+   "input_labels": [
+    "Sub-Network Input #1",
+    "Sub-Network Input #2",
+    "Sub-Network Input #3",
+    "Sub-Network Input #4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 11,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Sop/switch": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "switch"
+  },
+  "Sop/switchif": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1",
+    "Input 2"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "switchif"
+  },
+  "Sop/timeblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Evaluate at Another Time"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "timeblend"
+  },
+  "Sop/timeblend::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry to Evaluate at Another Time"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "timeblend::2.0"
+  },
+  "Sop/tissuesolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Skin",
+    "Animated Muscles",
+    "Static Muscles",
+    "Animated Bones",
+    "Static Bones"
+   ],
+   "instantiated": true,
+   "max_inputs": 5,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "Solver Output"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "tissuesolver"
+  },
+  "Sop/tissuesolvervellum": {
+   "category": "Sop",
+   "input_labels": [
+    "Tissue",
+    "Internal Attach Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Tissue Output"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "tissuesolvervellum"
+  },
+  "Sop/topnet": {
+   "category": "Sop",
+   "input_labels": [
+    "Input 1"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Sop/vdbmerge": {
+   "category": "Sop",
+   "input_labels": [
+    "VDBs To Merge"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "vdbmerge"
+  },
+  "Sop/vdbvectormerge": {
+   "category": "Sop",
+   "input_labels": [
+    "Scalar VDBs to merge into vector"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "vdbvectormerge"
+  },
+  "Sop/vellumconstraintproperty": {
+   "category": "Sop",
+   "input_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 3,
+   "output_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "sources": [
+    "emitted:vellumconstraintproperty"
+   ],
+   "type_name": "vellumconstraintproperty"
+  },
+  "Sop/vellumconstraints": {
+   "category": "Sop",
+   "input_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 1,
+   "output_count": 3,
+   "output_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "sources": [
+    "emitted:vellumconstraints"
+   ],
+   "type_name": "vellumconstraints"
+  },
+  "Sop/vellumdrape": {
+   "category": "Sop",
+   "input_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 3,
+   "output_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "sources": [
+    "emitted:vellumdrape"
+   ],
+   "type_name": "vellumdrape"
+  },
+  "Sop/vellumrestblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Geometry",
+    "Constraints",
+    "Collisions",
+    "Rest Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 2,
+   "output_count": 3,
+   "output_labels": [
+    "Geometry",
+    "Constraints",
+    "Collisions"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "vellumrestblend"
+  },
+  "Sop/vellumsolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 2,
+   "output_count": 3,
+   "output_labels": [
+    "Vellum Geometry",
+    "Constraint Geometry",
+    "Collision Geometry"
+   ],
+   "sources": [
+    "emitted:vellumsolver",
+    "sop_pattern"
+   ],
+   "type_name": "vellumsolver"
+  },
+  "Sop/volumemerge": {
+   "category": "Sop",
+   "input_labels": [
+    "Base Volume",
+    "Volumes to Merge in"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 2,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "volumemerge"
+  },
+  "Sop/volumerasterizeattributes": {
+   "category": "Sop",
+   "input_labels": [
+    "Points to Rasterize"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "VDBs"
+   ],
+   "sources": [
+    "emitted:volumerasterizeattributes"
+   ],
+   "type_name": "volumerasterizeattributes"
+  },
+  "Sop/whitewatersolver": {
+   "category": "Sop",
+   "input_labels": [
+    "Emission and Fluid Fields",
+    "Container",
+    "Collisions"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 3,
+   "output_count": 3,
+   "output_labels": [
+    "Whitewater Particles",
+    "Container",
+    "Collisions"
+   ],
+   "sources": [
+    "emitted:whitewatersolver",
+    "sop_pattern"
+   ],
+   "type_name": "whitewatersolver"
+  },
+  "Sop/whitewatersource": {
+   "category": "Sop",
+   "input_labels": [
+    "Liquid Simulation",
+    "Container",
+    "Collisions",
+    "Extra Sources"
+   ],
+   "instantiated": true,
+   "max_inputs": 2,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Volumes",
+    "Container",
+    "Collisions",
+    "Visualization Particles"
+   ],
+   "sources": [
+    "emitted:whitewatersource"
+   ],
+   "type_name": "whitewatersource"
+  },
+  "Sop/whitewatersource::2.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Liquid Simulation",
+    "Extra Source Points",
+    "Emission Mask"
+   ],
+   "instantiated": true,
+   "max_inputs": 3,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Volumes"
+   ],
+   "sources": [
+    "emitted:whitewatersource"
+   ],
+   "type_name": "whitewatersource::2.0"
+  },
+  "Sop/whitewatersource::3.0": {
+   "category": "Sop",
+   "input_labels": [
+    "Liquid Simulation",
+    "Container",
+    "Collisions",
+    "Extra Sources"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 1,
+   "output_count": 4,
+   "output_labels": [
+    "Volumes",
+    "Container",
+    "Collisions",
+    "Visualization Particles"
+   ],
+   "sources": [
+    "emitted:whitewatersource"
+   ],
+   "type_name": "whitewatersource::3.0"
+  },
+  "Sop/wireblend": {
+   "category": "Sop",
+   "input_labels": [
+    "Blend Source"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "sop_pattern"
+   ],
+   "type_name": "wireblend"
+  },
+  "Top/cop2net": {
+   "category": "Top",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:cop2net"
+   ],
+   "type_name": "cop2net"
+  },
+  "Top/dopnet": {
+   "category": "Top",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:dopnet"
+   ],
+   "type_name": "dopnet"
+  },
+  "Top/ffmpegencodevideo": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:ffmpegencodevideo"
+   ],
+   "type_name": "ffmpegencodevideo"
+  },
+  "Top/genericgenerator": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:genericgenerator"
+   ],
+   "type_name": "genericgenerator"
+  },
+  "Top/labs::wedge::1.0": {
+   "category": "Top",
+   "input_labels": [
+    "Work-Items to wedge"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Wedged Work-Items"
+   ],
+   "sources": [
+    "emitted:wedge"
+   ],
+   "type_name": "labs::wedge::1.0"
+  },
+  "Top/localscheduler": {
+   "category": "Top",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:localscheduler"
+   ],
+   "type_name": "localscheduler"
+  },
+  "Top/lopnet": {
+   "category": "Top",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:lopnet"
+   ],
+   "type_name": "lopnet"
+  },
+  "Top/merge": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:merge"
+   ],
+   "type_name": "merge"
+  },
+  "Top/null": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Top/output": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Top/partitionbyattribute": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 9999,
+   "min_inputs": 1,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:partitionbyattribute"
+   ],
+   "type_name": "partitionbyattribute"
+  },
+  "Top/pythonscript": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:pythonscript"
+   ],
+   "type_name": "pythonscript"
+  },
+  "Top/ropfetch": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:ropfetch"
+   ],
+   "type_name": "ropfetch"
+  },
+  "Top/subnet": {
+   "category": "Top",
+   "input_labels": [
+    "Input 1",
+    "Input 2",
+    "Input 3",
+    "Input 4"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 4,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "Top/topnet": {
+   "category": "Top",
+   "input_labels": [],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 0,
+   "output_labels": [],
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Top/wedge": {
+   "category": "Top",
+   "input_labels": [
+    "input"
+   ],
+   "instantiated": true,
+   "max_inputs": 1,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "output"
+   ],
+   "sources": [
+    "emitted:wedge"
+   ],
+   "type_name": "wedge"
+  },
+  "TopNet/topnet": {
+   "category": "TopNet",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 0,
+   "output_labels": null,
+   "sources": [
+    "emitted:topnet"
+   ],
+   "type_name": "topnet"
+  },
+  "Vop/block_begin": {
+   "category": "Vop",
+   "input_labels": [
+    "Next (Any Type)"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:block_begin"
+   ],
+   "type_name": "block_begin"
+  },
+  "Vop/block_end": {
+   "category": "Vop",
+   "input_labels": [
+    "Next (Any Type)"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:block_end"
+   ],
+   "type_name": "block_end"
+  },
+  "Vop/composite": {
+   "category": "Vop",
+   "input_labels": [
+    "Operation",
+    "A",
+    "A Alpha",
+    "B",
+    "B Alpha"
+   ],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 2,
+   "output_labels": [
+    "Resulting Color",
+    "Resulting Alpha"
+   ],
+   "sources": [
+    "emitted:composite"
+   ],
+   "type_name": "composite"
+  },
+  "Vop/file": {
+   "category": "Vop",
+   "input_labels": [
+    "File",
+    "Frame Offset",
+    "Motion Blur Style",
+    "Use Velocity Motion Blur",
+    "Blur File",
+    "Shutter",
+    "Material Archive",
+    "Share Geometry"
+   ],
+   "instantiated": true,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Geometry"
+   ],
+   "sources": [
+    "emitted:file"
+   ],
+   "type_name": "file"
+  },
+  "Vop/kinefx::blendtransforms": {
+   "category": "Vop",
+   "input_labels": [
+    "Transform 1",
+    "Transform 2",
+    "Components",
+    "Bias"
+   ],
+   "instantiated": true,
+   "max_inputs": 4,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Transform"
+   ],
+   "sources": [
+    "emitted:kinefx::blendtransforms"
+   ],
+   "type_name": "kinefx::blendtransforms"
+  },
+  "Vop/kinefx::twoboneik": {
+   "category": "Vop",
+   "input_labels": [
+    "Root",
+    "Mid",
+    "Tip",
+    "Root Driver",
+    "Twist",
+    "Goal",
+    "Stretch",
+    "Twist Offset",
+    "Blend",
+    "Orient Tip to Goal"
+   ],
+   "instantiated": true,
+   "max_inputs": 10,
+   "min_inputs": 0,
+   "output_count": 3,
+   "output_labels": [
+    "Root",
+    "Mid",
+    "Tip"
+   ],
+   "sources": [
+    "emitted:kinefx::twoboneik"
+   ],
+   "type_name": "kinefx::twoboneik"
+  },
+  "Vop/null": {
+   "category": "Vop",
+   "input_labels": [
+    "Next Input (all types allowed)"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:null"
+   ],
+   "type_name": "null"
+  },
+  "Vop/output": {
+   "category": "Vop",
+   "input_labels": [
+    "Surface Color",
+    "Surface Opacity",
+    "Surface Alpha",
+    "Surface Normal",
+    "BSDF"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 1,
+   "output_labels": [
+    "Output 1"
+   ],
+   "sources": [
+    "emitted:output"
+   ],
+   "type_name": "output"
+  },
+  "Vop/subnet": {
+   "category": "Vop",
+   "input_labels": [
+    "Next Input (all types allowed)"
+   ],
+   "instantiated": true,
+   "max_inputs": 2048,
+   "min_inputs": 0,
+   "output_count": 2048,
+   "output_labels": [],
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  },
+  "VopNet/light": {
+   "category": "VopNet",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:light"
+   ],
+   "type_name": "light"
+  },
+  "VopNet/subnet": {
+   "category": "VopNet",
+   "input_labels": null,
+   "instantiated": false,
+   "max_inputs": 0,
+   "min_inputs": 0,
+   "note": "no container for this category",
+   "output_count": 1,
+   "output_labels": null,
+   "sources": [
+    "emitted:subnet"
+   ],
+   "type_name": "subnet"
+  }
+ },
+ "generated": {
+  "by": "host/introspect_connectivity.py",
+  "from": "python/synapse/cognitive/tools/data/emitted_node_types.json",
+  "note": "deterministic: no wall-clock stamp — a second run on the same build must be byte-identical (the U.1 determinism pin)"
+ },
+ "houdini_version": "21.0.671",
+ "probe_errors": [],
+ "schema": "verified_connectivity/v2",
+ "v1_preserved": {
+  "_doc": "Mile-2 §2.5 preflight — IConnectivityOracle backing symbols, dir()-confirmed against LIVE Houdini 21.0.671 (headless hython, HYTHON=Houdini 21.0.671). Read-only: a throwaway /obj net was built in an isolated hython process; the user's session was untouched. Cross-checked against the committed scout symbol table (python/synapse/cognitive/tools/data/h21_symbol_table.json, houdini_version 21.0.671). Reproduce: harness/notes/mile2_2_5_introspect.py.",
+  "_provenance": "carried verbatim from verified_connectivity v1 (Mile-2 §2.5 preflight, dir()-confirmed on live 21.0.671; harness/notes/mile2_2_5_introspect.py) — NOT re-derived by host/introspect_connectivity.py",
+  "symbols_PHANTOM_do_not_use": {
+   "hou.NodeType.inputLabels": "ABSENT in 21.0.671 dir(hou.NodeType) — input labels are INSTANCE-level only (hou.Node.inputLabels). Type-level label lookup degrades to []. P3c is advisory, so this is graceful.",
+   "hou.NodeType.inputNames": "ABSENT in 21.0.671.",
+   "hou.NodeType.outputLabels": "ABSENT — same as inputLabels."
+  },
+  "symbols_present": {
+   "hou.Node.inputConnections": true,
+   "hou.Node.inputLabels": true,
+   "hou.Node.inputs": true,
+   "hou.Node.type": true,
+   "hou.NodeConnection.inputIndex": true,
+   "hou.NodeType.category": true,
+   "hou.NodeType.maxNumInputs": true,
+   "hou.NodeType.maxNumOutputs": true,
+   "hou.NodeType.minNumInputs": true,
+   "hou.NodeType.name": true,
+   "hou.NodeType.nameComponents": true,
+   "hou.NodeTypeCategory.name": true,
+   "hou.VopNode.inputDataTypes": true,
+   "hou.VopNode.outputDataTypes": true,
+   "hou.node": true,
+   "hou.nodeType": true,
+   "hou.nodeTypeCategories": true
+  },
+  "verified_values": {
+   "arity_min_max_outs": {
+    "Sop/box": [
+     0,
+     1,
+     1
+    ],
+    "Sop/merge": [
+     0,
+     9999,
+     1
+    ],
+    "Sop/xform": [
+     1,
+     1,
+     1
+    ],
+    "Vop/add": [
+     1,
+     2048,
+     1
+    ],
+    "Vop/constant": [
+     0,
+     0,
+     1
+    ]
+   },
+   "category_keys": [
+    "Chop",
+    "ChopNet",
+    "Cop",
+    "Cop2",
+    "CopNet",
+    "Data",
+    "Director",
+    "Dop",
+    "Driver",
+    "Lop",
+    "Manager",
+    "Object",
+    "Shop",
+    "Sop",
+    "Top",
+    "TopNet",
+    "Vop",
+    "VopNet"
+   ],
+   "occupied_input_logic": "merge with box wired to input0 -> inputConnections() yields one NodeConnection with inputIndex()==0. input_is_occupied(path, i) := any(c.inputIndex()==i for c in node.inputConnections()).",
+   "resolve_node_type_logic": "hou.node(path).type() -> (.name(), .category().name()); box -> ('box','Sop').",
+   "variadic_sentinel_note": "Variadic max inputs reported as a large finite cap (Sop/merge=9999, Vop/add=2048), NOT -1. The validator must treat 'index < max' generically; the in-repo MOCK uses -1 as its own unlimited sentinel, so the validator also treats max<0 as unlimited. Both map to 'no overflow'.",
+   "vop_datatypes_precook": "VopNode.inputDataTypes()/outputDataTypes() read ['undef'] on a fresh uncooked node -> NO reliable non-mutating type-level wire-compat oracle in 21.0.671. types_compatible() degrades; is_typed_category() still honest (Vop/Chop/Shop)."
+  }
+ }
+}

--- a/python/synapse/cognitive/tools/propose_graph.py
+++ b/python/synapse/cognitive/tools/propose_graph.py
@@ -57,6 +57,9 @@ def _edge_from_dict(d: dict) -> ProposedEdge:
         source_output_index=int(d.get("source_output_index", 0)),
         target_node_id=d["target_node_id"],
         target_input_index=int(d.get("target_input_index", 0)),
+        # U.1: optional declared slot label — P3e verifies it against the
+        # connectivity catalog when the target type is known.
+        target_input_label=str(d.get("target_input_label", "") or ""),
     )
 
 

--- a/python/synapse/core/wiring.py
+++ b/python/synapse/core/wiring.py
@@ -1,0 +1,167 @@
+"""Label-resolved node wiring against the probe-verified connectivity catalog.
+
+Utility-flywheel cycle U.1 (``harness/notes/spec-U1-wiring-flywheel.md``).
+Input indices drift in memory (the vellumsolver/rbdbulletsolver miswires);
+input LABELS are the surface artists see and the probe records. This module
+resolves a label to its live input index from the committed catalog and wires
+through ``node.setInput`` — so the code names the *intent* and the catalog
+supplies the index.
+
+The catalog is the packaged copy of the U.1 probe output
+(``python/synapse/cognitive/tools/data/connectivity_21.json`` — the scout
+symbol-table pattern: per-major committed authority, blake2b-stamped,
+byte-identical to ``harness/notes/verified_connectivity_21.0.671.json``).
+
+Fail-loud by design (``ScoutError``-style): an unknown type or label raises
+``WiringError`` — never a silent index guess. Index fallback exists ONLY via
+the explicit ``allow_index=True`` escape hatch.
+
+Zero ``hou`` import — the node/source arguments are duck-typed (live
+``hou.Node`` in production, fakes in tests), so this module is pure Python.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+CATALOG_SCHEMA = "verified_connectivity/v2"
+
+# Committed package authority — travels to CI / headless / hython where the
+# harness notes may be absent. Per-major naming like h21_symbol_table.json.
+_PKG_CATALOG = (Path(__file__).resolve().parents[1] / "cognitive" / "tools"
+                / "data" / "connectivity_21.json")
+
+_VERSION_COMPONENT = re.compile(r"^[0-9][0-9.]*$")
+
+_CATALOG_CACHE: dict = {}
+
+
+class WiringError(RuntimeError):
+    """Raised on any unresolvable wiring request (unknown type, unknown label,
+    missing/corrupt catalog). A plain exception ON PURPOSE — callers surface it;
+    nothing here degrades to a guessed input index."""
+
+
+def _strip_version(full_name: str) -> str:
+    parts = full_name.split("::")
+    if len(parts) > 1 and _VERSION_COMPONENT.match(parts[-1]):
+        return "::".join(parts[:-1])
+    return full_name
+
+
+def load_connectivity_catalog(path: Optional[Path] = None, *,
+                              strict: bool = True) -> Optional[dict]:
+    """Load + integrity-check the packaged catalog. ``strict=True`` raises
+    :class:`WiringError` on any problem (the wire-time posture: a mutation
+    must not proceed on a missing/corrupt catalog); ``strict=False`` returns
+    ``None`` (the validator posture: no catalog -> the additive check skips,
+    the oracle-backed checks still run)."""
+    fp = Path(path) if path is not None else _PKG_CATALOG
+    key = str(fp)
+    if key in _CATALOG_CACHE:
+        cached = _CATALOG_CACHE[key]
+        if cached is None and strict:
+            raise WiringError(f"connectivity catalog unusable at {fp}")
+        return cached
+
+    def _fail(reason: str):
+        _CATALOG_CACHE[key] = None
+        if strict:
+            raise WiringError(f"connectivity catalog {reason} ({fp})")
+        return None
+
+    if not fp.is_file():
+        return _fail("missing")
+    try:
+        data = json.loads(fp.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        return _fail(f"unreadable/malformed: {e}")
+    if data.get("schema") != CATALOG_SCHEMA:
+        return _fail(f"has schema {data.get('schema')!r}, expected {CATALOG_SCHEMA!r}")
+    digest = hashlib.blake2b(
+        json.dumps(data.get("entries", {}), sort_keys=True,
+                   ensure_ascii=False).encode("utf-8"),
+        digest_size=16,
+    ).hexdigest()
+    if digest != data.get("blake2b"):
+        return _fail("checksum mismatch (corrupt or hand-edited)")
+    _CATALOG_CACHE[key] = data
+    return data
+
+
+def resolve_catalog_entry(catalog: dict, category: str,
+                          type_name: str) -> Optional[dict]:
+    """The catalog entry for (category, type_name), accepting the spellings
+    ``createNode`` accepts: exact full name, version-elided, or bare name.
+    Ambiguous bare-name matches within a category return ``None`` (conservative
+    — no check beats a wrong check)."""
+    entries = catalog.get("entries", {})
+    exact = entries.get(f"{category}/{type_name}")
+    if exact is not None:
+        return exact
+    hits = []
+    for entry in entries.values():
+        if entry["category"] != category:
+            continue
+        base = _strip_version(entry["type_name"])
+        if base == type_name or (
+                "::" not in type_name and base.split("::")[-1] == type_name):
+            hits.append(entry)
+    return hits[0] if len(hits) == 1 else None
+
+
+def resolve_input_index(catalog: dict, category: str, type_name: str,
+                        label: str) -> int:
+    """The input index carrying ``label`` (case-insensitive EXACT match) on
+    (category, type_name). Raises :class:`WiringError` when the type is not in
+    the catalog, carries no probed labels, or has no such label."""
+    entry = resolve_catalog_entry(catalog, category, type_name)
+    if entry is None:
+        raise WiringError(
+            f"node type '{category}/{type_name}' is not in the connectivity "
+            f"catalog — probe it (host/introspect_connectivity.py) before "
+            f"wiring by label")
+    labels = entry.get("input_labels")
+    if not labels:
+        raise WiringError(
+            f"'{category}/{type_name}' has no probed input labels "
+            f"(instantiated={entry.get('instantiated')}) — wire_by_label "
+            f"cannot resolve '{label}'")
+    wanted = label.strip().lower()
+    for i, have in enumerate(labels):
+        if str(have).strip().lower() == wanted:
+            return i
+    raise WiringError(
+        f"'{category}/{type_name}' has no input labeled '{label}' — probe-"
+        f"verified labels are {labels}")
+
+
+def wire_by_label(node, label: str, source, catalog: Optional[dict] = None, *,
+                  source_output: int = 0, index: Optional[int] = None,
+                  allow_index: bool = False) -> int:
+    """Wire ``source`` into ``node``'s input named ``label``; returns the index.
+
+    The index comes from the connectivity catalog (probe truth), never from
+    memory. Unknown type/label FAILS LOUD with :class:`WiringError`; the ONLY
+    escape hatch is ``allow_index=True`` + an explicit ``index``, for types the
+    probe cannot label — and that fallback is a recorded decision at the call
+    site, not a silent default.
+    """
+    if catalog is None:
+        catalog = load_connectivity_catalog(strict=True)
+    nt = node.type()
+    type_name = nt.name()
+    category = nt.category().name()
+    try:
+        resolved = resolve_input_index(catalog, category, type_name, label)
+    except WiringError:
+        if allow_index and index is not None:
+            node.setInput(index, source, source_output)
+            return index
+        raise
+    node.setInput(resolved, source, source_output)
+    return resolved

--- a/python/synapse/routing/planner.py
+++ b/python/synapse/routing/planner.py
@@ -284,8 +284,10 @@ def _build_cloth_pipeline(
             "cloth.parm('constrainttype').set('cloth')\n"
             "solver = parent.createNode('vellumsolver', 'vellum_solver')\n"
             "solver.parm('substeps').set(5)\n"
-            "solver.setInput(0, cloth, 0)\n"
-            "solver.setInput(1, cloth, 1)\n"
+            "from synapse.core.wiring import wire_by_label\n"
+            "# U.1 catalog truth: vellumsolver 0=Vellum/1=Constraint/2=Collision\n"
+            "wire_by_label(solver, 'Vellum Geometry', cloth, source_output=0)\n"
+            "wire_by_label(solver, 'Constraint Geometry', cloth, source_output=1)\n"
             "result = {'cloth': cloth.path(), 'solver': solver.path()}\n"
         ),
     }))
@@ -311,7 +313,8 @@ def _build_cloth_pipeline(
                 "# straight into the solver's 'Collision Geometry' input.\n"
                 "collider = parent.createNode('null', 'collision_geo')\n"
                 "solver = parent.node('vellum_solver')\n"
-                "if solver: solver.setInput(2, collider, 0)\n"
+                "from synapse.core.wiring import wire_by_label\n"
+                "if solver: wire_by_label(solver, 'Collision Geometry', collider)\n"
                 "result = {'collider': collider.path()}\n"
             ),
         }))
@@ -373,8 +376,10 @@ def _build_destruction_pipeline(
             "props.parm('strength').set(500)\n"
             "props.setInput(0, cons, 0)\n"
             "solver = parent.createNode('rbdbulletsolver', 'rbd_solver')\n"
-            "solver.setInput(0, asm, 0)\n"
-            "solver.setInput(1, props, 0)\n"
+            "from synapse.core.wiring import wire_by_label\n"
+            "# U.1 catalog truth: rbdbulletsolver 0=Geometry/1=Constraint Geometry\n"
+            "wire_by_label(solver, 'Geometry', asm)\n"
+            "wire_by_label(solver, 'Constraint Geometry', props)\n"
             "result = {'fracture': frac.path(), 'solver': solver.path()}\n"
         ),
     }))

--- a/scripts/flywheel_review_wiring.py
+++ b/scripts/flywheel_review_wiring.py
@@ -1,0 +1,404 @@
+"""
+scripts/flywheel_review_wiring.py — U.1 REVIEW: wiring call sites vs probe truth
+================================================================================
+
+Utility-flywheel cycle U.1, REVIEW phase (harness/notes/spec-U1-wiring-flywheel.md).
+Pure Python + the connectivity catalog — no ``hou`` required (when run under
+hython, the optional Ledger deposit stamps the live build).
+
+Sweeps ``python/synapse/**`` for ``setInput(`` / ``insertInput(`` call sites —
+both real code and the generated-code string templates (the sweep is textual,
+so a template line like ``"solver.setInput(1, cloth, 1)\\n"`` is a call site
+too, which is exactly where yesterday's miswires lived). Each site is resolved
+to a node type via two lexical maps built per file:
+
+  * ``var = <anything>.createNode('<type>' [, '<name>'])``  → var carries <type>,
+    and <name> is registered so a later ``var = parent.node('<name>')`` in
+    another snippet resolves to the same type (the planner's modifier steps).
+  * nearest PRECEDING assignment wins (lexical flow).
+
+Classification against the catalog is CONSERVATIVE — a finding fires only when
+it holds for EVERY candidate category the type resolves in (bare 'merge' exists
+in Sop/Lop/Dop/...), so the gate cannot false-positive on category ambiguity:
+
+  CRITICAL index-out-of-arity   — literal input index >= max_inputs for ALL candidates
+  CRITICAL label-claim-mismatch — a nearby comment claims a quoted input label and
+                                  NO candidate's catalog label at that index matches
+  INFO     dynamic-index        — non-literal index (runtime passthrough; not provable here)
+  INFO     unresolved-receiver  — receiver's node type not lexically resolvable
+  INFO     type-not-in-catalog  — resolvable type the catalog doesn't carry
+
+Outputs ``.claude/flywheel_u1_findings.json`` + ``.md`` (severity-ranked).
+Exit 0 iff no CRITICAL findings (the ``wiring_conformance`` check verb).
+
+Options:
+  --deposit        deposit one Confirmation/DeadEnd Ledger record PER FINDING
+                   CLASS via synapse.science.deposit.LedgerDeposit (opt-in so
+                   the every-sprint check verb never re-deposits)
+  --queue-append   append the evidenced U.2+ candidates below to
+                   harness/state/flywheel_queue.json (status "candidate",
+                   ratified false — a HUMAN flips ratified; idempotent by id)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+CATALOG_PATH = _REPO / "harness" / "notes" / "verified_connectivity_21.0.671.json"
+SWEEP_ROOT = _REPO / "python" / "synapse"
+FINDINGS_JSON = _REPO / ".claude" / "flywheel_u1_findings.json"
+FINDINGS_MD = _REPO / ".claude" / "flywheel_u1_findings.md"
+QUEUE_PATH = _REPO / "harness" / "state" / "flywheel_queue.json"
+SKIP_PARTS = {"_vendor", "__pycache__"}
+
+SEVERITY_RANK = {"CRITICAL": 0, "INFO": 1}
+
+# --- lexical maps -----------------------------------------------------------
+# var = <recv>.createNode('type'[, 'name'])   (works inside string templates too)
+_CREATE_RE = re.compile(
+    r"(\w+)\s*=\s*[\w.()'\"/]+\.createNode\(\s*['\"]([\w:.]+)['\"]"
+    r"(?:\s*,\s*['\"]([\w:.]+)['\"])?")
+# var = <recv>.node('path-or-name')
+_NODE_LOOKUP_RE = re.compile(r"(\w+)\s*=\s*[\w.()'\"/]+\.node\(\s*['\"]([\w./: ]+)['\"]")
+# recv.setInput(<first-arg>  /  recv.insertInput(<first-arg>
+_CALLSITE_RE = re.compile(r"(\w+)\.(setInput|insertInput)\(\s*([^,)]+)")
+# a quoted label claimed in a comment, e.g.  # ... solver 'Constraint Geometry' input
+_COMMENT_LABEL_RE = re.compile(r"#[^'\"]*['\"]([A-Za-z][\w ]{2,40})['\"]")
+
+_VERSION_COMPONENT = re.compile(r"^[0-9][0-9.]*$")
+
+
+def _strip_version(full_name: str) -> str:
+    parts = full_name.split("::")
+    if len(parts) > 1 and _VERSION_COMPONENT.match(parts[-1]):
+        return "::".join(parts[:-1])
+    return full_name
+
+
+def load_catalog(path: Path = CATALOG_PATH) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema") != "verified_connectivity/v2":
+        raise SystemExit(f"catalog at {path} is not verified_connectivity/v2")
+    return data
+
+
+def candidates_for(catalog_entries: dict, type_name: str) -> list:
+    """Every catalog entry the spelling could resolve to (any category)."""
+    hits = []
+    for key, entry in catalog_entries.items():
+        full = entry["type_name"]
+        if (full == type_name
+                or _strip_version(full) == type_name
+                or ("::" not in type_name
+                    and _strip_version(full).split("::")[-1] == type_name)):
+            hits.append(entry)
+    return hits
+
+
+# --- the sweep ---------------------------------------------------------------
+
+def sweep_file(path: Path, catalog_entries: dict, name_registry: dict) -> list:
+    """All classified call sites in one file. ``name_registry`` maps created
+    node NAMES -> types across the whole sweep (two-pass: fill first)."""
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    var_types: list = []   # (line_no, var, type)
+    for i, line in enumerate(lines, 1):
+        for m in _CREATE_RE.finditer(line):
+            var_types.append((i, m.group(1), m.group(2)))
+        for m in _NODE_LOOKUP_RE.finditer(line):
+            base = m.group(2).rstrip("/").rsplit("/", 1)[-1]
+            if base in name_registry:
+                var_types.append((i, m.group(1), name_registry[base]))
+
+    def resolve_var(var: str, at_line: int):
+        best = None
+        for line_no, v, t in var_types:
+            if v == var and line_no <= at_line:
+                best = t
+        return best
+
+    sites = []
+    rel = str(path.relative_to(_REPO)).replace("\\", "/")
+    for i, line in enumerate(lines, 1):
+        for m in _CALLSITE_RE.finditer(line):
+            recv, call, first_arg = m.group(1), m.group(2), m.group(3).strip()
+            index = int(first_arg) if first_arg.isdigit() else None
+            recv_type = resolve_var(recv, i)
+            claimed = []
+            for back in range(max(0, i - 3), i):   # this line + 2 above
+                claimed += _COMMENT_LABEL_RE.findall(lines[back])
+            sites.append(classify_site(
+                catalog_entries, rel, i, recv, call, index, first_arg,
+                recv_type, claimed))
+    return sites
+
+
+def classify_site(catalog_entries, rel, line_no, recv, call, index, index_expr,
+                  recv_type, claimed_labels) -> dict:
+    site = {
+        "file": rel, "line": line_no, "call": call, "receiver": recv,
+        "receiver_type": recv_type, "index": index, "index_expr": index_expr,
+        "claimed_labels": claimed_labels,
+        "severity": "INFO", "kind": "", "detail": "",
+    }
+    if recv_type is None:
+        site.update(kind="unresolved-receiver",
+                    detail="receiver's node type not lexically resolvable (runtime object)")
+        return site
+    cands = candidates_for(catalog_entries, recv_type)
+    if not cands:
+        site.update(kind="type-not-in-catalog",
+                    detail=f"'{recv_type}' has no entry in the connectivity catalog")
+        return site
+    site["candidate_keys"] = sorted(f"{c['category']}/{c['type_name']}" for c in cands)
+    if index is None:
+        site.update(kind="dynamic-index",
+                    detail=f"input index '{index_expr}' is not a literal — not provable statically")
+        return site
+
+    # (a) arity: fires only if the index overflows EVERY candidate
+    def overflows(c):
+        mx = c.get("max_inputs")
+        return mx is not None and mx >= 0 and index >= mx
+    if all(overflows(c) for c in cands):
+        worst = max(c.get("max_inputs") or 0 for c in cands)
+        site.update(severity="CRITICAL", kind="index-out-of-arity",
+                    detail=f"input index {index} >= max_inputs ({worst}) for every "
+                           f"candidate of '{recv_type}'")
+        return site
+
+    # (b) label claim: a nearby comment names a quoted label — does the catalog
+    # agree that label lives at THIS index on at least one candidate?
+    labeled = [c for c in cands if c.get("input_labels")]
+    if claimed_labels and labeled:
+        def label_at(c):
+            labels = c["input_labels"]
+            return labels[index] if 0 <= index < len(labels) else None
+        def claim_matches(c):
+            at = label_at(c)
+            if at is None:
+                return False
+            at_l = at.lower()
+            return any(cl.lower() == at_l or cl.lower() in at_l or at_l in cl.lower()
+                       for cl in claimed_labels)
+        if any(claim_matches(c) for c in labeled):
+            site.update(kind="label-claim-verified",
+                        detail=f"comment label claim matches catalog label at index {index}")
+        else:
+            ats = sorted({str(label_at(c)) for c in labeled})
+            site.update(severity="CRITICAL", kind="label-claim-mismatch",
+                        detail=f"comment claims {claimed_labels} but catalog puts "
+                               f"{ats} at index {index} of '{recv_type}'")
+        return site
+
+    site.update(kind="index-within-arity",
+                detail=f"input index {index} within max_inputs for '{recv_type}'")
+    return site
+
+
+def run_sweep(catalog: dict) -> list:
+    entries = catalog["entries"]
+    files = sorted(p for p in SWEEP_ROOT.rglob("*.py")
+                   if not any(s in p.parts for s in SKIP_PARTS))
+    # pass 1: global created-name registry ('vellum_solver' -> 'vellumsolver')
+    name_registry: dict = {}
+    for p in files:
+        text = p.read_text(encoding="utf-8", errors="replace")
+        for m in _CREATE_RE.finditer(text):
+            if m.group(3):
+                name_registry.setdefault(m.group(3), m.group(2))
+    # pass 2: sweep
+    sites: list = []
+    for p in files:
+        sites.extend(sweep_file(p, entries, name_registry))
+    sites.sort(key=lambda s: (SEVERITY_RANK[s["severity"]], s["file"], s["line"]))
+    return sites
+
+
+# --- outputs ------------------------------------------------------------------
+
+def summarize(sites: list) -> dict:
+    by_kind: dict = {}
+    for s in sites:
+        by_kind[s["kind"]] = by_kind.get(s["kind"], 0) + 1
+    return {
+        "total_sites": len(sites),
+        "critical": sum(1 for s in sites if s["severity"] == "CRITICAL"),
+        "by_kind": dict(sorted(by_kind.items())),
+    }
+
+
+def write_findings(catalog: dict, sites: list) -> dict:
+    summary = summarize(sites)
+    payload = {
+        "schema": "flywheel_findings/v1",
+        "task": "U.1",
+        "catalog": {"path": str(CATALOG_PATH.relative_to(_REPO)).replace("\\", "/"),
+                    "houdini_version": catalog["houdini_version"],
+                    "blake2b": catalog["blake2b"]},
+        "summary": summary,
+        "findings": sites,
+    }
+    FINDINGS_JSON.parent.mkdir(parents=True, exist_ok=True)
+    FINDINGS_JSON.write_text(json.dumps(payload, indent=1, ensure_ascii=False) + "\n",
+                             encoding="utf-8", newline="\n")
+
+    md = ["# U.1 wiring review — findings (severity-ranked)", "",
+          f"Catalog: `{payload['catalog']['path']}` (build "
+          f"{catalog['houdini_version']}, blake2b `{catalog['blake2b'][:12]}`)", "",
+          f"**{summary['critical']} CRITICAL** of {summary['total_sites']} call sites. "
+          f"By kind: " + ", ".join(f"{k}={v}" for k, v in summary["by_kind"].items()), ""]
+    for sev in ("CRITICAL", "INFO"):
+        group = [s for s in sites if s["severity"] == sev]
+        if not group:
+            continue
+        md.append(f"## {sev} ({len(group)})")
+        md.append("")
+        cap = len(group) if sev == "CRITICAL" else 40
+        for s in group[:cap]:
+            md.append(f"- `{s['file']}:{s['line']}` **{s['kind']}** "
+                      f"`{s['receiver']}.{s['call']}({s['index_expr']}, ...)` "
+                      f"type={s['receiver_type']} — {s['detail']}")
+        if len(group) > cap:
+            md.append(f"- ... and {len(group) - cap} more (see JSON)")
+        md.append("")
+    FINDINGS_MD.write_text("\n".join(md), encoding="utf-8", newline="\n")
+    return summary
+
+
+# --- Ledger deposit (opt-in) ---------------------------------------------------
+
+def deposit_finding_classes(sites: list, summary: dict) -> tuple:
+    """One Confirmation/DeadEnd per verified finding CLASS via the §7.2 seam.
+    Run under hython for the live build stamp (LedgerDeposit reads hou when present)."""
+    sys.path.insert(0, str(_REPO / "python"))
+    from synapse.science.deposit import LedgerDeposit  # noqa: PLC0415 — after path fix
+
+    sink = LedgerDeposit()
+    now = int(time.time())
+    artifact = str(FINDINGS_JSON.relative_to(_REPO)).replace("\\", "/")
+    n_arity_bad = summary["by_kind"].get("index-out-of-arity", 0)
+    n_label_bad = summary["by_kind"].get("label-claim-mismatch", 0)
+    n_arity_ok = summary["by_kind"].get("index-within-arity", 0) \
+        + summary["by_kind"].get("label-claim-verified", 0)
+    n_label_ok = summary["by_kind"].get("label-claim-verified", 0)
+
+    sink({
+        "surface": "wiring/setInput-literal-index-within-catalog-arity",
+        "status": "champion" if n_arity_bad == 0 else "dead_end",
+        "detail": (f"{n_arity_ok} literal-index call sites resolve within catalog "
+                   f"arity; {n_arity_bad} overflow. Sweep artifact: {artifact}"),
+        "timestamp": now, "kind": "wiring_review", "context": "flywheel U.1 REVIEW",
+    })
+    sink({
+        "surface": "wiring/comment-label-claims-match-catalog-labels",
+        "status": "champion" if n_label_bad == 0 else "dead_end",
+        "detail": (f"{n_label_ok} label-claimed sites match the catalog label at "
+                   f"their index; {n_label_bad} mismatch. Sweep artifact: {artifact}"),
+        "timestamp": now, "kind": "wiring_review", "context": "flywheel U.1 REVIEW",
+    })
+    return sink.deposited, sink.failures
+
+
+# --- queue append (opt-in; candidates are proposals — a human ratifies) --------
+
+U2_CANDIDATES = [
+    {
+        "id": "U.2",
+        "title": "Parameter-name truth: gate emitted parm()/setParm literals against "
+                 "the nodetype catalog's live parm fingerprints",
+        "status": "candidate",
+        "evidence": [
+            "harness/notes/verified_nodetype_catalog_21.0.671.json",
+            ".claude/flywheel_u1_findings.json",
+            "python/synapse/routing/planner.py",
+            "python/synapse/routing/recipes/fx_recipes.py",
+        ],
+        "ratified": False,
+        "note": "The nodetype catalog already carries ordered [(parm, type, default)] "
+                "per resolved type — the same sweep pattern (createNode var map -> "
+                "parm('x') literals) closes the loop nobody gates today.",
+    },
+    {
+        "id": "U.3",
+        "title": "Source-output-index truth: validate setInput's third arg against "
+                 "catalog output_count/output_labels",
+        "status": "candidate",
+        "evidence": [
+            "harness/notes/verified_connectivity_21.0.671.json",
+            ".claude/flywheel_u1_findings.json",
+        ],
+        "ratified": False,
+        "note": "v2 catalog now carries output_count + ordered output_labels (e.g. "
+                "vellumconstraints out 1 = Constraint Geometry, relied on by "
+                "solver.setInput(1, cloth, 1)); the U.1 sweep only proves the "
+                "TARGET side.",
+    },
+    {
+        "id": "U.4",
+        "title": "Wire-time arity guard at the dynamic-index API boundary "
+                 "(handlers_node/api_adapter setInput passthroughs)",
+        "status": "candidate",
+        "evidence": [
+            ".claude/flywheel_u1_findings.json",
+            "python/synapse/server/api_adapter.py",
+            "python/synapse/server/handlers_node.py",
+        ],
+        "ratified": False,
+        "note": "The sweep's dynamic-index INFO sites are runtime passthroughs with "
+                "no catalog check; wiring.wire_by_label/catalog lookup can gate them "
+                "at call time.",
+    },
+]
+
+
+def append_queue_candidates() -> int:
+    queue = json.loads(QUEUE_PATH.read_text(encoding="utf-8"))
+    have = {c["id"] for c in queue["cycles"]}
+    added = 0
+    for cand in U2_CANDIDATES:
+        if cand["id"] not in have:
+            queue["cycles"].append(cand)
+            added += 1
+    if added:
+        QUEUE_PATH.write_text(json.dumps(queue, indent=2, ensure_ascii=False) + "\n",
+                              encoding="utf-8", newline="\n")
+    return added
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--deposit", action="store_true",
+                    help="deposit per-class Ledger records (opt-in)")
+    ap.add_argument("--queue-append", action="store_true",
+                    help="append evidenced U.2+ candidates to the flywheel queue")
+    a = ap.parse_args(argv)
+
+    catalog = load_catalog()
+    sites = run_sweep(catalog)
+    summary = write_findings(catalog, sites)
+    print(f"WIRING REVIEW: {summary['total_sites']} sites, "
+          f"{summary['critical']} CRITICAL -> {FINDINGS_JSON}")
+    for k, v in summary["by_kind"].items():
+        print(f"  {k}: {v}")
+
+    if a.deposit:
+        deposited, failures = deposit_finding_classes(sites, summary)
+        print(f"  ledger: deposited={deposited} failures={len(failures)}")
+        for f in failures:
+            print(f"  DEPOSIT-FAIL: {f}")
+    if a.queue_append:
+        print(f"  queue: appended {append_queue_candidates()} candidate(s) "
+              f"(ratified=false — human flips)")
+
+    return 1 if summary["critical"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_wiring_flywheel.py
+++ b/tests/test_wiring_flywheel.py
@@ -1,0 +1,365 @@
+"""U.1 utility-flywheel pins — network-wiring truth.
+
+Pins the three SCAFFOLD deliverables of harness/notes/spec-U1-wiring-flywheel.md:
+
+  1. the packaged connectivity catalog is deterministic + byte-identical to the
+     probe artifact (a drifted/hand-edited catalog fails loud),
+  2. wire_by_label resolves labels from the catalog and FAILS LOUD on anything
+     else (index fallback only behind the explicit allow_index gate),
+  3. GraphValidator P3e REJECTS the three golden miswires (the exact bug class
+     fixed on the release train) while the corrected forms pass.
+
+Pure Python — no hou, no Houdini. The catalog under test is the committed
+packaged copy (python/synapse/cognitive/tools/data/connectivity_21.json),
+probe-generated on live 21.0.671 by host/introspect_connectivity.py.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from conftest import HOUDINI_BUILD
+from synapse.cognitive.graph_proposal import (
+    GraphProposal,
+    NodeKind,
+    ProposedEdge,
+    ProposedNode,
+    ValidationStatus,
+)
+from synapse.cognitive.graph_validator import GraphValidator
+from synapse.core.wiring import (
+    WiringError,
+    load_connectivity_catalog,
+    resolve_catalog_entry,
+    resolve_input_index,
+    wire_by_label,
+)
+
+_REPO = Path(__file__).resolve().parents[1]
+PKG_CATALOG = _REPO / "python/synapse/cognitive/tools/data/connectivity_21.json"
+HARNESS_CATALOG = _REPO / "harness/notes/verified_connectivity_21.0.671.json"
+
+
+# ---------------------------------------------------------------------------
+# 1. Catalog determinism pin
+# ---------------------------------------------------------------------------
+
+class TestCatalogDeterminism:
+    def test_packaged_catalog_loads_and_verifies(self):
+        cat = load_connectivity_catalog()
+        assert cat["schema"] == "verified_connectivity/v2"
+        assert cat["houdini_version"] == HOUDINI_BUILD
+
+    def test_blake2b_recomputes_over_sorted_entries(self):
+        # The determinism contract: the stamp is a pure function of the sorted
+        # entries — any drift (hand edit, non-deterministic probe) fails here.
+        raw = json.loads(PKG_CATALOG.read_text(encoding="utf-8"))
+        digest = hashlib.blake2b(
+            json.dumps(raw["entries"], sort_keys=True,
+                       ensure_ascii=False).encode("utf-8"),
+            digest_size=16,
+        ).hexdigest()
+        assert digest == raw["blake2b"]
+
+    def test_packaged_copy_byte_identical_to_probe_artifact(self):
+        assert PKG_CATALOG.read_bytes() == HARNESS_CATALOG.read_bytes(), (
+            "packaged connectivity_21.json drifted from the harness probe "
+            "artifact — re-run host/introspect_connectivity.py and re-copy"
+        )
+
+    def test_v1_payload_preserved_with_provenance(self):
+        # EXPLORE must extend v1, not discard it: the dir()-membership facts and
+        # the phantom list survive the v2 fold, provenance-marked.
+        raw = json.loads(PKG_CATALOG.read_text(encoding="utf-8"))
+        v1 = raw["v1_preserved"]
+        assert "NOT re-derived" in v1["_provenance"]
+        assert v1["symbols_present"]["hou.Node.inputLabels"] is True
+        assert "hou.NodeType.inputLabels" in v1["symbols_PHANTOM_do_not_use"]
+
+    def test_regression_seed_labels_are_probe_truth(self):
+        # The two known-true seeds this whole cycle grew from.
+        cat = load_connectivity_catalog()
+        vs = cat["entries"]["Sop/vellumsolver"]
+        assert vs["input_labels"] == [
+            "Vellum Geometry", "Constraint Geometry", "Collision Geometry"]
+        rbd = cat["entries"]["Sop/rbdbulletsolver"]
+        assert rbd["input_labels"][0] == "Geometry"
+        assert rbd["input_labels"][1] == "Constraint Geometry"
+
+
+# ---------------------------------------------------------------------------
+# 2. wire_by_label unit matrix
+# ---------------------------------------------------------------------------
+
+class _FakeCategory:
+    def __init__(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+class _FakeType:
+    def __init__(self, name, category):
+        self._name, self._category = name, _FakeCategory(category)
+
+    def name(self):
+        return self._name
+
+    def category(self):
+        return self._category
+
+
+class _FakeNode:
+    def __init__(self, type_name, category="Sop"):
+        self._type = _FakeType(type_name, category)
+        self.wired = []
+
+    def type(self):
+        return self._type
+
+    def setInput(self, index, source, source_output=0):
+        self.wired.append((index, source, source_output))
+
+
+class TestWireByLabel:
+    def test_known_label_resolves_to_catalog_index(self):
+        solver, cloth = _FakeNode("vellumsolver"), object()
+        idx = wire_by_label(solver, "Constraint Geometry", cloth, source_output=1)
+        assert idx == 1
+        assert solver.wired == [(1, cloth, 1)]
+
+    def test_case_variance_still_resolves(self):
+        solver, src = _FakeNode("vellumsolver"), object()
+        assert wire_by_label(solver, "collision geometry", src) == 2
+        assert wire_by_label(solver, "  VELLUM GEOMETRY ", src) == 0
+
+    def test_unknown_label_fails_loud(self):
+        solver = _FakeNode("vellumsolver")
+        with pytest.raises(WiringError, match="no input labeled"):
+            wire_by_label(solver, "Constraint Geoemtry", object())
+        assert solver.wired == []            # nothing was wired on the failure
+
+    def test_unknown_type_fails_loud(self):
+        with pytest.raises(WiringError, match="not in the connectivity catalog"):
+            wire_by_label(_FakeNode("totally_phantom_solver"), "Geometry", object())
+
+    def test_index_fallback_requires_explicit_allow_index(self):
+        node = _FakeNode("totally_phantom_solver")
+        # index alone is NOT an escape hatch...
+        with pytest.raises(WiringError):
+            wire_by_label(node, "Geometry", object(), index=1)
+        # ...allow_index without an index isn't either...
+        with pytest.raises(WiringError):
+            wire_by_label(node, "Geometry", object(), allow_index=True)
+        # ...only the explicit pair wires.
+        src = object()
+        assert wire_by_label(node, "Geometry", src, index=1, allow_index=True) == 1
+        assert node.wired == [(1, src, 0)]
+
+    def test_rbdbulletsolver_constraint_is_input_1(self):
+        # The second regression seed, end to end through the public API.
+        solver, props = _FakeNode("rbdbulletsolver"), object()
+        assert wire_by_label(solver, "Constraint Geometry", props) == 1
+
+    def test_resolve_helpers_handle_versioned_and_bare_names(self):
+        cat = load_connectivity_catalog()
+        # exact spelling wins outright ('Lop/light' is a real plain key)...
+        entry = resolve_catalog_entry(cat, "Lop", "light")
+        assert entry is not None and entry["type_name"] == "light"
+        # ...and a versioned spelling resolves its own exact entry.
+        entry = resolve_catalog_entry(cat, "Lop", "light::2.0")
+        assert entry is not None and entry["type_name"] == "light::2.0"
+        with pytest.raises(WiringError):
+            resolve_input_index(cat, "Sop", "vellumsolver", "Nope")
+
+
+# ---------------------------------------------------------------------------
+# 3. Golden miswire fixtures through GraphValidator P3e
+# ---------------------------------------------------------------------------
+
+class _AllExist:
+    def node_type_exists(self, node_type, category):
+        return True
+
+    def parameter_exists(self, node_type, category, parm):
+        return True
+
+
+class _MockConn:
+    """Permissive IConnectivityOracle: generous arity/outputs so the ORACLE
+    phases pass and any rejection provably comes from the catalog (P3e)."""
+
+    def __init__(self, existing=None):
+        self._existing = existing or {}
+
+    def input_arity(self, node_type, category):
+        return (0, 9999)
+
+    def input_labels(self, node_type, category):
+        return []
+
+    def output_count(self, node_type, category):
+        return 9999
+
+    def is_typed_category(self, category):
+        return False
+
+    def types_compatible(self, *a):
+        return True
+
+    def input_is_occupied(self, scene_path, input_index):
+        return False
+
+    def resolve_node_type(self, scene_path):
+        return self._existing[scene_path]
+
+
+def _proposal(nodes, edges):
+    return GraphProposal(
+        proposal_id="u1-golden",
+        network_type="SOP",
+        parent_path="/obj/geo1",
+        nodes=nodes,
+        edges=edges,
+        natural_language_intent="U.1 golden miswire fixture",
+        model_id="fixture",
+        houdini_version_stamp=HOUDINI_BUILD,
+    )
+
+
+def _validate(p):
+    conn = _MockConn(existing={"/obj/geo1": ("geo", "Object")})
+    return GraphValidator(_AllExist(), conn).validate(p)
+
+
+_VELLUM_NODES = [
+    ProposedNode("cloth", NodeKind.NEW, "Sop", node_type="vellumconstraints",
+                 friendly_name="vellum_cloth"),
+    ProposedNode("solver", NodeKind.NEW, "Sop", node_type="vellumsolver",
+                 friendly_name="vellum_solver"),
+    ProposedNode("collider", NodeKind.NEW, "Sop", node_type="null",
+                 friendly_name="collision_geo"),
+]
+
+_RBD_NODES = [
+    ProposedNode("asm", NodeKind.NEW, "Sop", node_type="assemble",
+                 friendly_name="assemble1"),
+    ProposedNode("props", NodeKind.NEW, "Sop", node_type="rbdconstraintproperties",
+                 friendly_name="glue_props"),
+    ProposedNode("solver", NodeKind.NEW, "Sop", node_type="rbdbulletsolver",
+                 friendly_name="rbd_solver"),
+]
+
+
+class TestGoldenMiswires:
+    def test_golden_1_vellum_constraint_collision_swap_rejected(self):
+        # THE historical miswire: constraints wired to input 2, collision to 1.
+        p = _proposal(_VELLUM_NODES, [
+            ProposedEdge("cloth", 0, "solver", 0, target_input_label="Vellum Geometry"),
+            ProposedEdge("cloth", 1, "solver", 2, target_input_label="Constraint Geometry"),
+            ProposedEdge("collider", 0, "solver", 1, target_input_label="Collision Geometry"),
+        ])
+        report = _validate(p)
+        assert report.status == ValidationStatus.INVALID
+        mismatches = [i for i in report.errors if "label-mismatched slot" in i.message]
+        assert len(mismatches) == 2
+        assert all(HOUDINI_BUILD in i.message for i in report.errors)
+
+    def test_golden_1_corrected_form_passes(self):
+        p = _proposal(_VELLUM_NODES, [
+            ProposedEdge("cloth", 0, "solver", 0, target_input_label="Vellum Geometry"),
+            ProposedEdge("cloth", 1, "solver", 1, target_input_label="Constraint Geometry"),
+            ProposedEdge("collider", 0, "solver", 2, target_input_label="Collision Geometry"),
+        ])
+        report = _validate(p)
+        assert report.status == ValidationStatus.VALID, [e.message for e in report.errors]
+
+    def test_golden_2_rbd_constraint_to_input_2_rejected(self):
+        p = _proposal(_RBD_NODES, [
+            ProposedEdge("asm", 0, "solver", 0, target_input_label="Geometry"),
+            ProposedEdge("props", 0, "solver", 2, target_input_label="Constraint Geometry"),
+        ])
+        report = _validate(p)
+        assert report.status == ValidationStatus.INVALID
+        assert any("label-mismatched slot" in i.message
+                   and "index 1" in i.message for i in report.errors)
+
+    def test_golden_2_corrected_form_passes(self):
+        p = _proposal(_RBD_NODES, [
+            ProposedEdge("asm", 0, "solver", 0, target_input_label="Geometry"),
+            ProposedEdge("props", 0, "solver", 1, target_input_label="Constraint Geometry"),
+        ])
+        report = _validate(p)
+        assert report.status == ValidationStatus.VALID, [e.message for e in report.errors]
+
+    def test_golden_3_out_of_range_index_rejected_by_catalog_not_oracle(self):
+        # The oracle mock allows 9999 inputs — the rejection can ONLY come from
+        # the probe-verified catalog arity (vellumsolver max_inputs=3).
+        p = _proposal(_VELLUM_NODES, [
+            ProposedEdge("cloth", 0, "solver", 5),
+        ])
+        report = _validate(p)
+        assert report.status == ValidationStatus.INVALID
+        assert any("probe-verified arity" in i.message for i in report.errors)
+
+    def test_golden_3_corrected_form_passes(self):
+        p = _proposal(_VELLUM_NODES, [
+            ProposedEdge("cloth", 0, "solver", 0),
+        ])
+        report = _validate(p)
+        assert report.status == ValidationStatus.VALID, [e.message for e in report.errors]
+
+    def test_unknown_label_rejected(self):
+        p = _proposal(_VELLUM_NODES, [
+            ProposedEdge("cloth", 0, "solver", 0, target_input_label="Constraint Geoemtry"),
+        ])
+        report = _validate(p)
+        assert report.status == ValidationStatus.INVALID
+        assert any("no such input" in i.message for i in report.errors)
+
+    def test_catalog_check_is_additive_unknown_types_skip(self):
+        # A type the catalog does not carry: P3e stays silent (no false reject);
+        # the oracle-backed phases still govern.
+        nodes = [
+            ProposedNode("a", NodeKind.NEW, "Sop", node_type="not_in_catalog_a",
+                         friendly_name="a1"),
+            ProposedNode("b", NodeKind.NEW, "Sop", node_type="not_in_catalog_b",
+                         friendly_name="b1"),
+        ]
+        p = _proposal(nodes, [ProposedEdge("a", 0, "b", 7)])
+        report = _validate(p)
+        assert report.status == ValidationStatus.VALID
+
+
+# ---------------------------------------------------------------------------
+# 4. Planner adoption pin — the live sites emit wire_by_label, not raw indices
+# ---------------------------------------------------------------------------
+
+class TestPlannerAdoption:
+    def setup_method(self):
+        from synapse.routing.planner import WorkflowPlanner
+        self.planner = WorkflowPlanner()
+
+    def test_cloth_core_step_wires_by_label(self):
+        plan = self.planner.plan("set up cloth sim")
+        code = plan.steps[0].payload["code"]
+        assert "wire_by_label(solver, 'Vellum Geometry', cloth, source_output=0)" in code
+        assert "wire_by_label(solver, 'Constraint Geometry', cloth, source_output=1)" in code
+        assert "solver.setInput(" not in code
+
+    def test_cloth_collision_step_wires_by_label(self):
+        plan = self.planner.plan("set up cloth simulation with collision")
+        collision_code = plan.steps[1].payload["code"]
+        assert "wire_by_label(solver, 'Collision Geometry', collider)" in collision_code
+        assert "solver.setInput(" not in collision_code
+
+    def test_destruction_core_step_wires_by_label(self):
+        plan = self.planner.plan("setup destruction pipeline")
+        code = plan.steps[0].payload["code"]
+        assert "wire_by_label(solver, 'Geometry', asm)" in code
+        assert "wire_by_label(solver, 'Constraint Geometry', props)" in code
+        assert "solver.setInput(" not in code


### PR DESCRIPTION
## Summary

**The UTILITY FLYWHEEL — cycle U.1 (network-wiring truth).** A long-running, recursion-bounded self-improvement loop inside the existing `harness/` machine: EXPLORE (live-probed ground truth) → REVIEW (diff SYNAPSE's behavior against it, deposit findings to the Ledger, append evidenced next-cycle candidates to `harness/state/flywheel_queue.json`) → SCAFFOLD (wire the truth into the live path + pin it). A cycle counts only when its improvement is *consumed* by the live path — activation, not recording. New cycle classes require human ratification (the anti-runaway anchor).

### Cycle U.1, end-to-end on 21.0.671
- **EXPLORE** — `host/introspect_connectivity.py` (zero-synapse-import, scout-verified APIs): 282 (category,type) connectivity entries — arity + ordered input labels + output counts — into `verified_connectivity_21.0.671.json` v2 (June v1 folded in with provenance). Byte-identical across two hython runs.
- **REVIEW** — `scripts/flywheel_review_wiring.py`: 147 `setInput`/`insertInput` sites swept, **0 CRITICAL** (the classifier self-test proves all three golden miswires would fire). Two Confirmation records deposited via the Ledger path. Queue seeded with U.2 (parm-name truth), U.3 (source-output truth), U.4 (dynamic-index wire-time guard) — all `ratified:false`, awaiting the human.
- **SCAFFOLD** — `python/synapse/core/wiring.py::wire_by_label` (catalog-backed label→index resolution, fail-loud, index fallback only behind `allow_index=True`), adopted behavior-identically at the vellumsolver/rbdbulletsolver sites; `graph_validator` P3e slot-semantic checks (additive; carried through the live `/mcp` propose path via `target_input_label`); packaged catalog `connectivity_21.json` (blake2b-verified on load, symbol-table pattern); 3 new harness check verbs; 23 new test pins incl. the three golden miswires REJECTED / corrected forms VALID.

### Gates
- Full suite: **3,994 passed, 80 skipped** (baseline 3,971 — delta is exactly the new pins).
- `checks.py --task U.1`: **PASS** (catalog fresh + conformance rc=0 + miswire fixtures) · guardrails: 0 violations.
- Probe determinism proven; Ledger deposits stamped `against_build=21.0.671`.

### Meta-finding (not fixed here)
The dev machine's global editable install (`__editable__.synapse-*.pth`) makes bare pytest in ANY worktree silently import the MAIN checkout's package — this build pinned `PYTHONPATH` to compensate. Recommend pinning it in the harness runner itself (queued observation).

### Owed
- Human: flip U.1 → `done` in the queue; ratify (or reject) U.2/U.3/U.4.
- Re-run `scripts/flywheel_review_wiring.py --deposit` under hython post-merge to land the two Ledger records in the main checkout.
- Per-build: re-probe connectivity on H22 (the `connectivity_catalog_fresh` check fails loud until then, by design).

Base is `feat/h22-release-train` (all inputs live there); GitHub will retarget to `master` when PR #38 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
