### PR TITLE
Panel v9: in Houdini's skin - type-led redesign via the PANEL RELAY, crucible-verified

### DIFF
--- a/.claude/design/panel_v9_comp.html
+++ b/.claude/design/panel_v9_comp.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<!-- SYNAPSE panel v9 comp — "in Houdini's skin" — saved from the design brief 2026-07-02.
+     RATIFIED CALLS (CTO defaults, owner may override): bundle Space Grotesk + Space Mono (OFL,
+     native fallback) · underline tabs · author-token-opens-engine-menu (no pill bar in chrome) ·
+     land by Jul 11 off feat/h22-release-train. Cost meter: TOKENS ONLY (no $ — metering deferred D4). -->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>SYNAPSE — panel · v9 · in Houdini's skin</title>
+<style>
+  :root{
+    /* greys from Houdini UIDark.hcs · field inset nudged to Houdini's editable grey */
+    --stage:#1a1a1a; --panel:#2A2A2A; --ground:#1f1f1f; --raised:#323232;
+    --line:#363636; --hair:#303030;
+    --t1:#AEAEAE; --tb:#D4D4D4; --t2:#8A8A8A; --t3:#7E7E7E;
+    --signal:#8FB3D9; --signal-ink:#0F1F2B; --coral:#FF7759;
+    --ok:#6FBF8E; --no:#D96975; --hot:#D08A57;
+    --hou-tabstrip:#1c1c1c; --hou-tabline:#141414; --hou-tabtext:#9a9a9a;
+    --sans:'Space Grotesk','DM Sans',sans-serif;
+    --mono:'Space Mono','JetBrains Mono',monospace;
+    --tr-eyebrow: 0.22em; --tr-brand: 0.16em; --tr-label: 0.15em;
+    --tr-label-sm:0.12em; --tr-data: 0.03em; --tr-display: -0.015em; --tr-lede: -0.012em;
+  }
+  /* ── RAIL ── */
+  .rail{padding:16px 26px 14px;border-bottom:0.5px solid var(--hair);display:flex;align-items:center;}
+  .mk{width:16px;height:16px;border-radius:50%;}
+  .mk-idle{background:transparent;border:2px solid var(--coral);}
+  .mk-work{background:conic-gradient(var(--coral) 0 35%,transparent 35% 100%);animation:sweep 1.5s linear infinite;}
+  .mk-done{background:var(--coral);border:2px solid var(--coral);}
+  @media (prefers-reduced-motion: reduce){.mk-work{animation:none;}}
+  .word{font:500 14px var(--sans);letter-spacing:var(--tr-brand);color:var(--t1);margin-left:12px;}
+  .author{font:11px var(--mono);letter-spacing:var(--tr-data);color:var(--signal);} /* v9: CLICK TARGET → engine+model menu */
+  .meter{font:11px var(--mono);letter-spacing:var(--tr-data);color:var(--t3);} /* tokens only, e.g. "18.0k" */
+  .cmdk{font:10.5px var(--mono);letter-spacing:var(--tr-data);color:var(--t3);border:0.5px solid var(--line);border-radius:4px;padding:3px 7px;}
+  /* ── TABS (underline — ratified) ── */
+  .tabs{display:flex;gap:28px;padding:20px 26px 0;border-bottom:0.5px solid var(--line);}
+  .tabs b{font:400 11px var(--mono);letter-spacing:var(--tr-label);text-transform:uppercase;color:var(--t3);
+          padding-bottom:12px;border-bottom:2px solid transparent;}
+  .tabs b.on{color:var(--tb);border-bottom-color:var(--signal);}
+  /* ── DIRECT face: prose holds a measure (~440px); the input spans the pane ── */
+  .you{border-left:2px solid var(--signal);padding-left:14px;color:var(--tb);font-size:14px;line-height:1.5;max-width:440px;}
+  .syn{font-size:14px;line-height:1.55;color:var(--t1);margin-top:16px;max-width:440px;}
+  .chip{display:inline-flex;align-items:center;gap:8px;background:var(--ground);border:0.5px solid var(--line);
+        border-radius:4px;padding:7px 11px;}  /* node chip: 10px square swatch + mono path + "signed <model>" */
+  .bigfield{width:100%;min-height:132px;background:var(--ground);border:0.5px solid var(--line);border-radius:4px;
+            padding:14px 15px;color:var(--t3);font-size:13.5px;line-height:1.55;}
+  .send{background:var(--signal);color:var(--signal-ink);font:500 11px var(--sans);letter-spacing:0.08em;
+        text-transform:uppercase;padding:9px 15px;border-radius:4px;} /* bottom-right inside composer */
+  .khint{font:10px var(--mono);letter-spacing:var(--tr-data);color:var(--t3);margin-top:12px;}
+  /* ── WORK face ── */
+  .cookbar{height:3px;border-radius:2px;background:var(--ground);} /* fill: var(--raised) */
+  .cookline{font:10px var(--mono);letter-spacing:var(--tr-data);color:var(--t3);margin-top:8px;} /* "cooked 30/30 · 41s · karma_xpu · f1" + signal link */
+  .verdict{font:500 21px var(--sans);color:var(--tb);line-height:1.28;letter-spacing:var(--tr-display);max-width:360px;}
+  .credit{font:10.5px var(--mono);letter-spacing:var(--tr-data);color:var(--t3);line-height:1.95;}
+  /* credit rows: "DECISION <signal>value</signal> — rationale" / "SIGNED <signal>model</signal> · /stage customData"; key column 64px */
+  .ddot{width:6px;height:6px;border-radius:50%;} /* ok/no/hot status dots + 10px mono lines */
+  .acts{display:flex;gap:22px;margin-top:24px;padding-top:20px;border-top:0.5px solid var(--hair);max-width:440px;}
+  /* acts: "Accept"(ok) "↶ Revert"(t2) spacer "Commit to /stage?"(hot) — 10.5px mono uppercase tracking label */
+  /* ── WIDE DOCKS: structure spans the pane (rail/tabs/input/cookbar); reading holds ~340-440px measure ── */
+  /* ── PySide realities (from the comp's reconciliation column):
+       tracking = QFont.setLetterSpacing per role (QSS has none);
+       fonts = QFontDatabase.addApplicationFont, fallback native family;
+       mark = QPainter (existing MarkDat) incl. reduced-motion;
+       0.5px hairlines round up to ~1px on device. ── */
+</style>
+</head>
+<body><!-- structure: rail → tabs → stage{Direct face | Work face} — the panel IS the pane content; never a second pane --></body>
+</html>

--- a/audit_panel.py
+++ b/audit_panel.py
@@ -173,7 +173,7 @@ try:
           f"{len(under)} under {TARGET_FLOOR}px  " + tag(not under, warnable=True))
 
     texts = [b.text() for b in btns if b.text()]
-    faces = [f for f in ("Direct", "Work") if f in texts]
+    faces = [f for f in ("DIRECT", "WORK") if f in texts]   # v9: pre-uppercased tabs
     print(f"   tabs present        : {faces}  " + tag(len(faces) == 2))
     # v9: Review folded into Work's done sub-state. Assert its synthesis (the
     # consent gate) still lives in-tree, so the fold didn't silently drop the
@@ -202,60 +202,84 @@ try:
     qss_bundled = [b for b in ("space grotesk", "space mono") if b in qss_text]
     print(f"   no bundled font in QSS: {qss_bundled or 'clean'}  " + tag(not qss_bundled))
 
-    # --- Image #6 · model selection must be APPARENT (not buried in a menu) ---
-    from synapse.panel.providers.registry import PROVIDER_LABELS, DEFAULT_PROVIDER
-    label_set = set(PROVIDER_LABELS.values())
-    engine_btns = [b for b in btns if b.text() in label_set and not b.isHidden()]
-    print(f"   model selector      : {[b.text() for b in engine_btns]}  "
-          + tag(len(engine_btns) >= len(PROVIDER_LABELS)))
-    # the active engine must be visibly marked (active property), and match state
-    active = [b for b in engine_btns if b.property("active") in (True, "true")]
-    want = PROVIDER_LABELS.get(getattr(panel, "_provider_id", DEFAULT_PROVIDER))
-    sel_ok = len(active) == 1 and active[0].text() == want
-    print(f"   active engine mark  : {[b.text() for b in active]} (want {want!r})  "
-          + tag(sel_ok))
-    # prominent model chip (the readout) is present + non-empty
-    chip = getattr(panel, "_model_chip", None)
-    chip_ok = chip is not None and bool(chip.text()) and not chip.isHidden()
-    chip_txt = repr(chip.text()) if chip is not None else None
-    print(f"   model readout chip  : {chip_txt}  " + tag(chip_ok))
+    # --- v9 · engine selection must stay REACHABLE + OBSERVABLE from the rail
+    #     author token (the ENGINE pill bar left the chrome; same intent as the
+    #     old visible-pills check, re-anchored). The token is a visible,
+    #     enabled button; _author_menu_items() — the exact data its menu
+    #     renders — covers every provider. ---
+    from synapse.panel.providers.registry import PROVIDER_IDS, DEFAULT_PROVIDER
+    author = getattr(panel, "_author_lbl", None)
+    author_ok = (isinstance(author, QtWidgets.QAbstractButton)
+                 and not author.isHidden() and author.isEnabled()
+                 and bool(author.text()) and hasattr(panel, "_open_author_menu"))
+    a_txt = repr(author.text()) if author is not None else None
+    print(f"   engine reachable    : author token {a_txt}  " + tag(author_ok))
+    aitems = panel._author_menu_items() if hasattr(panel, "_author_menu_items") else []
+    got_pids = [pid for pid, _, _ in aitems]
+    print(f"   engine menu covers  : {got_pids}  "
+          + tag(got_pids == list(PROVIDER_IDS)))
+    # exactly ONE (engine, model) row active across the whole menu, == state
+    a_active = [(pid, mid) for pid, _, rows in aitems for mid, _, on in rows if on]
+    want_pair = (getattr(panel, "_provider_id", DEFAULT_PROVIDER),
+                 panel._active_model())
+    print(f"   active engine mark  : {a_active} (want {want_pair})  "
+          + tag(a_active == [want_pair]))
+    # the author token IS the model readout — non-empty and equal to the
+    # panel's own author formatting (selection observable)
+    readout_ok = author is not None and author.text() == panel._author_token()
+    print(f"   model readout token : {a_txt}  " + tag(readout_ok))
 
     # --- the model switcher must expose the registry's models + mark the active
-    #     one (switching Anthropic models must be apparent, not hidden) ---
+    #     one (switching Anthropic models must be apparent, not hidden) —
+    #     machinery reused, re-anchored to the author token. The rows lead with
+    #     the registry models IN ORDER; at most ONE extra row is permitted at
+    #     the tail: the active model, when the persisted pick went stale
+    #     (registry rotation) — the selection stays observable, never blank ---
     from synapse.panel.providers import registry as _reg
     items = panel._model_menu_items() if hasattr(panel, "_model_menu_items") else []
     want_ids = [m for m, _ in _reg.models_for(getattr(panel, "_provider_id", "claude"))]
     got_ids = [m for m, _, _ in items]
     actives = [m for m, _, a in items if a]
-    picker_ok = (got_ids == want_ids and len(got_ids) >= 2 and len(actives) == 1
-                 and isinstance(chip, QtWidgets.QAbstractButton))
+    rows_ok = (got_ids == want_ids
+               or (got_ids[:-1] == want_ids and got_ids[-1:] == actives))
+    picker_ok = (rows_ok and len(got_ids) >= 2 and len(actives) == 1
+                 and isinstance(author, QtWidgets.QAbstractButton))
     print(f"   model picker        : {len(got_ids)} models, active={actives}  "
           + tag(picker_ok))
 
-    # --- match Houdini: the panel must inherit the host's native UI font, not
-    #     override it with the bundled designed families (Space Grotesk/Mono).
-    #     Mono stays legal only for genuine code/paths inside the chat HTML. ---
+    # --- token meter: tokens ONLY, never $ (metering-deferred D4, structural).
+    #     Providers surface no usage yet, so empty is the honest state. ---
+    meter = getattr(panel, "_meter_lbl", None)
+    meter_ok = meter is not None and "$" not in (meter.text() or "")
+    m_txt = repr(meter.text()) if meter is not None else None
+    print(f"   meter tokens-only   : {m_txt}  " + tag(meter_ok))
+
+    # --- v9 ratified bundle (INVERTED from the old native-chrome check): the
+    #     chrome the type system fonts must resolve to the BUNDLED families
+    #     (Space Grotesk / Space Mono) — OR the documented graceful fallback
+    #     with font_status().build_mismatch flagged. Samples are the widgets
+    #     the role factory types (chat/verbs inherit per L1 and are not here);
+    #     the 'no bundled font in QSS' check above survives (QFont only). ---
     BUNDLED = {"space grotesk", "space mono"}
-    verbs = [b for b in btns if b.objectName() == "DsVerb"]
     samples = {
-        "wordmark":  getattr(panel, "_wordmark", None),
-        "tab":       (getattr(panel, "_face_pills", {}) or {}).get("direct"),
-        "verb":      verbs[0] if verbs else None,
-        "model chip": getattr(panel, "_model_chip", None),
-        "engine seg": (getattr(panel, "_engine_pills", {}) or {}).get("claude"),
-        "chat":      getattr(panel, "_chat", None),
+        "wordmark": getattr(panel, "_wordmark", None),
+        "tab":      (getattr(panel, "_face_pills", {}) or {}).get("direct"),
+        "author":   getattr(panel, "_author_lbl", None),
+        "meter":    getattr(panel, "_meter_lbl", None),
     }
-    fams, bad = {}, []
+    fams, not_bundled = {}, []
     for nm, wdg in samples.items():
         if wdg is None:
             continue
         fam = wdg.font().family()
         fams[nm] = fam
-        if fam.strip().lower() in BUNDLED:
-            bad.append("%s=%s" % (nm, fam))
-    print(f"   native chrome font  : host={app.font().family()!r}  " + tag(not bad))
-    if bad:
-        print("      overrides host font: " + ", ".join(bad))
+        if fam.strip().lower() not in BUNDLED:
+            not_bundled.append("%s=%s" % (nm, fam))
+    flagged_fb = bool((fontload.font_status() or {}).get("build_mismatch"))
+    print(f"   bundled chrome font : {fams}  "
+          + tag(not not_bundled or flagged_fb))
+    if not_bundled and not flagged_fb:
+        print("      not bundled: " + ", ".join(not_bundled))
 
     # --- Image #5 bug 3 · the prompt box must not crop at the min pane height ---
     try:
@@ -286,10 +310,10 @@ try:
     print(f"   body matches host   : body {body_px}px vs host {host_px}px  "
           + tag(body_px >= host_px - 1))
 
-    # --- model chip shows a SHORT label, not the long raw model id ---
-    chip_short = chip is not None and "/" not in chip.text() and 0 < len(chip.text()) < 30
-    _chip_txt = repr(chip.text()) if chip is not None else None
-    print(f"   chip short-label    : {_chip_txt}  " + tag(chip_short))
+    # --- the author token shows a SHORT label, not the long raw model id ---
+    chip_short = (author is not None and "/" not in author.text()
+                  and 0 < len(author.text()) < 30)
+    print(f"   token short-label   : {a_txt}  " + tag(chip_short))
 
     # --- ⌘K folded into the input ("/" opens palette; no bar glyph button) ---
     inp = getattr(panel, "_input", None)
@@ -337,7 +361,7 @@ try:
     _saved_scale = panel._font_scale
     try:
         chrome = ("_wordmark", "_header_status", "_palette_hint", "_author_lbl",
-                  "_foot_label", "_ctx_label", "_engine_lbl")
+                  "_foot_label", "_ctx_label", "_meter_lbl")
         panel._set_scale(1.0)
         chrome_a = {n: _hdr_px(n) for n in chrome}
         in_a, chat_a = _input_px(), getattr(panel._chat, "font_scale", None)
@@ -348,10 +372,16 @@ try:
         panel._set_scale(_saved_scale)
 
     READABLE_FLOOR = 11  # px — chrome must clear this
+    # v9: the wordmark is the 14px/500 BRAND word (demoted from the 19px hero)
+    # and must carry BRAND tracking (PercentageSpacing 100 + em×100).
     wm = chrome_a.get("_wordmark")
-    wm_heading = wm is not None and wm >= round(t.SIZE_TITLE)
-    print(f"   wordmark is heading  : {wm}px >= title {round(t.SIZE_TITLE)}px  "
-          + tag(wm_heading))
+    _wmf = panel._wordmark.font()
+    _want_pct = 100 + t.TRACKING_EM["BRAND"] * 100
+    wm_brand = (wm == round(14 * panel._chrome_scale)
+                and _wmf.letterSpacingType() == type(_wmf).PercentageSpacing
+                and abs(_wmf.letterSpacing() - _want_pct) < 0.05)
+    print(f"   wordmark is brand    : {wm}px @ tracking {_wmf.letterSpacing():.1f}%  "
+          + tag(wm_brand))
     chrome_floor_ok = all(v is not None and v >= READABLE_FLOOR
                           for n, v in chrome_a.items() if n != "_wordmark")
     print(f"   chrome floor (>=11)  : {chrome_a}  " + tag(chrome_floor_ok))
@@ -362,21 +392,22 @@ try:
     print(f"   content scales on Aa : prompt {in_a}->{in_b}px · chat {chat_a}->{chat_b}  "
           + tag(content_scales))
 
-    # --- the chip stays SHORT for the slash-bearing provider (Nemotron) — the
-    #     real test the long raw id isn't shown (claude alone never has a slash) ---
+    # --- the author token stays SHORT for the slash-bearing provider (Nemotron)
+    #     — the real test the long raw id isn't shown (claude never has a slash);
+    #     it must also TRACK the switch (selection observable) ---
     panel._set_provider("nemotron")
-    nemo_chip = panel._model_chip.text()
+    nemo_tok = panel._author_lbl.text()
     panel._set_provider("claude")
-    print(f"   chip short (nemotron): {nemo_chip!r}  "
-          + tag("/" not in nemo_chip and len(nemo_chip) < 30))
+    print(f"   token short (nemotron): {nemo_tok!r}  "
+          + tag("/" not in nemo_tok and 0 < len(nemo_tok) < 30))
 
     # --- same for Ollama — the registry label ('GLM 5'), never the raw
     #     tag-bearing id ('glm-5:cloud') ---
     panel._set_provider("ollama")
-    oll_chip = panel._model_chip.text()
+    oll_tok = panel._author_lbl.text()
     panel._set_provider("claude")
-    print(f"   chip short (ollama)  : {oll_chip!r}  "
-          + tag("/" not in oll_chip and ":" not in oll_chip and len(oll_chip) < 30))
+    print(f"   token short (ollama)  : {oll_tok!r}  "
+          + tag("/" not in oll_tok and ":" not in oll_tok and 0 < len(oll_tok) < 30))
 except (Exception, SystemExit) as e:
     WARNS.append(1)
     print(f"   [skip] live build unavailable here: {type(e).__name__}: {e}")
@@ -434,8 +465,10 @@ else:
         _tl.set_reduced_motion(True)
         try:
             panel._set_thinking(True)
+            # v9 DsCookBar: reduced-motion = a static determinate track (never
+            # the style-driven indeterminate sweep, i.e. maximum() != 0).
             rm_ok = (not panel._mark._spin.isActive()
-                     and not panel._work_face._cook._timer.isActive())
+                     and panel._work_face._cook.maximum() != 0)
         finally:
             panel._set_thinking(False)
             _tl.set_reduced_motion(None)

--- a/python/synapse/panel/chat_display.py
+++ b/python/synapse/panel/chat_display.py
@@ -144,6 +144,17 @@ class ChatDisplay(QtWidgets.QTextBrowser):
         scrollbar = self.verticalScrollBar()
         scrollbar.setValue(scrollbar.maximum())
 
+    def resizeEvent(self, event):
+        """v9 WIDE DOCKS rule: reading holds a ~440px measure inside wide
+        panes (440 + 26×2 padding) — cap the document text width; structure
+        spans. Best-effort: if the cap ever fights QTextBrowser's relayout,
+        the fallback is dropping it (long lines, no breakage)."""
+        super().resizeEvent(event)
+        try:
+            self.document().setTextWidth(min(self.viewport().width(), 492))
+        except Exception:
+            pass
+
     # -- Message append methods ----------------------------------------------
 
     def append_user_message(self, text):

--- a/python/synapse/panel/designsystem/components.py
+++ b/python/synapse/panel/designsystem/components.py
@@ -16,6 +16,7 @@ except ImportError:  # pragma: no cover - Houdini ships PySide6
     from PySide2.QtCore import Qt
 
 from . import tokens as t
+from . import fontload
 
 __all__ = [
     "Button", "Pill", "Card", "Badge", "StatusDot", "MarkDot", "ProgressBar",
@@ -32,13 +33,13 @@ def repolish(w):
 
 
 def apply_font_role(w, role="body", scale=1.0):
-    """Apply size/weight/tracking from a TYPE_ROLE while INHERITING Houdini's
-    native app-level UI font — only the ``code`` role forces the mono family
-    (paths / data). This is what makes the panel read as native, not web."""
-    _fam, size, weight, tracking = t.TYPE_ROLES.get(role, t.TYPE_ROLES["body"])
-    f = QtGui.QFont(w.font())  # start from the inherited native UI font
-    if role == "code":
-        f.setFamily(t.FONT_MONO)
+    """Apply family/size/weight/tracking from a TYPE_ROLE. v9 ratified call:
+    the family is the bundled pair (Space Grotesk sans / Space Mono for the
+    mono-stack roles), applied via QFont with fontload's graceful native
+    fallback when the bundle didn't register (build_mismatch)."""
+    fam, size, weight, tracking = t.TYPE_ROLES.get(role, t.TYPE_ROLES["body"])
+    f = QtGui.QFont(w.font())  # inherit host attrs (hinting, style strategy)
+    fontload.apply_family(f, mono=(fam == t.FONT_MONO_CSS))
     f.setPixelSize(t.scaled(size, scale))
     f.setBold(weight >= 600)
     if tracking:

--- a/python/synapse/panel/designsystem/fontload.py
+++ b/python/synapse/panel/designsystem/fontload.py
@@ -3,14 +3,16 @@
 Loads the vendored Space Grotesk + Space Mono ``.ttf`` (designsystem/fonts/) into
 QFontDatabase once, and exposes ``tracked_font(role, px)`` — the only correct way
 to apply per-role tracking in Qt, because Qt QSS has **no** ``letter-spacing``.
-Tracking is set on the QFont via ``setLetterSpacing(AbsoluteSpacing, em × px)``,
-with the em values living in ``tokens.TRACKING_EM``.
+Tracking is set on the QFont via ``setLetterSpacing(PercentageSpacing,
+100 + em × 100)``, with the em values living in ``tokens.TRACKING_EM``.
 
-Locked call #3: bundle via QFontDatabase, and **flag if a family is absent** —
+Ratified v9 call: the factory's default family IS the bundled Space Grotesk
+(``mono=True`` → Space Mono), applied via QFont only (never QSS). Locked call
+#3: bundle via QFontDatabase, and **flag if a family is absent** —
 ``load_application_fonts()`` returns a status whose ``build_mismatch`` is True
-when either expected family failed to register; the panel logs it and falls back
-to the documented fallback families in ``tokens``. Kept Qt-only so ``tokens.py``
-stays stdlib-only.
+when either expected family failed to register; the panel logs it and the
+factory gracefully keeps the host's native family instead. Kept Qt-only so
+``tokens.py`` stays stdlib-only.
 """
 
 import os
@@ -28,6 +30,14 @@ _EXPECTED = ("Space Grotesk", "Space Mono")
 
 _STATUS = None   # cached load result (idempotent across panel instances)
 
+# QApplication dynamic-property key for the load status. The panel loader
+# purges ``synapse.*`` from sys.modules on every reopen (fresh-reload
+# contract), which resets ``_STATUS`` — but the QApplication (and its
+# QFontDatabase registrations) survive the purge. Stashing the status on the
+# app makes the load idempotent PER PROCESS, not per import: without it every
+# panel reopen re-registers the same 3 .ttf into the process-wide database.
+_APP_STATUS_PROP = "_synapse_fonts_status_v1"
+
 
 def _fonts_dir():
     return os.path.join(os.path.dirname(__file__), "fonts")
@@ -35,8 +45,9 @@ def _fonts_dir():
 
 def load_application_fonts():
     """Load the bundled .ttf into QFontDatabase once. Returns a status dict:
-    ``{ok, families, missing, loaded, build_mismatch}``. Idempotent — the first
-    call does the work; later calls return the cached status. Safe with no
+    ``{ok, families, missing, loaded, build_mismatch}``. Idempotent per
+    PROCESS — the first call does the work; later calls (including after a
+    panel-reload sys.modules purge) return the cached status. Safe with no
     QApplication (returns a not-loaded status without raising)."""
     global _STATUS
     if _STATUS is not None:
@@ -48,6 +59,23 @@ def load_application_fonts():
         app = QtWidgets.QApplication.instance()
     except Exception:
         app = None
+
+    if app is None:
+        # No QApplication yet — report not-loaded WITHOUT caching, so an early
+        # caller (e.g. tracked_font before the panel boots) can never poison
+        # the idempotent cache and block the real load later.
+        return {"ok": False, "families": [], "missing": list(_EXPECTED),
+                "loaded": [], "build_mismatch": True}
+
+    try:
+        prior = app.property(_APP_STATUS_PROP)
+        if isinstance(prior, dict) and "build_mismatch" in prior:
+            # A previous import in THIS process already registered the bundle
+            # (the fonts outlive the panel-loader purge) — adopt, don't re-add.
+            _STATUS = prior
+            return _STATUS
+    except Exception:
+        pass
 
     if app is not None:
         fdir = _fonts_dir()
@@ -70,6 +98,10 @@ def load_application_fonts():
         "loaded": loaded,
         "build_mismatch": bool(missing),
     }
+    try:
+        app.setProperty(_APP_STATUS_PROP, _STATUS)   # survives the reload purge
+    except Exception:
+        pass
 
     if missing:
         # Build-mismatch flag — log; the panel falls back to the documented
@@ -90,32 +122,69 @@ def font_status():
     return _STATUS
 
 
-def tracked_font(role, px, scale=1.0, mono=False, bold=False):
-    """Build a QFont for a tracking role: size in PIXELS + AbsoluteSpacing =
-    ``tokens.TRACKING_EM[role] × px`` (the only way to track in Qt). ``role`` ∈
-    BRAND/LABEL/LABEL_SM/DATA/DISPLAY/BODY.
+# The bundled family chains (QFont.setFamilies order — Qt walks them until one
+# resolves). Families land via QFont ONLY, never QSS (the audit pins that).
+_SANS_CHAIN = ("Space Grotesk", "DM Sans", "Segoe UI")
+_MONO_CHAIN = ("Space Mono", "JetBrains Mono", "Consolas")
 
-    The family INHERITS Houdini's native app UI font (so the panel matches the
-    host chrome) — it no longer forces the bundled Space Grotesk. ``mono`` opts
-    a label into the host's fixed-pitch family for genuine tabular/data text."""
-    spx = t.scaled(px, scale)
-    try:
-        f = QtGui.QFont(QtWidgets.QApplication.font())   # the native app UI font
-    except Exception:
-        f = QtGui.QFont()
-    if mono:
+
+def _bundle_registered():
+    """True when both bundled families registered (loads on first use — safe
+    pre-QApplication: that path returns a non-cached not-loaded status)."""
+    st = load_application_fonts()
+    return bool(st.get("ok")) and not st.get("build_mismatch")
+
+
+def apply_family(f, mono=False):
+    """Set the ratified v9 family on a QFont: the bundled Space Grotesk (sans)
+    or Space Mono (``mono=True``), with the documented fallback chain. Graceful
+    native fallback: when the bundle failed to register (``build_mismatch``),
+    the font keeps the host family (mono → the host fixed-pitch face)."""
+    if _bundle_registered():
+        chain = _MONO_CHAIN if mono else _SANS_CHAIN
+        try:
+            f.setFamilies(list(chain))          # PySide6 / Qt ≥ 5.13
+        except Exception:
+            f.setFamily(chain[0])               # PySide2: first registered family
+    elif mono:
         try:
             f.setFamily(
                 QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.FixedFont).family())
         except Exception:
             f.setFamily("monospace")
+    return f
+
+
+def tracked_font(role, px, scale=1.0, mono=False, bold=False, weight=400):
+    """Build a QFont for a tracking role: size in PIXELS + PercentageSpacing =
+    ``100 + tokens.TRACKING_EM[role] × 100`` (the only way to track in Qt).
+    ``role`` ∈ EYEBROW/BRAND/LABEL/LABEL_SM/DATA/SEND/DISPLAY/BODY.
+
+    v9 ratified call: the family is the bundled Space Grotesk (``mono=True`` →
+    Space Mono) with the graceful native-family fallback when the bundle didn't
+    register (``font_status()['build_mismatch']``). ``weight`` 500 maps to
+    QFont Medium (never ``setBold``); ≥600 (or ``bold=True``) is bold."""
+    spx = t.scaled(px, scale)
+    try:
+        f = QtGui.QFont(QtWidgets.QApplication.font())   # inherit host attrs
+    except Exception:
+        f = QtGui.QFont()
+    apply_family(f, mono=mono)
     f.setPixelSize(spx)
-    if bold:
+    if bold or weight >= 600:
         f.setBold(True)
+    elif weight == 500:
+        try:
+            f.setWeight(QtGui.QFont.Weight.Medium)       # Qt6
+        except Exception:
+            try:
+                f.setWeight(QtGui.QFont.Medium)          # Qt5 / PySide2
+            except Exception:
+                pass
     em = t.TRACKING_EM.get(role, 0.0)
     if em:
         try:
-            f.setLetterSpacing(QtGui.QFont.AbsoluteSpacing, em * spx)
+            f.setLetterSpacing(QtGui.QFont.PercentageSpacing, 100.0 + em * 100.0)
         except Exception:
             pass
     return f

--- a/python/synapse/panel/designsystem/qss.py
+++ b/python/synapse/panel/designsystem/qss.py
@@ -26,10 +26,11 @@ QWidget#DsRoot {{
 }}
 QWidget#DsSection {{ background: {t.PANEL}; }}
 QTextBrowser {{ background: {t.GROUND}; border: none; }}
-/* Cohere 'gradient atmosphere' — a faint cool→warm wash across the header. */
+/* v9 rail: flat PANEL with a 1px HAIR bottom rule (the comp retired the
+   cool→warm gradient wash). */
 QWidget#DsHeader {{
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
-        stop:0 #2B2E33, stop:0.5 {t.PANEL}, stop:1 #332E2C);
+    background: {t.PANEL};
+    border-bottom: 1px solid {t.HAIR};
 }}
 QToolTip {{
     background: {t.SURFACE}; color: {t.TEXT_PRIMARY};
@@ -39,7 +40,7 @@ QToolTip {{
 
 /* ---- buttons (variant via dynamic property) ------------------ */
 QPushButton#DsButton {{
-    border-radius: {t.RADIUS_MD}px;
+    border-radius: {t.RADIUS_SM}px;
     padding: {t.SPACE_SM}px {t.SPACE_MD}px;
     font-size: {s(t.SIZE_UI)}px;
     font-weight: 600;
@@ -67,39 +68,41 @@ QPushButton#DsButton:disabled {{ background: {t.DISABLED_BG}; color: {t.TEXT_DIS
 
 /* ---- tabs: underline on a baseline track (v9 call 1) --------- */
 /* Retires the filled-pill active state: tabs read as text on a shared 2px
-   baseline; the active tab lights its rule + text. Flat, native font; the
-   active accent is the only chrome. */
-QPushButton#DsPill {{
-    background: none; color: {t.TEXT_SECONDARY};
-    border: none; border-bottom: 2px solid transparent; border-radius: 0;
-    padding: {t.SPACE_XS}px {t.SPACE_MD}px;
-    font-size: {s(t.SIZE_UI + 2)}px; font-weight: 500;
+   baseline; the active tab lights its rule + text (TEXT_BRIGHT per comp).
+   Font family/size/tracking live on the QFont (LABEL role), never here. */
+QWidget#DsTabRow {{
+    background: {t.PANEL};
+    border-bottom: 1px solid {t.BORDER};
 }}
-QPushButton#DsPill:hover  {{ color: {t.TEXT_ACCENT}; }}
+QPushButton#DsPill {{
+    background: none; color: {t.TEXT_TERTIARY};
+    border: none; border-bottom: 2px solid transparent; border-radius: 0;
+    padding: 0 0 12px 0;
+}}
+QPushButton#DsPill:hover  {{ color: {t.TEXT_BRIGHT}; }}
 QPushButton#DsPill:disabled {{ color: {t.TEXT_DISABLED}; }}
 QPushButton#DsPill[active="true"] {{
-    color: {t.TEXT_ACCENT}; border-bottom: 2px solid {t.SIGNAL};
+    color: {t.TEXT_BRIGHT}; border-bottom: 2px solid {t.SIGNAL};
 }}
 
-/* ---- engine selector: a segmented control (model selection must be
-   APPARENT, not buried in the ⋯ menu) — the active engine is a SIGNAL fill --- */
-QPushButton#DsSeg {{
-    background: {t.SURFACE}; color: {t.TEXT_SECONDARY};
-    border: 1px solid {t.BORDER}; border-radius: {t.RADIUS_PILL}px;
-    padding: 3px {t.SPACE_MD}px;
-    font-size: {s(t.SIZE_SMALL)}px; font-weight: 600;
-}}
-QPushButton#DsSeg:hover {{ color: {t.TEXT_PRIMARY}; border-color: {t.BORDER_STRONG}; }}
-QPushButton#DsSeg[active="true"] {{
-    background: {t.SIGNAL}; color: {t.TEXT_ON_ACCENT}; border-color: {t.SIGNAL};
-}}
-
-/* ---- model picker chip — small label + ▾, NOT the dominant element ---- */
-QPushButton#DsModelChip {{
+/* ---- rail author token — THE engine+model click target (v9) ----
+   Mono/DATA family+tracking live on the QFont; hover underline + pointing
+   hand carry discoverability (the comp shows no ▾). */
+QPushButton#DsAuthor {{
     background: transparent; border: none; padding: 0 {t.SPACE_XS}px;
-    color: {t.TEXT_BRIGHT}; font-size: {s(t.SIZE_SMALL)}px; font-weight: 600;
+    color: {t.SIGNAL};
 }}
-QPushButton#DsModelChip:hover {{ color: {t.TEXT_ACCENT}; }}
+QPushButton#DsAuthor:hover {{
+    color: {t.SIGNAL_HOVER}; text-decoration: underline;
+}}
+
+/* ---- rail token meter (tokens only, never $) + ⌘K chip -------- */
+QLabel#DsMeter {{ color: {t.TEXT_TERTIARY}; }}
+QLabel#DsKHint {{
+    color: {t.TEXT_TERTIARY};
+    border: 1px solid {t.BORDER}; border-radius: {t.RADIUS_SM}px;
+    padding: 3px 7px;
+}}
 
 /* ---- type-set verbs (Direct act bar + Review actions) — Mile 7 --- */
 /* Verbs read as type, not buttons: flat, mono, the chrome recedes. */
@@ -109,8 +112,8 @@ QPushButton#DsVerb {{
     font-size: {s(11)}px;
 }}
 QPushButton#DsVerb:hover {{ color: {t.TEXT_ACCENT}; }}
-QPushButton#DsVerb[tone="ok"]     {{ color: {t.GROW}; }}
-QPushButton#DsVerb[tone="hot"]    {{ color: {t.WARM}; }}
+QPushButton#DsVerb[tone="ok"]     {{ color: {t.OK_SOFT}; }}
+QPushButton#DsVerb[tone="hot"]    {{ color: {t.HOT_SOFT}; }}
 QPushButton#DsVerb[tone="accent"] {{ color: {t.TEXT_ACCENT}; }}
 
 /* ---- two-axis palette chips (⌘K · DO × WHERE) ---------------- */
@@ -153,11 +156,21 @@ QLabel#DsBadge[kind="signal"]{{ color: {t.SIGNAL};background: {t.STATE_TINTS["si
 /* ---- text inputs (v9 call 2: darker field-inset grey) -------- */
 QTextEdit#DsInput, QLineEdit#DsField {{
     background: {t.FIELD_INSET}; color: {t.TEXT_PRIMARY};
-    border: 1px solid {t.BORDER}; border-radius: {t.RADIUS_MD}px;
-    padding: {t.SPACE_SM}px; font-size: {s(t.SIZE_UI)}px;
+    border: 1px solid {t.BORDER}; border-radius: {t.RADIUS_SM}px;
+    padding: 14px 15px; font-size: {s(t.SIZE_UI)}px;
     selection-background-color: {t.SIGNAL_TINT_STRONG};
 }}
 QTextEdit#DsInput:focus, QLineEdit#DsField:focus {{ border-color: {t.SIGNAL}; }}
+
+/* ---- SEND — embedded bottom-right inside the composer (comp) --- */
+QPushButton#DsSend {{
+    background: {t.SIGNAL}; color: {t.TEXT_ON_ACCENT};
+    border: none; border-radius: {t.RADIUS_SM}px;
+    padding: 9px 15px;
+}}
+QPushButton#DsSend:hover   {{ background: {t.SIGNAL_HOVER}; }}
+QPushButton#DsSend:pressed {{ background: {t.SIGNAL_PRESS}; }}
+QPushButton#DsSend:disabled {{ background: {t.DISABLED_BG}; color: {t.TEXT_DISABLED}; }}
 
 /* ---- role labels (color; font set in Python from TYPE_ROLES) -- */
 QLabel[role="title"]   {{ color: {t.TEXT_BRIGHT}; }}
@@ -172,6 +185,18 @@ QProgressBar#DsProgress {{
     height: {t.SPACE_XS}px; text-align: center;
 }}
 QProgressBar#DsProgress::chunk {{ background: {t.SIGNAL}; border-radius: {t.RADIUS_SM}px; }}
+
+/* ---- cook bar (comp .cookbar): 3px neutral track, RAISED fill --- */
+QProgressBar#DsCookBar {{
+    background: {t.GROUND}; border: none; border-radius: 2px;
+}}
+QProgressBar#DsCookBar::chunk {{ background: {t.RAISED}; border-radius: 2px; }}
+
+/* ---- Work-face acts row (comp .acts): quiet HAIR top rule ----- */
+QWidget#DsActs {{
+    background: {t.PANEL};
+    border-top: 1px solid {t.HAIR};
+}}
 
 /* ---- scrollbars (quiet) -------------------------------------- */
 QScrollBar:vertical {{ background: transparent; width: {t.SPACE_SM}px; margin: 0; }}

--- a/python/synapse/panel/designsystem/tokens.py
+++ b/python/synapse/panel/designsystem/tokens.py
@@ -117,7 +117,9 @@ def _host_surface_rgb():
 # Houdini-native dark pane grey (verified vs UIDark.hcs) — the HEADLESS surface
 # anchor. The text ramp is no longer a fixed table; it is solved from these by
 # _derive_palette so headless and live use the identical contrast-aware path.
-_FALLBACK_RGB = (46, 46, 46)   # #2E2E2E — the host pane grey when no scheme reads
+# v9: retuned to the ratified comp's --panel (#2A2A2A) — a seeded fallback
+# input, never a scattered literal (the comp hexes land HERE only).
+_FALLBACK_RGB = (42, 42, 42)   # #2A2A2A — the host pane grey when no scheme reads
 
 # Contrast targets for the solved text ramp. body=primary is held a hair above
 # AA (4.5); bright is AAA-crisp; tertiary stays above the dark-DCC pragmatic
@@ -138,10 +140,13 @@ def _derive_palette(r, g, b):
     A3 sweep gates. Exposed (underscore) so the audit can sweep it directly."""
     def step(d):
         return _hexrgb(r + d, g + d, b + d)
+    # v9 elevation offsets, retuned to the ratified comp (relative to --panel):
+    # --ground −11 · field inset = ground · --raised +8 · --line +12 (borders
+    # flip lighter-than-panel) · --hair +6 (rail rule / acts rule) · strong +18.
     surface = {
-        "ground": step(-8), "field_inset": step(-16), "panel": _hexrgb(r, g, b),
-        "surface": step(12), "raised": step(40), "border": step(-8),
-        "border_strong": step(30),
+        "ground": step(-11), "field_inset": step(-11), "panel": _hexrgb(r, g, b),
+        "surface": step(12), "raised": step(8), "border": step(12),
+        "border_strong": step(18), "hair": step(6),
     }
     # Text lands on ground / panel / surface. Choose the text DIRECTION (light
     # vs dark) that MAXIMIZES the achievable contrast on those surfaces — not a
@@ -184,6 +189,7 @@ SURFACE       = _SURF["surface"]        # cards, drawers, containers
 RAISED        = _SURF["raised"]         # raised / hover surface
 BORDER        = _SURF["border"]         # hairline divider
 BORDER_STRONG = _SURF["border_strong"]  # separator
+HAIR          = _SURF["hair"]           # quietest rule — rail bottom, acts top
 
 ELEVATION = {  # role -> bg color, for components to read by name
     "ground": GROUND, "panel": PANEL, "surface": SURFACE,
@@ -205,7 +211,7 @@ TEXT_TERTIARY  = _TXT["tertiary"]   # captions / hints
 TEXT_BRIGHT    = _TXT["bright"]     # emphasis / headings
 TEXT_ACCENT    = SIGNAL     # links, accent labels (NOT body — see WCAG note)
 TEXT_DISABLED  = _TXT["disabled"]
-TEXT_ON_ACCENT = "#13212C"  # text on a SIGNAL fill (dark navy on light blue = AA-safe)
+TEXT_ON_ACCENT = "#0F1F2B"  # text on a SIGNAL fill (comp --signal-ink; AA-safe)
 
 # WCAG note: SIGNAL (#8FB3D9) on PANEL passes AA for >=14px / bold, but FAILS
 # for small body text. Use TEXT_ACCENT for labels/links/icons only; never for
@@ -229,6 +235,13 @@ WARM        = "#FF7759"
 WARM_HOVER  = "#FF8E72"
 WARM_PRESS  = "#E5634A"
 WARM_TINT   = "rgba(255, 119, 89, 0.14)"
+
+# v9 muted status hues (comp --ok/--no/--hot) — the Work face's quiet verdict
+# grammar (status dots, DsVerb ok/hot tones). NOT a retune of GROW/ERROR/FIRE:
+# gates, badges and the STATUS table keep the full-strength hues.
+OK_SOFT  = "#6FBF8E"
+NO_SOFT  = "#D96975"
+HOT_SOFT = "#D08A57"
 
 HOVER_BG   = RAISED        # neutral hover surface
 PRESS_BG   = "#202022"     # neutral press surface
@@ -285,22 +298,21 @@ TYPE_ROLES: Dict[str, Tuple[str, int, int, float]] = {
     "status":  (FONT_MONO_CSS, SIZE_SMALL, 500, 0.5),
 }
 
-# v9 tracking map — em per role. Tracking lives on QFont (AbsoluteSpacing =
-# em × px), NEVER in QSS (Qt QSS has no letter-spacing). fontload.tracked_font()
-# reads this. Roles → where they apply:
+# v9 tracking map — em per role, RESTORED to the ratified comp values (the
+# near-flat "match Houdini" dial was superseded by the ratified v9 comp).
+# Tracking lives on QFont (PercentageSpacing = 100 + em×100), NEVER in QSS
+# (Qt QSS has no letter-spacing). fontload.tracked_font() reads this.
+#   EYEBROW  +0.22  section labels (PLAN title, credit-section heads)
 #   BRAND    +0.16  wordmark
-#   LABEL    +0.15  tabs, section + action labels
-#   LABEL_SM +0.12  credit keys, tiny labels
-#   DATA     +0.03  author, meter, paths, cookline, chip, mini
+#   LABEL    +0.15  tabs (DIRECT / WORK)
+#   LABEL_SM +0.12  credit keys, acts verbs, tiny labels
+#   DATA     +0.03  author, meter, paths, cookline, ⌘K chip
+#   SEND     +0.08  the SEND button
 #   DISPLAY  -0.015 verdict
 #   BODY      0     conversation, prompt
-# Dialed near-flat to match Houdini's native UI (which doesn't letter-space its
-# labels). BRAND keeps a hair of tracking (the wordmark's only remaining flourish
-# — and tracked_font needs it non-zero to apply AbsoluteSpacing); DISPLAY stays
-# slightly tight. Everything else is flat.
 TRACKING_EM: Dict[str, float] = {
-    "BRAND": 0.02, "LABEL": 0.0, "LABEL_SM": 0.0,
-    "DATA": 0.0, "DISPLAY": -0.01, "BODY": 0.0,
+    "EYEBROW": 0.22, "BRAND": 0.16, "LABEL": 0.15, "LABEL_SM": 0.12,
+    "DATA": 0.03, "SEND": 0.08, "DISPLAY": -0.015, "BODY": 0.0,
 }
 
 

--- a/python/synapse/panel/face_review.py
+++ b/python/synapse/panel/face_review.py
@@ -38,11 +38,12 @@ try:
 except Exception:  # pragma: no cover
     run_preflight = None
 
-# quality-flag status → dot color
+# quality-flag status → dot color (v9: the muted comp hues — GROW/WARN/ERROR
+# stay full-strength for gates/badges; the done-state verdict grammar is quiet)
 _FLAG_COLOR = {
-    "ok": t.GROW, "pass": t.GROW,
-    "warn": t.WARN,
-    "fail": t.ERROR, "no": t.ERROR,
+    "ok": t.OK_SOFT, "pass": t.OK_SOFT,
+    "warn": t.HOT_SOFT,
+    "fail": t.NO_SOFT, "no": t.NO_SOFT,
 }
 
 
@@ -181,19 +182,29 @@ class FaceReview(QtWidgets.QWidget):
         self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
 
         col = QtWidgets.QVBoxLayout(self)
-        col.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_MD)
+        col.setContentsMargins(26, 20, 26, 20)   # comp face padding
         col.setSpacing(t.SPACE_SM)
+
+        # — the done sub-state shows the same cook bar, full (comp) —
+        self._cookbar = QtWidgets.QProgressBar()
+        self._cookbar.setObjectName("DsCookBar")
+        self._cookbar.setTextVisible(False)
+        self._cookbar.setFixedHeight(3)
+        self._cookbar.setRange(0, 1)
+        self._cookbar.setValue(1)
+        col.addWidget(self._cookbar)
 
         # — the render, the hero —
         self._hero = RenderHero()
         col.addWidget(self._hero)
 
-        # — taut benefit verdict —
+        # — taut benefit verdict (comp .verdict: 21px/500, ~360px measure) —
         self._verdict = c.label("", role="title")
         self._verdict.setWordWrap(True)
         self._verdict.setStyleSheet("color:%s;" % t.TEXT_BRIGHT)
-        self._verdict.setFont(fontload.tracked_font("DISPLAY", 15))  # tight display
-        col.addWidget(self._verdict)
+        self._verdict.setFont(fontload.tracked_font("DISPLAY", 21, weight=500))
+        self._verdict.setMaximumWidth(360)
+        col.addWidget(self._verdict, 0, Qt.AlignmentFlag.AlignLeft)
 
         # — no-frame locator — when no real frame is on disk, the render stays
         # Houdini's job: show the frame/AOV/path meta + a verb that surfaces the
@@ -214,18 +225,24 @@ class FaceReview(QtWidgets.QWidget):
         self._locator.setVisible(False)
         col.addWidget(self._locator)
 
-        # — SIGNED authorship line — DISPLAY ONLY. It reports who produced the
-        # result (the panel's model); it NEVER authors USD / customData. —
-        self._signed = c.label("", role="code")
-        self._signed.setStyleSheet(
-            "color:%s; font-size:10px; letter-spacing:1px;" % t.TEXT_TERTIARY)
-        self._signed.setVisible(False)
-        col.addWidget(self._signed)
-
-        # — credit headline (the DECISION leads; provenance folds into detail) —
-        self._credit_box = QtWidgets.QVBoxLayout()
-        self._credit_box.setSpacing(1)
-        col.addLayout(self._credit_box)
+        # — credit grid (comp): a 64px mono key column · DECISION rows lead ·
+        # SIGNED folds in as a grid row (display-only authorship — it NEVER
+        # authors USD / customData). Rebuilt from state on every set. —
+        self._decisions = []        # [(label, value, note)] — DECISION rows
+        self._signed_author = ""    # the SIGNED row's model (display-only)
+        self._signed = None         # the live SIGNED value QLabel (rebuilt)
+        credit_wrap = QtWidgets.QWidget()
+        credit_wrap.setObjectName("DsSection")
+        credit_wrap.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        credit_wrap.setMaximumWidth(440)     # reading measure (WIDE DOCKS rule)
+        self._credit_grid = QtWidgets.QGridLayout(credit_wrap)
+        self._credit_grid.setContentsMargins(0, 0, 0, 0)
+        self._credit_grid.setColumnMinimumWidth(0, 64)
+        self._credit_grid.setColumnStretch(1, 1)
+        self._credit_grid.setVerticalSpacing(8)
+        self._credit_grid.setHorizontalSpacing(0)
+        col.addWidget(credit_wrap, 0, Qt.AlignmentFlag.AlignLeft)
+        self._rebuild_credit()
 
         # — quality flags / status dots (preflight + BL-007 / BL-008) —
         self._flags_box = QtWidgets.QVBoxLayout()
@@ -260,15 +277,29 @@ class FaceReview(QtWidgets.QWidget):
         else:
             self.gate = None
 
-        # — the close: accept / revert / commit —
-        acts = QtWidgets.QHBoxLayout()
-        acts.setSpacing(t.SPACE_MD)
-        acts.addWidget(_verb("ACCEPT", lambda _=False: self.accepted.emit(), tone="ok"))
-        acts.addWidget(_verb("↶ REVERT", lambda _=False: self.reverted.emit()))
+        # — the close: accept / revert / commit (comp .acts: HAIR top rule,
+        # 440px measure, LABEL_SM mono verbs; Commit reads as a question) —
+        col.addSpacing(t.SPACE_LG)
+        acts_wrap = QtWidgets.QWidget()
+        acts_wrap.setObjectName("DsActs")
+        acts_wrap.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        acts_wrap.setMaximumWidth(440)       # reading measure (WIDE DOCKS rule)
+        acts = QtWidgets.QHBoxLayout(acts_wrap)
+        acts.setContentsMargins(0, 20, 0, 0)  # QSS padding can't move children
+        acts.setSpacing(22)
+        _acts_font = fontload.tracked_font("LABEL_SM", 11, mono=True)
+        for verb in (
+            _verb("ACCEPT", lambda _=False: self.accepted.emit(), tone="ok"),
+            _verb("↶ REVERT", lambda _=False: self.reverted.emit()),
+        ):
+            verb.setFont(_acts_font)
+            acts.addWidget(verb)
         acts.addStretch(1)
-        acts.addWidget(_verb("COMMIT TO /STAGE", lambda _=False: self.committed.emit(),
-                             tone="hot"))
-        col.addLayout(acts)
+        commit = _verb("COMMIT TO /STAGE?", lambda _=False: self.committed.emit(),
+                       tone="hot")
+        commit.setFont(_acts_font)
+        acts.addWidget(commit)
+        col.addWidget(acts_wrap, 0, Qt.AlignmentFlag.AlignLeft)
         col.addStretch(1)
 
         self._verdict.setText("Standing by for the next result.")
@@ -291,16 +322,67 @@ class FaceReview(QtWidgets.QWidget):
         self._verdict.setText(text or "")
 
     def set_signed(self, author):
-        """The SIGNED authorship line — DISPLAY ONLY. Reports who produced the
-        result (the panel's model). It NEVER authors USD / customData."""
-        if author:
-            self._signed.setText("SIGNED  %s" % author)
-            self._signed.setVisible(True)
-        else:
-            self._signed.setText("")
-            self._signed.setVisible(False)
+        """The SIGNED authorship credit — DISPLAY ONLY, a credit-grid row (v9).
+        Reports who produced the result (the panel's model). It NEVER authors
+        USD / customData. Same signature as the retired standalone label."""
+        self._signed_author = author or ""
+        self._rebuild_credit()
 
-    def _credit_row(self, label, value, note):
+    def _credit_key(self, label):
+        """Col-0 key: 11px mono LABEL_SM, tertiary, pre-uppercased."""
+        key = QtWidgets.QLabel(str(label).upper())
+        key.setFont(fontload.tracked_font("LABEL_SM", 11, mono=True))
+        key.setStyleSheet("color:%s;" % t.TEXT_TERTIARY)
+        key.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
+        return key
+
+    def _credit_value(self, value, note):
+        """Col-1 value line: SIGNAL value + ' — ' TEXT_SECONDARY note."""
+        row = QtWidgets.QLabel()
+        row.setTextFormat(Qt.TextFormat.RichText)
+        row.setWordWrap(True)
+        row.setFont(fontload.tracked_font("DATA", 11, mono=True))
+        row.setText(
+            '<span style="color:%s;">%s</span>'
+            '<span style="color:%s;">%s</span>' % (
+                t.SIGNAL, value,
+                t.TEXT_SECONDARY, (" — " + note) if note else "",
+            )
+        )
+        return row
+
+    def _rebuild_credit(self):
+        """Rebuild the credit grid from state: DECISION rows lead, SIGNED
+        closes. ``self._signed`` stays the live SIGNED value label so the
+        display-only pin (tests) keeps a stable handle."""
+        self._clear(self._credit_grid)
+        r = 0
+        for label, value, note in self._decisions:
+            self._credit_grid.addWidget(self._credit_key(label), r, 0)
+            self._credit_grid.addWidget(self._credit_value(value, note), r, 1)
+            r += 1
+        self._signed_key = self._credit_key("SIGNED")
+        self._signed = self._credit_value(self._signed_author, "")
+        show = bool(self._signed_author)
+        self._signed_key.setVisible(show)
+        self._signed.setVisible(show)
+        self._credit_grid.addWidget(self._signed_key, r, 0)
+        self._credit_grid.addWidget(self._signed, r, 1)
+
+    def set_credit(self, items):
+        """items: list of (label, value, note). DECISION leads the credit grid;
+        VIA / ROUTED / other provenance fold into the expandable detail
+        (the simplified synthesis keeps the headline taut)."""
+        self._decisions = [(label, value, note) for label, value, note in items or []
+                           if str(label).upper() == "DECISION"]
+        self._clear(self._via_box)
+        for label, value, note in items or []:
+            if str(label).upper() != "DECISION":
+                self._via_box.addWidget(self._legacy_credit_row(label, value, note))
+        self._rebuild_credit()
+
+    def _legacy_credit_row(self, label, value, note):
+        """The folded-detail provenance row (VIA / ROUTED) — unchanged form."""
         row = QtWidgets.QLabel()
         row.setTextFormat(Qt.TextFormat.RichText)
         row.setWordWrap(True)
@@ -315,32 +397,24 @@ class FaceReview(QtWidgets.QWidget):
         )
         return row
 
-    def set_credit(self, items):
-        """items: list of (label, value, note). DECISION leads the headline;
-        VIA / ROUTED / other provenance fold into the expandable detail
-        (the simplified synthesis keeps the headline taut)."""
-        self._clear(self._credit_box)
-        self._clear(self._via_box)
-        for label, value, note in items or []:
-            box = self._credit_box if str(label).upper() == "DECISION" else self._via_box
-            box.addWidget(self._credit_row(label, value, note))
-
     def _toggle_detail(self):
         self._detail_expanded = not self._detail_expanded
         self._detail.setVisible(self._detail_expanded)
         self._detail_btn.setText("▾ detail" if self._detail_expanded else "▸ detail")
 
     def set_flags(self, flags):
-        """flags: list of (status, text). status in ok/pass/warn/fail/no."""
+        """flags: list of (status, text). status in ok/pass/warn/fail/no.
+        v9: muted dot hues (OK/NO/HOT_SOFT) + 10px mono secondary text."""
         self._clear(self._flags_box)
         for status, text in flags or []:
             color = _FLAG_COLOR.get(status, t.TEXT_SECONDARY)
             row = QtWidgets.QLabel()
             row.setTextFormat(Qt.TextFormat.RichText)
             row.setWordWrap(True)
+            row.setFont(fontload.tracked_font("DATA", 10, mono=True))
             row.setText(
                 '<span style="color:%s;">&#9679;</span> '
-                '<span style="color:%s;">%s</span>' % (color, t.TEXT_PRIMARY, text)
+                '<span style="color:%s;">%s</span>' % (color, t.TEXT_SECONDARY, text)
             )
             self._flags_box.addWidget(row)
 

--- a/python/synapse/panel/face_work.py
+++ b/python/synapse/panel/face_work.py
@@ -23,6 +23,7 @@ except ImportError:  # pragma: no cover - Houdini ships PySide6
 
 from synapse.panel.designsystem import tokens as t
 from synapse.panel.designsystem import components as c
+from synapse.panel.designsystem import fontload
 
 try:
     from synapse.panel.designsystem.loader import BouncingToy
@@ -159,7 +160,7 @@ class FaceWork(QtWidgets.QWidget):
         self._steps = []   # ordered [name, phase] — the live plan-with-progress
 
         col = QtWidgets.QVBoxLayout(self)
-        col.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_SM)
+        col.setContentsMargins(26, 20, 26, 20)   # comp face padding
         col.setSpacing(t.SPACE_SM)
 
         # — activity + current tool status —
@@ -174,17 +175,28 @@ class FaceWork(QtWidgets.QWidget):
         head.addStretch(1)
         col.addLayout(head)
 
-        # — the cook preview (the focus of the glance) —
-        self._cook = BucketGrid()
+        # — the cook bar (comp .cookbar): a 3px neutral track; the fill is
+        # RAISED, not signal. Indeterminate = the style busy sweep (working
+        # with no counts); reduced-motion shows a static track instead —
+        # never a fabricated number. (BucketGrid below is retired from the
+        # layout but kept in-file this pass.)
+        self._cook = QtWidgets.QProgressBar()
+        self._cook.setObjectName("DsCookBar")
+        self._cook.setTextVisible(False)
+        self._cook.setFixedHeight(3)
+        self._cook.setRange(0, 1)
+        self._cook.setValue(0)
         col.addWidget(self._cook)
+        # — cookline (comp): 10px mono DATA, e.g. "cooked 30/30 · 41s · karma_xpu"
         self._cook_lbl = c.label("waiting for work", role="caption")
+        self._cook_lbl.setFont(fontload.tracked_font("DATA", 10, mono=True))
         self._cook_lbl.setStyleSheet("color:%s;" % t.TEXT_TERTIARY)
         col.addWidget(self._cook_lbl)
 
         # — plan-with-progress (driven by the live tool stream + routing_log) —
         self._plan_title = c.label("PLAN", role="label")
-        self._plan_title.setStyleSheet(
-            "color:%s; letter-spacing:1.5px;" % t.TEXT_TERTIARY)
+        self._plan_title.setFont(fontload.tracked_font("EYEBROW", 10, mono=True))
+        self._plan_title.setStyleSheet("color:%s;" % t.TEXT_TERTIARY)
         col.addWidget(self._plan_title)
         self._plan_box = QtWidgets.QVBoxLayout()
         self._plan_box.setSpacing(2)
@@ -201,14 +213,18 @@ class FaceWork(QtWidgets.QWidget):
 
     # -- panel-facing API ------------------------------------------------
     def set_thinking(self, on):
-        """Working ↔ at rest. Couples the toy + the cook's indeterminate pulse."""
+        """Working ↔ at rest. Couples the toy + the cook bar's busy sweep.
+        Reduced-motion: a static track (range 0..1, empty) — the sweep never
+        runs and no progress is fabricated."""
         if self._toy is not None:
             self._toy.start() if on else self._toy.stop()
-        if on:
-            self._cook.start_pulse()
+        if on and not t.reduced_motion():
+            self._cook.setRange(0, 0)        # style-driven indeterminate sweep
         else:
-            self._cook.stop_pulse()
-            self._status.setText("Standing by")
+            self._cook.setRange(0, 1)
+            self._cook.setValue(0)
+            if not on:
+                self._status.setText("Standing by")
 
     def set_tool_status(self, name, phase, detail=None):
         """A live tool event → update the status line + the plan-with-progress."""
@@ -225,10 +241,12 @@ class FaceWork(QtWidgets.QWidget):
         self._render_plan()
 
     def set_cook(self, done, total, live=True, label=None):
-        """Wire real cook / render progress onto the bucket grid."""
-        self._cook.set_progress(done, total, live=live)
-        self._cook_lbl.setText(
-            label or ("cooking %d / %d" % (done, total)))
+        """Wire real cook / render progress onto the cook bar. ``live`` is
+        accepted for call-site compatibility (the bar has no per-bucket state)."""
+        total = max(1, int(total))
+        self._cook.setRange(0, total)
+        self._cook.setValue(max(0, min(total, int(done))))
+        self._cook_lbl.setText(label or ("cooked %d/%d" % (done, total)))
 
     def set_health(self, data):
         if self._health is not None:
@@ -236,7 +254,8 @@ class FaceWork(QtWidgets.QWidget):
 
     def reset(self):
         self._steps = []
-        self._cook.reset()
+        self._cook.setRange(0, 1)
+        self._cook.setValue(0)
         self._cook_lbl.setText("waiting for work")
         self._render_plan()
 

--- a/python/synapse/panel/message_formatter.py
+++ b/python/synapse/panel/message_formatter.py
@@ -122,21 +122,30 @@ def _format_inline_code(match, font_scale=1.0):
     )
 
 
-def _format_node_path(match, font_scale=1.0):
+def _format_node_path(match, font_scale=1.0, signed=None):
     """Render a Houdini node path as a clickable **artifact chip** — a node
     mark + the mono path, a thing rather than a sentence fragment. The
-    ``node:`` href keeps click-to-locate (ChatDisplay.node_clicked) intact."""
+    ``node:`` href keeps click-to-locate (ChatDisplay.node_clicked) intact.
+    ``signed`` (v9 comp) appends a quiet ``· signed <model>`` authorship
+    suffix inside the chip — display-only, once per message."""
     path = match.group(1)
     sz = _scale(_SMALL_PX, font_scale)
+    note = ""
+    if signed:
+        note = (
+            '&#160;&#183;&#160;<span style="color:{dim}; '
+            'font-size:{ssz}px;">signed {who}</span>'
+        ).format(dim=_TEXT_DIM, ssz=_scale(10, font_scale),
+                 who=html.escape(str(signed)))
     return (
         '<a href="node:{path}" style="text-decoration:none;">'
         '<span style="background:{bg}; font-family:{mono}; font-size:{sz}px;">'
         '<span style="color:{mark};">&#9642;</span> '
         '<span style="color:{fg};">{path}</span>'
-        "&#160;</span></a>"
+        "{note}&#160;</span></a>"
     ).format(
         path=path, bg=_GROUND, mark=_SIGNAL, fg=_TEXT_BRIGHT,
-        mono=_MONO, sz=sz,
+        mono=_MONO, sz=sz, note=note,
     )
 
 
@@ -152,11 +161,23 @@ def _format_list_items(text):
     return _LIST_ITEM_RE.sub("", text).rstrip() + ul_html
 
 
-def _process_rich_text(raw, font_scale=1.0):
-    """Apply code block, inline code, node-chip, and list formatting."""
+def _process_rich_text(raw, font_scale=1.0, signed=None):
+    """Apply code block, inline code, node-chip, and list formatting. Returns
+    ``(html, signed_used)`` — when ``signed`` is given, the FIRST node chip
+    carries the authorship suffix (once per message) and ``signed_used`` says
+    whether a chip took it (else the caller renders the standalone note)."""
+    state = {"signed_used": False}
+
+    def _node(m):
+        s = None
+        if signed and not state["signed_used"]:
+            state["signed_used"] = True
+            s = signed
+        return _format_node_path(m, font_scale, signed=s)
+
     raw = _CODE_BLOCK_RE.sub(lambda m: _format_code_block(m, font_scale), raw)
     raw = _INLINE_CODE_RE.sub(lambda m: _format_inline_code(m, font_scale), raw)
-    raw = _NODE_PATH_RE.sub(lambda m: _format_node_path(m, font_scale), raw)
+    raw = _NODE_PATH_RE.sub(_node, raw)
     raw = _format_list_items(raw)
 
     # Newlines to <br> (but not inside <pre> blocks)
@@ -164,15 +185,12 @@ def _process_rich_text(raw, font_scale=1.0):
     for i, part in enumerate(parts):
         if not part.startswith("<pre"):
             parts[i] = part.replace("\n", "<br>")
-    return "".join(parts)
+    return "".join(parts), state["signed_used"]
 
 
-def format_response(response, font_scale=1.0):
-    """Convert a SYNAPSE response (dict or str) to styled HTML.
-
-    The agent voice: neutral body copy, no chrome. Node refs become artifact
-    chips; a status, if present, leads with a single colored dot.
-    """
+def _format_response_ex(response, font_scale=1.0, signed=None):
+    """format_response + ``signed_used`` (did a node chip carry the authorship
+    suffix?). Internal — the public surface stays unchanged."""
     if isinstance(response, str):
         raw = response
         status = None
@@ -186,14 +204,23 @@ def format_response(response, font_scale=1.0):
         )
         status = response.get("status")
 
-    raw = _process_rich_text(raw, font_scale)
+    raw, signed_used = _process_rich_text(raw, font_scale, signed=signed)
     prefix = _status_prefix(status) if status else ""
 
     return (
         '<div style="color:{fg}; font-size:{sz}px;">{prefix}{body}</div>'
     ).format(
         fg=_TEXT, sz=_scale(_BODY_PX, font_scale), prefix=prefix, body=raw,
-    )
+    ), signed_used
+
+
+def format_response(response, font_scale=1.0):
+    """Convert a SYNAPSE response (dict or str) to styled HTML.
+
+    The agent voice: neutral body copy, no chrome. Node refs become artifact
+    chips; a status, if present, leads with a single colored dot.
+    """
+    return _format_response_ex(response, font_scale)[0]
 
 
 def format_user_message(text, grouped=False, timestamp=None, font_scale=1.0):
@@ -207,12 +234,14 @@ def format_user_message(text, grouped=False, timestamp=None, font_scale=1.0):
     escaped = html.escape(text).replace("\n", "<br>")
     body_sz = _scale(_BODY_PX, font_scale)
     my = _MSG_MARGIN_Y if grouped else _GROUP_MARGIN_Y
+    # v9 comp .you: 2px SIGNAL rule · 14px gap · bright text at 1.5 line-height
+    # (line-height is best-effort — harmless if the QTextDocument subset drops it).
     return (
         '<table border="0" cellspacing="0" cellpadding="0" width="100%" '
         'style="margin:{my}px 0;"><tr>'
         '<td width="2" style="background:{sig};"></td>'
-        '<td width="10"></td>'
-        '<td style="color:{fg}; font-size:{sz}px;">{body}</td>'
+        '<td width="14"></td>'
+        '<td style="color:{fg}; font-size:{sz}px; line-height:150%;">{body}</td>'
         "</tr></table>"
     ).format(my=my, sig=_SIGNAL, fg=_TEXT_BRIGHT, sz=body_sz, body=escaped)
 
@@ -224,11 +253,14 @@ def format_synapse_message(content, grouped=False, timestamp=None, font_scale=1.
 
     ``signed`` adds a quiet, display-only authorship note (the model that
     produced the result) once at the head of a SYNAPSE group — never per
-    message. It is a label, not a substrate write."""
-    body = format_response(content, font_scale)
+    message. It is a label, not a substrate write. v9: when the result carries
+    a node chip, the FIRST chip carries the ``signed`` suffix (comp anatomy);
+    otherwise the standalone note renders as before — exactly one either way."""
+    body, chip_signed = _format_response_ex(
+        content, font_scale, signed=None if grouped else signed)
     my = _MSG_MARGIN_Y if grouped else _GROUP_MARGIN_Y
     note = ""
-    if signed and not grouped:
+    if signed and not grouped and not chip_signed:
         note = (
             '<div style="color:{dim}; font-size:{sz}px; letter-spacing:1px; '
             'margin-top:2px;">signed {who}</div>'

--- a/python/synapse/panel/synapse_panel.py
+++ b/python/synapse/panel/synapse_panel.py
@@ -88,12 +88,11 @@ class _GrowingInput(QtWidgets.QTextEdit):
         self.setObjectName("DsInput")
         self.setAcceptRichText(False)
         self.setPlaceholderText("Ask SYNAPSE…    ·    / for commands")
-        # Default a comfortable multi-line height — but small enough that the
-        # input + Send row are never pushed off the bottom at the min pane
-        # height (the old 216px default was the crop culprit). The artist can
-        # still drag it taller via the resize grip; it also auto-grows to fit.
-        self._user_h = 96
+        # v9 comp: a 132px composer (was 96). The artist can still drag it
+        # taller via the resize grip; it also auto-grows to fit the content.
+        self._user_h = 132
         self._floor, self._max_h = 64, 600
+        self._send_widget = None    # the embedded Send (attach_send)
         self.setFixedHeight(self._user_h)
         self.textChanged.connect(self._autosize)
 
@@ -105,6 +104,32 @@ class _GrowingInput(QtWidgets.QTextEdit):
         """Set the artist's preferred input height (driven by the resize grip)."""
         self._user_h = max(self._floor, min(self._max_h, int(h)))
         self._autosize()
+
+    # -- embedded Send (v9 comp: bottom-right INSIDE the field) -------------
+    def attach_send(self, btn):
+        """Parent the Send button to the field itself (NOT the viewport, so it
+        never scrolls) and reserve a bottom viewport margin so text never
+        flows under it."""
+        self._send_widget = btn
+        btn.setParent(self)
+        try:
+            self.setViewportMargins(0, 0, 0, btn.sizeHint().height() + 12)
+        except Exception:
+            pass
+        btn.show()
+        self._place_send()
+
+    def _place_send(self):
+        btn = self._send_widget
+        if btn is None:
+            return
+        bs = btn.sizeHint()
+        btn.resize(bs)
+        btn.move(self.width() - bs.width() - 10, self.height() - bs.height() - 10)
+
+    def resizeEvent(self, e):
+        super().resizeEvent(e)
+        self._place_send()
 
     def keyPressEvent(self, e):
         # "/" on an empty prompt opens the command palette (⌘K folded into the
@@ -302,15 +327,13 @@ class SynapsePanel(QtWidgets.QWidget):
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(0)
 
-        # Persistent rail (Mile 1) → context ribbon → switcher → the three faces.
-        # Each face is a full content surface; the controller brings the right
-        # one forward as the agent's state changes. The work is the hero.
-        root.addWidget(self._build_rail())          # mark-as-status · state · Stop
-        root.addWidget(c.divider())
-        root.addWidget(self._build_model_bar())     # engine selection — apparent
-        root.addWidget(c.divider())
+        # Persistent rail (Mile 1) → context ribbon → switcher → the two faces.
+        # v9: the ENGINE pill bar left the chrome — the rail author token is the
+        # engine+model click target now (its menu machinery is reused). The
+        # rail's bottom rule is the #DsHeader HAIR border (no divider widget).
+        root.addWidget(self._build_rail())          # mark · brand · author · Stop
         root.addWidget(self._build_context_ribbon())
-        root.addWidget(self._build_mode_bar())      # Direct · Work · Review pills
+        root.addWidget(self._build_mode_bar())      # DIRECT · WORK underline tabs
         root.addWidget(self._build_faces(), 1)      # dominant — the stacked faces
         self._set_face("direct")                    # idle resting face
 
@@ -322,55 +345,79 @@ class SynapsePanel(QtWidgets.QWidget):
         beneath. Termination and live state never scroll away.
         """
         w = self._section()
-        w.setObjectName("DsHeader")          # keep the subtle cool→warm gradient
+        w.setObjectName("DsHeader")          # flat PANEL + 1px HAIR bottom rule
         col = QtWidgets.QVBoxLayout(w)
-        # Generous, confident header padding (Pentagram): a wider left margin and
-        # real vertical air so the brand isn't crammed against the pane edge.
-        col.setContentsMargins(t.SPACE_LG, t.SPACE_MD, t.SPACE_MD, t.SPACE_MD)
+        # Comp row-1 padding: 16 / 26 / 14 (the confident header air).
+        col.setContentsMargins(26, 16, 26, 14)
         col.setSpacing(t.SPACE_SM)
 
-        # line 1 — identity + state. The mark fills with the agent's state.
+        # line 1 — identity + selection + state (comp order):
+        # [mark]·12·[SYNAPSE] ··· [state] [author▾] [meter] [⌘K] [⋯] [Stop*]
         top = QtWidgets.QHBoxLayout()
         top.setSpacing(t.SPACE_SM)
         self._mark = c.MarkDot("idle", diameter=16)
-        word = c.label("SYNAPSE", role="display")
-        # BRAND tracking lives on the QFont (Qt QSS has no letter-spacing); the
-        # stylesheet carries colour only.
-        word.setStyleSheet("color:%s;" % t.TEXT_BRIGHT)
-        word.setFont(fontload.tracked_font("BRAND", t.SIZE_HERO, scale=self._chrome_scale))
+        # brand word — demoted to 14px/500/TEXT_PRIMARY (comp .word); tracking
+        # lives on the QFont (Qt QSS has no letter-spacing), colour in the sheet.
+        word = c.label("SYNAPSE", role="body")
+        word.setStyleSheet("color:%s;" % t.TEXT_PRIMARY)
+        word.setFont(fontload.tracked_font("BRAND", 14, scale=self._chrome_scale,
+                                           weight=500))
         self._wordmark = word
         self._header_status = c.label("Standing by", role="caption", scale=self._chrome_scale)
         self._header_status.setStyleSheet("color:%s;" % t.TEXT_SECONDARY)
+        # author token — THE engine+model click target (v9): a flat button whose
+        # text is _author_token(); click opens the engine menu. Discoverability =
+        # pointing-hand + hover underline + tooltip (comp shows no ▾).
+        self._author_lbl = QtWidgets.QPushButton()
+        self._author_lbl.setObjectName("DsAuthor")
+        self._author_lbl.setFlat(True)
+        self._author_lbl.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._author_lbl.setToolTip("Engine & model — click to switch")
+        self._author_lbl.setFont(fontload.tracked_font(
+            "DATA", t.SIZE_SMALL, scale=self._chrome_scale, mono=True))
+        self._author_lbl.setText(self._author_token())
+        self._author_lbl.clicked.connect(self._open_author_menu)
+        # token meter — TOKENS ONLY, never $ (metering-deferred D4). Providers
+        # don't surface usage yet, so it stays EMPTY until real usage arrives —
+        # never estimated. _format_tokens is the one display rule.
+        self._meter_lbl = c.label("", role="caption")
+        self._meter_lbl.setObjectName("DsMeter")
+        self._meter_lbl.setFont(fontload.tracked_font(
+            "DATA", t.SIZE_SMALL, scale=self._chrome_scale, mono=True))
+        self._session_tokens = 0
         # quiet ⌘K affordance — the palette is already bound (QShortcut); this
-        # only makes it discoverable. Its text is set from the ACTUAL bound
+        # only makes it discoverable, restyled as a bordered chip (comp .cmdk;
+        # 11px = the L2 chrome floor). Its text is set from the ACTUAL bound
         # QKeySequence after the shortcut is created (platform-correct, never
-        # lies about the key). It rides line 1, never the meter row.
+        # lies about the key).
         self._palette_hint = c.label("", role="caption")
-        self._palette_hint.setFont(fontload.tracked_font("LABEL_SM", t.SIZE_SMALL, scale=self._chrome_scale))
-        self._palette_hint.setStyleSheet("color:%s;" % t.TEXT_TERTIARY)
+        self._palette_hint.setObjectName("DsKHint")
+        self._palette_hint.setFont(fontload.tracked_font(
+            "DATA", t.SIZE_SMALL, scale=self._chrome_scale, mono=True))
         overflow = c.Button("⋯", variant="ghost")
         overflow.setFixedWidth(32)
         overflow.clicked.connect(self._show_overflow)
+        self._stop_btn = c.Button("Stop", variant="danger")
+        self._stop_btn.setMinimumWidth(64)
+        self._stop_btn.clicked.connect(self._on_stop)
+        self._stop_btn.setEnabled(False)
+        self._stop_btn.setVisible(False)   # state-gated: shown only while working
         top.addWidget(self._mark)
         top.addSpacing(t.SPACE_XS)        # a beat between the mark and the wordmark
         top.addWidget(word)
-        top.addSpacing(t.SPACE_SM)        # let the brand breathe before the stretch
         top.addStretch(1)
         top.addWidget(self._header_status)
+        top.addWidget(self._author_lbl)
+        top.addWidget(self._meter_lbl)
         top.addWidget(self._palette_hint)
         top.addWidget(overflow)
+        top.addWidget(self._stop_btn)     # termination never scrolls away
         col.addLayout(top)
 
-        # line 2 — connection · activity meter · Stop. The meter lifts to WARM
-        # while the agent works, dim at rest (observability, always on).
+        # line 2 — connection · corpus · activity strip (kept-for-now: not in
+        # the comp, not ratified out — retiring it is a future owner call).
         bot = QtWidgets.QHBoxLayout()
         bot.setSpacing(t.SPACE_SM)
-        # author signature — DISPLAY ONLY — leads the telemetry cluster it
-        # answers for (the model that produces results in this panel).
-        self._author_lbl = c.label("", role="caption")
-        self._author_lbl.setStyleSheet("color:%s;" % t.TEXT_TERTIARY)
-        self._author_lbl.setFont(fontload.tracked_font("DATA", t.SIZE_SMALL, scale=self._chrome_scale))
-        self._author_lbl.setText(self._author_token())
         self._foot_dot = c.StatusDot("disconnected")
         self._foot_label = c.label("Not connected", role="caption", scale=self._chrome_scale)
         self._foot_label.setStyleSheet("color:%s;" % t.TEXT_TERTIARY)
@@ -400,20 +447,35 @@ class SynapsePanel(QtWidgets.QWidget):
         self._observe.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
         self._observe.setFixedHeight(3)
         self._observe.setStyleSheet("background:%s; border-radius:2px;" % t.SIGNAL_TINT)
-        self._stop_btn = c.Button("Stop", variant="danger")
-        self._stop_btn.setMinimumWidth(64)
-        self._stop_btn.clicked.connect(self._on_stop)
-        self._stop_btn.setEnabled(False)
-        self._stop_btn.setVisible(False)   # state-gated: shown only while working
-        bot.addWidget(self._author_lbl)
         bot.addWidget(self._foot_dot)
         bot.addWidget(self._foot_label)
         bot.addWidget(self._connect_btn)
         bot.addWidget(self._corpus_btn)
         bot.addWidget(self._observe, 1)
-        bot.addWidget(self._stop_btn)
         col.addLayout(bot)
         return w
+
+    def _format_tokens(self, n):
+        """Token-count display rule for the rail meter — tokens only, no $:
+        812 · 18.0k · 1.2M. Pure formatting; the meter never estimates."""
+        n = int(n)
+        if n < 1000:
+            return "%d" % n
+        if n < 1_000_000:
+            return "%.1fk" % (n / 1000.0)
+        return "%.1fM" % (n / 1_000_000.0)
+
+    def _note_usage(self, total_tokens):
+        """Accumulate real provider-reported usage into the session meter.
+        No provider surfaces usage yet (the seam is a future providers/ slice);
+        until it lands the meter stays empty — never estimated."""
+        try:
+            self._session_tokens += int(total_tokens)
+        except Exception:
+            return
+        lbl = getattr(self, "_meter_lbl", None)
+        if lbl is not None:
+            lbl.setText(self._format_tokens(self._session_tokens))
 
     def _on_connect(self):
         """Force-start the Synapse bridge server — the hwebserver that serves the
@@ -517,66 +579,11 @@ class SynapsePanel(QtWidgets.QWidget):
         if btn is not None:
             btn.setText("Corpus ✓" if loaded else "Corpus")
 
-    def _build_model_bar(self):
-        """Model selection, made APPARENT (Image #6). A segmented Claude·Gemini
-        control whose active engine reads as a filled SIGNAL pill, plus a
-        prominent model-id chip — the switch used to be buried two levels deep
-        in the ⋯ menu. Display/telemetry only; the pick takes effect on the NEXT
-        message (same contract as the old menu switch)."""
-        w = self._section()
-        lay = QtWidgets.QHBoxLayout(w)
-        lay.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_SM)
-        lay.setSpacing(t.SPACE_SM)
-        lbl = c.label("ENGINE", role="caption")
-        lbl.setFont(fontload.tracked_font("LABEL_SM", t.SIZE_SMALL, scale=self._chrome_scale))
-        self._engine_lbl = lbl
-        lay.addWidget(lbl)
-        self._engine_pills = {}
-        try:
-            from synapse.panel.providers.registry import PROVIDER_IDS, PROVIDER_LABELS
-            ids, labels = PROVIDER_IDS, PROVIDER_LABELS
-        except Exception:
-            ids, labels = ("claude",), {"claude": "Claude"}
-        for pid in ids:
-            seg = QtWidgets.QPushButton(labels.get(pid, pid))
-            seg.setObjectName("DsSeg")
-            seg.setCursor(Qt.CursorShape.PointingHandCursor)
-            seg.clicked.connect(lambda _=False, p=pid: self._set_provider(p))
-            lay.addWidget(seg)
-            self._engine_pills[pid] = seg
-        lay.addStretch(1)
-        # prominent model-id readout (e.g. 'sonnet-4.6') — the chip Image #6 asks
-        # for; cost is intentionally omitted (the worker doesn't surface usage yet,
-        # so a cost figure would be fabricated).
-        # Clickable model picker — a SHORT model label + a ▾ affordance; opens a
-        # menu of the active engine's models (Opus/Sonnet/Haiku/Fable for Claude).
-        # Styled by the QSS #DsModelChip rule (caption-size, so the long NVIDIA
-        # ids no longer dominate the panel).
-        self._model_chip = QtWidgets.QPushButton(self._model_chip_text())
-        self._model_chip.setObjectName("DsModelChip")
-        self._model_chip.setCursor(Qt.CursorShape.PointingHandCursor)
-        self._model_chip.setFlat(True)
-        self._model_chip.setToolTip("Switch model")
-        self._model_chip.clicked.connect(self._open_model_menu)
-        lay.addWidget(self._model_chip)
-        self._refresh_engine_selector()
-        return w
-
     def _refresh_engine_selector(self):
-        """Paint the active engine (filled pill) + the model chip from the live
-        provider id. Idempotent; safe before the bar is built."""
-        cur = getattr(self, "_provider_id", "claude")
-        for pid, seg in getattr(self, "_engine_pills", {}).items():
-            seg.setProperty("active", pid == cur)
-            c.repolish(seg)
-        chip = getattr(self, "_model_chip", None)
-        if chip is not None:
-            try:
-                chip.setText(self._model_chip_text())
-            except Exception:
-                pass
-        # keep the rail author signature in sync too — a MODEL switch (not just a
-        # provider switch) must update it (its docstring promises this).
+        """Repaint the engine/model selection readout — v9: the rail author
+        token IS the selector (the ENGINE pill bar left the chrome; this keeps
+        its name for the 4 call sites). A MODEL switch (not just a provider
+        switch) must update it. Idempotent; safe before the rail is built."""
         lbl = getattr(self, "_author_lbl", None)
         if lbl is not None:
             try:
@@ -614,32 +621,41 @@ class SynapsePanel(QtWidgets.QWidget):
             pass
         # The chat is the dominant surface via stretch (it expands to fill), so
         # its MINIMUM is kept low — a high min here was what summed past the pane
-        # height and clipped the input/Send row at short pane sizes.
-        self._chat.setMinimumHeight(80)
+        # height and clipped the input/Send row at short pane sizes. v9: lower
+        # still (the 132px comp composer + khint reclaim the floor's budget).
+        self._chat.setMinimumHeight(24)
         self._converse_stack = QtWidgets.QStackedWidget()
         self._converse_stack.addWidget(self._chat)              # page 0: chat
         self._converse_stack.addWidget(self._build_hda_form())  # page 1: Build HDA
+        # Vertical IGNORED: the stack lives off its stretch factor, not its
+        # pages' size hints — otherwise the chat/HDA-form hints manufacture a
+        # layout deficit that compresses the 132px composer even in tall panes.
         self._converse_stack.setSizePolicy(
-            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Ignored
         )
-        self._converse_stack.setMinimumHeight(80)
+        self._converse_stack.setMinimumHeight(24)
         return self._converse_stack
 
     # the two tabs, in switcher order (v9: Review folded into Work's done state)
     _FACE_INDEX = {"direct": 0, "work": 1}
 
     def _build_mode_bar(self):
-        """The switcher: Direct · Work. Underline tabs (v9 call 1). A pill click
+        """The switcher: DIRECT · WORK. Underline tabs on a shared baseline
+        track (v9 call 1; #DsTabRow carries the 1px BORDER rule). A pill click
         is the *only* thing that moves the visible tab — agent state never does
-        (the same-pane law)."""
+        (the same-pane law). Text is pre-uppercased (QSS has no text-transform);
+        `_face_pills` keys stay "direct"/"work" — the same-pane invariants key
+        on those, not on the label text."""
         w = self._section()
+        w.setObjectName("DsTabRow")
         lay = QtWidgets.QHBoxLayout(w)
-        lay.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_XS)
-        lay.setSpacing(t.SPACE_SM)
+        lay.setContentsMargins(26, 20, 26, 0)
+        lay.setSpacing(28)
         self._face_pills = {}
-        for face, text in (("direct", "Direct"), ("work", "Work")):
+        for face, text in (("direct", "DIRECT"), ("work", "WORK")):
             pill = c.Pill(text)
-            pill.setFont(fontload.tracked_font("LABEL", t.SIZE_UI + 2))  # tab tracking
+            pill.setFont(fontload.tracked_font(
+                "LABEL", t.SIZE_SMALL, scale=self._chrome_scale, mono=True))
             pill.clicked.connect(lambda _=False, f=face: self._set_face(f))
             lay.addWidget(pill)
             self._face_pills[face] = pill
@@ -663,10 +679,12 @@ class SynapsePanel(QtWidgets.QWidget):
         return self._faces
 
     def _build_direct_face(self):
-        """Direct — converse + quick actions + input. The artist's surface."""
+        """Direct — converse + quick actions + input. The artist's surface.
+        The face carries the comp's 26/20 content padding; inner rows are
+        flush (their old horizontal margins would double it)."""
         page = self._section()
         col = QtWidgets.QVBoxLayout(page)
-        col.setContentsMargins(0, 0, 0, 0)
+        col.setContentsMargins(26, 20, 26, 20)
         col.setSpacing(0)
         col.addWidget(self._build_converse(), 1)   # chat | Build-HDA inner stack
         col.addWidget(self._build_act())
@@ -767,17 +785,6 @@ class SynapsePanel(QtWidgets.QWidget):
             pass
         return t.FONT_SCALE_DEFAULT
 
-    def _model_chip_text(self):
-        """Short, readable chip label for the active model (e.g. 'Sonnet 4.6'),
-        NOT the raw model id (which is long enough to dominate the panel)."""
-        try:
-            from synapse.panel.providers.registry import model_label
-            pid = getattr(self, "_provider_id", "claude")
-            lbl = model_label(pid, self._active_model())
-        except Exception:
-            lbl = self._author_token()
-        return (lbl or "model") + "  ▾"
-
     def _active_model(self):
         """Model id of the active engine — the picked model for this provider,
         else the registry default (no network)."""
@@ -795,28 +802,110 @@ class SynapsePanel(QtWidgets.QWidget):
             except Exception:
                 return ""
 
-    def _model_menu_items(self):
-        """``(model_id, label, active)`` rows for the active provider's picker —
-        the exact data the model menu renders; exposed for the readability
-        audit so the picker is gate-checkable offscreen."""
+    def _provider_model_rows(self, pid):
+        """``(model_id, label)`` rows for a provider — the registry rows, with
+        the Ollama live-tag special case hoisted here (menu-open is user-
+        initiated; 1s localhost timeout; the registry row is only the static
+        fallback). Shared by the model picker AND the author engine menu.
+
+        Guarantee (v9 hardening): when ``pid`` is the ACTIVE provider, the
+        active model is always among the rows — a persisted pick can go stale
+        (registry rotation) or be live-only (an Ollama tag while the daemon is
+        down), and the selection must stay OBSERVABLE: the artist sees exactly
+        what will run, checked, never a silently blank menu. The stale row is
+        appended after the registry rows (label falls back to the raw id)."""
         try:
             from synapse.panel.providers import registry as reg
         except Exception:
             return []
-        pid = getattr(self, "_provider_id", "claude")
-        cur = self._active_model()
-        rows = reg.models_for(pid)
+        rows = list(reg.models_for(pid))
         if pid == "ollama":
-            # Live local tag list (menu-open is user-initiated; 1s localhost
-            # timeout) — the registry row is only the static fallback.
             try:
                 from synapse.panel.providers.ollama_provider import OllamaProvider
                 live = OllamaProvider.available_models(timeout=1.0)
                 if live:
-                    rows = live
+                    rows = list(live)
             except Exception:
                 pass
-        return [(mid, lbl, mid == cur) for mid, lbl in rows]
+        if pid == getattr(self, "_provider_id", "claude"):
+            cur = self._active_model()
+            if cur and cur not in {mid for mid, _ in rows}:
+                rows.append((cur, reg.model_label(pid, cur)))
+        return rows
+
+    def _model_menu_items(self):
+        """``(model_id, label, active)`` rows for the active provider's picker —
+        the exact data the model menu renders; exposed for the readability
+        audit so the picker is gate-checkable offscreen."""
+        pid = getattr(self, "_provider_id", "claude")
+        cur = self._active_model()
+        return [(mid, lbl, mid == cur)
+                for mid, lbl in self._provider_model_rows(pid)]
+
+    def _author_menu_items(self):
+        """``(pid, provider_label, [(mid, label, active)])`` — the exact data
+        the author-token engine menu renders, exposed so engine selection stays
+        gate-checkable offscreen (the ``_model_menu_items`` pattern). Exactly
+        ONE ``(pid, mid)`` is active across the whole tree."""
+        try:
+            from synapse.panel.providers.registry import PROVIDER_IDS, PROVIDER_LABELS
+        except Exception:
+            return []
+        cur_pid = getattr(self, "_provider_id", "claude")
+        cur_mid = self._active_model()
+        return [
+            (pid, PROVIDER_LABELS.get(pid, pid),
+             [(mid, lbl, pid == cur_pid and mid == cur_mid)
+              for mid, lbl in self._provider_model_rows(pid)])
+            for pid in PROVIDER_IDS
+        ]
+
+    def _fill_author_submenu(self, sub, pid):
+        """(Re)build one provider submenu from live rows. The Ollama submenu
+        re-fills on aboutToShow so the local tag list stays current; Custom
+        appends Configure… (and opens even while unconfigured)."""
+        sub.clear()
+        cur_pid = getattr(self, "_provider_id", "claude")
+        cur_mid = self._active_model()
+        for mid, lbl in self._provider_model_rows(pid):
+            act = sub.addAction(lbl)
+            act.setCheckable(True)
+            act.setChecked(pid == cur_pid and mid == cur_mid)
+            act.triggered.connect(
+                lambda _=False, p=pid, m=mid: self._pick_engine_model(p, m))
+        if pid == "custom":
+            if not sub.isEmpty():
+                sub.addSeparator()
+            sub.addAction("Configure…", self._configure_custom)
+
+    def _open_author_menu(self):
+        """The rail author token's engine+model menu (v9) — one submenu per
+        provider, rows from the registry; REUSES the proven _set_provider /
+        _set_model / _persist_picks machinery (only the anchor moved from the
+        retired pill bar). Exactly one row is checked: the active pair."""
+        try:
+            from synapse.panel.providers.registry import PROVIDER_IDS, PROVIDER_LABELS
+        except Exception:
+            return
+        menu = QtWidgets.QMenu(self)
+        for pid in PROVIDER_IDS:
+            sub = menu.addMenu(PROVIDER_LABELS.get(pid, pid))
+            self._fill_author_submenu(sub, pid)
+            if pid == "ollama":
+                sub.aboutToShow.connect(
+                    lambda s=sub, p=pid: self._fill_author_submenu(s, p))
+        btn = getattr(self, "_author_lbl", None)
+        anchor = btn if btn is not None else self
+        pos = anchor.mapToGlobal(QtCore.QPoint(0, anchor.height()))
+        menu.exec(pos) if hasattr(menu, "exec") else menu.exec_(pos)
+
+    def _pick_engine_model(self, pid, mid):
+        """A row pick from the author menu: switch the engine if needed, then
+        the model — both existing persisted paths (effective on the NEXT
+        message; two chat announcements are acceptable)."""
+        if pid != getattr(self, "_provider_id", "claude"):
+            self._set_provider(pid)
+        self._set_model(mid)
 
     def _open_model_menu(self):
         """Drop the model picker for the active engine — switching Anthropic
@@ -1163,7 +1252,7 @@ class SynapsePanel(QtWidgets.QWidget):
     def _build_act(self):
         w = self._section()
         lay = QtWidgets.QHBoxLayout(w)
-        lay.setContentsMargins(t.SPACE_MD, t.SPACE_SM, t.SPACE_MD, t.SPACE_SM)
+        lay.setContentsMargins(0, t.SPACE_SM, 0, t.SPACE_SM)  # face carries 26/20
         lay.setSpacing(t.SPACE_MD)
         for label_text, prompt in _QUICK_ACTIONS:
             lay.addWidget(self._verb(
@@ -1183,7 +1272,7 @@ class SynapsePanel(QtWidgets.QWidget):
     def _build_input(self):
         w = self._section()
         col = QtWidgets.QVBoxLayout(w)
-        col.setContentsMargins(t.SPACE_MD, 0, t.SPACE_MD, t.SPACE_SM)
+        col.setContentsMargins(0, 0, 0, 0)   # the Direct face carries the 26/20
         col.setSpacing(t.SPACE_XS)
         self._input = _GrowingInput()
         # The prompt scales with the Aa content scale via a widget-level sheet
@@ -1199,13 +1288,24 @@ class SynapsePanel(QtWidgets.QWidget):
         attach.setFixedWidth(32)
         attach.setToolTip("Attach image / file as context")
         attach.clicked.connect(self._on_attach)
-        self._send_btn = c.Button("Send", variant="primary")
-        self._send_btn.setMinimumWidth(72)
+        # v9 comp: SEND rides bottom-right INSIDE the composer (the attr name
+        # `_send_btn` is load-bearing — the clip audit finds it by name).
+        self._send_btn = QtWidgets.QPushButton("SEND")
+        self._send_btn.setObjectName("DsSend")
+        self._send_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._send_btn.setFont(fontload.tracked_font(
+            "SEND", t.SIZE_SMALL, scale=self._chrome_scale, weight=500))
         self._send_btn.clicked.connect(self._on_submit)
+        self._input.attach_send(self._send_btn)
         row.addWidget(self._input, 1)
         row.addWidget(attach)
-        row.addWidget(self._send_btn)
         col.addLayout(row)
+        # khint — the composer's quiet key legend (comp .khint)
+        self._khint = c.label("↵ send · ⇧↵ newline · / commands", role="caption")
+        self._khint.setFont(fontload.tracked_font(
+            "DATA", t.SIZE_MICRO, scale=self._chrome_scale, mono=True))
+        col.addSpacing(t.SPACE_SM)          # +XS layout spacing ⇒ the comp's 12
+        col.addWidget(self._khint)
         return w
 
     def _on_attach(self):

--- a/tests/panel/test_font_scale.py
+++ b/tests/panel/test_font_scale.py
@@ -94,8 +94,10 @@ def test_aa_scales_content_only_chrome_frozen():
     # never jitters when the artist changes reading size.
     import re
     p = _panel()
+    # v9: the ENGINE pill bar (and its _engine_lbl) left the chrome; the rail
+    # token meter joined it.
     chrome = ("_wordmark", "_header_status", "_palette_hint", "_author_lbl",
-              "_foot_label", "_ctx_label", "_engine_lbl")
+              "_foot_label", "_ctx_label", "_meter_lbl")
 
     def _px(name):
         w = getattr(p, name, None)

--- a/tests/test_panel_faces.py
+++ b/tests/test_panel_faces.py
@@ -192,11 +192,20 @@ def test_scripted_conversation_renders():
 
 
 def test_direct_input_is_roomy_multiline():
-    # Spike 4 — the Direct composer is a roomy multi-line prompt (not a one-line
-    # field), with Send present; conversation is told apart by type, no bubbles.
+    # v9 — the Direct composer defaults to the comp's roomy 132px (Preferred
+    # policy: it may compress toward the 64px floor only when the pane is
+    # short, so the embedded Send never crops). Needs an activated layout.
     p = _make_panel()
-    assert p._input.height() >= 120, "the prompt must be roomy multi-line"
-    assert p._send_btn is not None
+    p.resize(500, 700)
+    p.show()                                   # offscreen: activates layout
+    QtWidgets.QApplication.processEvents()
+    try:
+        assert p._input.height() >= 120, "the prompt must be roomy multi-line"
+        assert p._send_btn is not None
+        # Send is embedded INSIDE the composer (comp), never a separate row
+        assert p._send_btn.parent() is p._input
+    finally:
+        p.hide()
 
 
 def test_synapse_reply_carries_signed_author():
@@ -216,13 +225,13 @@ def test_work_face_present():
 
 
 def test_work_face_pulses_while_thinking():
-    # The cook preview runs its indeterminate sweep while the agent thinks,
-    # and stops at rest — "the walk-away glance" reads alive.
+    # The cook bar runs its indeterminate busy sweep while the agent thinks
+    # (QProgressBar range 0..0 — v9 DsCookBar), and rests static after.
     p = _make_panel()
     p._set_thinking(True)
-    assert p._work_face._cook._timer.isActive()
+    assert p._work_face._cook.maximum() == 0, "thinking → indeterminate sweep"
     p._set_thinking(False)
-    assert not p._work_face._cook._timer.isActive()
+    assert p._work_face._cook.maximum() != 0, "at rest → static track"
 
 
 def test_tool_status_feeds_plan():
@@ -238,12 +247,13 @@ def test_tool_status_feeds_plan():
 
 
 def test_cook_progress_is_determinate():
-    # Real cook counts switch the grid out of pulse into determinate progress.
+    # Real cook counts switch the bar out of the busy sweep into determinate
+    # progress; the cookline reads the comp's "cooked d/t" grammar.
     p = _make_panel()
     p._work_face.set_cook(14, 30)
-    assert p._work_face._cook._determinate
-    assert not p._work_face._cook._timer.isActive()
-    assert "14 / 30" in p._work_face._cook_lbl.text()
+    assert p._work_face._cook.maximum() == 30
+    assert p._work_face._cook.value() == 14
+    assert "14/30" in p._work_face._cook_lbl.text()
 
 
 def test_review_face_present_with_gate():
@@ -270,8 +280,8 @@ def test_review_show_result_populates_all_parts():
         signed="sonnet-4.6",
     )
     assert "Dark_Glass" in rf._verdict.text()
-    # DECISION leads the headline; VIA folds into the (collapsed) detail
-    assert rf._credit_box.count() == 1
+    # DECISION leads the credit grid; VIA folds into the (collapsed) detail
+    assert len(rf._decisions) == 1
     assert rf._via_box.count() == 1
     assert rf._flags_box.count() == 2
     # SIGNED line is display-only and shown
@@ -333,38 +343,141 @@ def test_fonts_bundled_and_registered():
         assert "Space Grotesk" in st["families"] and "Space Mono" in st["families"]
 
 
+def test_font_load_survives_panel_reload_purge():
+    # v9 hardening (CRUCIBLE) — the .pypanel loader purges synapse.* from
+    # sys.modules on every panel reopen, which resets fontload's module cache.
+    # The QFontDatabase registrations OUTLIVE the purge, so a fresh import must
+    # adopt the process-level status instead of re-registering the bundle
+    # (3 duplicate registrations per reopen, unbounded over a session).
+    from synapse.panel.designsystem import fontload
+    QtGui = fontload.QtGui
+    first = fontload.load_application_fonts()     # ensure the real load ran
+    calls = {"n": 0}
+    real = QtGui.QFontDatabase.addApplicationFont
+
+    def counted(path):
+        calls["n"] += 1
+        return real(path)
+
+    QtGui.QFontDatabase.addApplicationFont = staticmethod(counted)
+    try:
+        fontload._STATUS = None                   # what a fresh import sees
+        again = fontload.load_application_fonts()
+        assert calls["n"] == 0, "a reload purge must not re-register the bundle"
+        assert again["ok"] == first["ok"]
+        assert again["build_mismatch"] == first["build_mismatch"]
+        assert again["families"] == first["families"]
+    finally:
+        QtGui.QFontDatabase.addApplicationFont = real
+
+
 def test_tracking_applied_per_role():
-    # Spike 6 — the factory sets AbsoluteSpacing = em × px per role; BODY is
-    # untracked (default PercentageSpacing).
+    # v9 comp — the factory sets PercentageSpacing = 100 + em×100 per role
+    # (the AbsoluteSpacing form was superseded with the TRACKING_EM restore).
     from synapse.panel.designsystem import fontload
     from synapse.panel.designsystem import tokens as t
     f = fontload.tracked_font("BRAND", 16)
-    AbsoluteSpacing = type(f).AbsoluteSpacing
-    assert f.letterSpacingType() == AbsoluteSpacing
-    # Qt stores AbsoluteSpacing in 26.6 fixed-point (1/64 px), so allow a
-    # quantization tolerance rather than exact float equality.
-    assert abs(f.letterSpacing() - t.TRACKING_EM["BRAND"] * 16) < 0.05
-    # negative tracking for the display role (tighter verdict)
+    PercentageSpacing = type(f).PercentageSpacing
+    assert f.letterSpacingType() == PercentageSpacing
+    assert abs(f.letterSpacing() - (100 + t.TRACKING_EM["BRAND"] * 100)) < 0.05
+    # negative tracking for the display role (tighter verdict) → below 100%
     fd = fontload.tracked_font("DISPLAY", 15)
-    assert fd.letterSpacing() < 0
-    # BODY: no absolute tracking applied
+    assert 0 < fd.letterSpacing() < 100
+    # BODY: untracked — spacing left at the QFont default (0 / Percentage)
     fb = fontload.tracked_font("BODY", 13)
-    assert fb.letterSpacingType() == type(fb).PercentageSpacing
+    assert fb.letterSpacingType() == PercentageSpacing
+    assert fb.letterSpacing() == 0
+
+
+def test_tracked_font_uses_bundled_families():
+    # v9 ratified call — tracked_font defaults to the bundled Space Grotesk;
+    # mono=True opts into Space Mono. When the bundle failed to register, the
+    # factory keeps the native family instead (graceful fallback, flagged).
+    from synapse.panel.designsystem import fontload
+    p = _make_panel()                    # panel init loads the bundle
+    st = fontload.font_status() or p._font_status or {}
+    sans = fontload.tracked_font("BRAND", 14)
+    mono = fontload.tracked_font("DATA", 11, mono=True)
+    if st.get("ok") and not st.get("build_mismatch"):
+        assert sans.family() == "Space Grotesk"
+        assert mono.family() == "Space Mono"
+    else:
+        assert st.get("build_mismatch"), "unregistered bundle must be flagged"
 
 
 def test_wordmark_carries_brand_tracking():
-    # Spike 6 — the wordmark QFont carries BRAND AbsoluteSpacing (QSS can't).
+    # v9 — the wordmark QFont carries BRAND PercentageSpacing (QSS can't track).
+    from synapse.panel.designsystem import tokens as t
     p = _make_panel()
     f = p._wordmark.font()
-    assert f.letterSpacingType() == type(f).AbsoluteSpacing
+    assert f.letterSpacingType() == type(f).PercentageSpacing
+    assert abs(f.letterSpacing() - (100 + t.TRACKING_EM["BRAND"] * 100)) < 0.05
 
 
 def test_rail_author_token_shows():
-    # Spike 5 — the rail carries the author signature (display-only); the label
-    # tracks _author_token() regardless of whether the worker model imports.
+    # v9 — the rail author token is the ENGINE+MODEL click target: a clickable
+    # button whose text tracks _author_token(); its menu data covers every
+    # provider with exactly one active (engine, model) pair.
+    from synapse.panel.providers.registry import PROVIDER_IDS
     p = _make_panel()
     assert p._author_lbl is not None
+    assert isinstance(p._author_lbl, QtWidgets.QAbstractButton)
     assert p._author_lbl.text() == p._author_token()
+    assert hasattr(p, "_open_author_menu")
+    items = p._author_menu_items()
+    assert [pid for pid, _, _ in items] == list(PROVIDER_IDS)
+    active = [(pid, mid) for pid, _, rows in items for mid, _, on in rows if on]
+    assert active == [(p._provider_id, p._active_model())]
+
+
+def test_author_menu_tracks_engine_and_model_switch():
+    # v9 — selection stays OBSERVABLE on the token: a provider switch and a
+    # model switch each repaint the author token and move the single active row.
+    p = _make_panel()
+    pid0, mid0 = p._provider_id, p._active_model()   # restore whatever was picked
+    p._set_provider("gemini")
+    try:
+        assert p._author_lbl.text() == p._author_token()
+        active = [(pid, mid) for pid, _, rows in p._author_menu_items()
+                  for mid, _, on in rows if on]
+        assert active == [("gemini", p._active_model())]
+        # a row pick through the menu path switches engine AND model in one go
+        p._pick_engine_model("claude", "claude-fable-5")
+        assert p._provider_id == "claude"
+        assert p._active_model() == "claude-fable-5"
+        assert p._author_lbl.text() == p._author_token()
+        active = [(pid, mid) for pid, _, rows in p._author_menu_items()
+                  for mid, _, on in rows if on]
+        assert active == [("claude", "claude-fable-5")]
+    finally:
+        p._pick_engine_model(pid0, mid0)
+
+
+def test_stale_persisted_model_selection_stays_observable():
+    # v9 hardening (CRUCIBLE) — a persisted model pick can go STALE between
+    # sessions (registry rotation) while its provider stays valid. The boot
+    # merge keeps the pick; the selection must stay OBSERVABLE: every menu
+    # still leads with the registry rows in order, and the active pair is
+    # present + checked (exactly one) — never a silently blank menu.
+    from synapse.panel.providers import registry as reg
+    p = _make_panel()
+    pid = p._provider_id
+    stale = "claude-sonnet-4-5-RETIRED-TEST"
+    p._model_by_provider[pid] = stale     # what boot merges from a stale file
+    try:
+        want_ids = [m for m, _ in reg.models_for(pid)]
+        items = p._model_menu_items()
+        got_ids = [m for m, _, _ in items]
+        actives = [m for m, _, a in items if a]
+        assert got_ids[: len(want_ids)] == want_ids, "registry rows must lead, in order"
+        assert actives == [stale], "the stale pick must be checked (exactly one)"
+        assert got_ids[-1] == stale, "the stale row is appended at the tail"
+        a_active = [(apid, mid) for apid, _, rows in p._author_menu_items()
+                    for mid, _, on in rows if on]
+        assert a_active == [(pid, stale)], "author menu: exactly one active pair"
+        assert p._author_token(), "the token still renders a signature"
+    finally:
+        p._model_by_provider[pid] = reg.PROVIDER_DEFAULT_MODEL[pid]
 
 
 def test_stop_gated_to_working_state():
@@ -399,7 +512,7 @@ def test_reduced_motion_stops_animations():
         p = _make_panel()
         p._set_thinking(True)
         assert not p._mark._spin.isActive(), "mark must not spin under reduced-motion"
-        assert not p._work_face._cook._timer.isActive(), "cook must not pulse"
+        assert p._work_face._cook.maximum() != 0, "cook bar must stay static"
     finally:
         t.set_reduced_motion(None)
 
@@ -412,7 +525,7 @@ def test_motion_default_still_animates():
     try:
         p = _make_panel()
         p._set_thinking(True)
-        assert p._work_face._cook._timer.isActive()
+        assert p._work_face._cook.maximum() == 0   # indeterminate busy sweep
     finally:
         t.set_reduced_motion(None)
 

--- a/tests/test_panel_faces.py
+++ b/tests/test_panel_faces.py
@@ -371,6 +371,34 @@ def test_font_load_survives_panel_reload_purge():
         QtGui.QFontDatabase.addApplicationFont = real
 
 
+def test_font_load_no_app_never_poisons_cache():
+    # v9 hardening (CRUCIBLE) — an early load/tracked_font call with NO
+    # QApplication (pre-boot) must report not-loaded WITHOUT caching, so it
+    # can never block the real load once the app exists. tracked_font must
+    # still construct a QFont on that path (no raise, no poison).
+    from synapse.panel.designsystem import fontload
+    _make_panel()                                  # real app + real load ran
+    st_real = fontload.load_application_fonts()
+    saved = fontload._STATUS
+    real_instance = fontload.QtWidgets.QApplication.instance
+    fontload.QtWidgets.QApplication.instance = staticmethod(lambda: None)
+    try:
+        fontload._STATUS = None                    # what a fresh import sees
+        st = fontload.load_application_fonts()
+        assert st["ok"] is False and st["build_mismatch"] is True
+        assert fontload._STATUS is None, "no-app status must never be cached"
+        fontload.tracked_font("BRAND", 14)         # constructs — no raise
+        fontload.tracked_font("DATA", 11, mono=True)
+        assert fontload._STATUS is None, "tracked_font pre-app must not cache"
+    finally:
+        fontload.QtWidgets.QApplication.instance = real_instance
+        fontload._STATUS = saved
+    # the real load stays reachable — the cache was never poisoned
+    st2 = fontload.load_application_fonts()
+    assert st2["ok"] == st_real["ok"]
+    assert st2["families"] == st_real["families"]
+
+
 def test_tracking_applied_per_role():
     # v9 comp — the factory sets PercentageSpacing = 100 + em×100 per role
     # (the AbsoluteSpacing form was superseded with the TRACKING_EM restore).
@@ -478,6 +506,66 @@ def test_stale_persisted_model_selection_stays_observable():
         assert p._author_token(), "the token still renders a signature"
     finally:
         p._model_by_provider[pid] = reg.PROVIDER_DEFAULT_MODEL[pid]
+
+
+def test_unconfigured_custom_surfaces_configure_dialog():
+    # v9 adversarial (CRUCIBLE) — picking Custom while unconfigured must
+    # SURFACE the Configure dialog path (never a silent Claude floor, never a
+    # dead engine with nothing to chat with); a configured Custom must NOT
+    # re-open it. Settings are pointed at a tmp path so the real
+    # .synapse/panel_settings.json is never touched.
+    import tempfile
+    from pathlib import Path
+    from synapse.panel import settings as pset
+    p = _make_panel()
+    pid0 = p._provider_id
+    tmpfile = Path(tempfile.mkdtemp(prefix="synapse_test_custom_")) / "s.json"
+    real_path = pset.settings_path
+    pset.settings_path = lambda: tmpfile
+    calls = []
+    p._configure_custom = lambda: calls.append(1)   # record, don't open a dialog
+    try:
+        assert not p._custom_configured()
+        p._set_provider("custom")
+        assert calls == [1], "unconfigured Custom must surface Configure…"
+        assert p._provider_id == "custom", "the pick must hold — no silent floor"
+        st = pset.load_settings()
+        st["custom"] = {"base_url": "http://localhost:1", "model": "m", "key_env": ""}
+        pset.save_settings(st)
+        p._set_provider("custom")
+        assert calls == [1], "a configured Custom must not re-open the dialog"
+    finally:
+        p._set_provider(pid0)            # restore state (still on the tmp path)
+        p.__dict__.pop("_configure_custom", None)
+        pset.settings_path = real_path
+
+
+def test_author_submenu_ollama_down_degrades_static():
+    # v9 adversarial (CRUCIBLE) — the Ollama author submenu re-fills on
+    # aboutToShow; with the daemon down (available_models raising) both the
+    # initial fill and the refresh must degrade to the static registry rows
+    # WITHOUT raising — opening the menu never breaks on a dead daemon.
+    from synapse.panel.providers import registry as reg
+    from synapse.panel.providers import ollama_provider as op
+    p = _make_panel()
+    real = op.OllamaProvider.available_models
+
+    def down(timeout=1.0):
+        raise OSError("CRUCIBLE: daemon down")
+
+    op.OllamaProvider.available_models = staticmethod(down)
+    try:
+        menu = QtWidgets.QMenu()
+        sub = menu.addMenu("Ollama")
+        p._fill_author_submenu(sub, "ollama")          # initial fill
+        got1 = [a.text() for a in sub.actions() if not a.isSeparator()]
+        p._fill_author_submenu(sub, "ollama")          # the aboutToShow refresh
+        got2 = [a.text() for a in sub.actions() if not a.isSeparator()]
+    finally:
+        op.OllamaProvider.available_models = real
+    want = [lbl for _, lbl in reg.models_for("ollama")]
+    assert got1[: len(want)] == want, "registry rows must lead when the daemon is down"
+    assert got1 == got2, "the refresh must be stable, not shrink or raise"
 
 
 def test_stop_gated_to_working_state():


### PR DESCRIPTION
## Summary

**Panel v9 — "in Houdini's skin."** The Pentagram-practice type pass, built by the PANEL RELAY (cartographer → spec → forge in four gated slices → adversarial crucible). Design record + ratified decisions: `.claude/design/panel_v9_comp.html`.

- **Type system**: bundled Space Grotesk / Space Mono (OFL, already vendored) via `QFontDatabase` with a flagged native-family fallback; per-role tracking via `QFont.setLetterSpacing` (eyebrow/brand/label/data/display/lede).
- **Tokens**: comp greys land only as seeded-pipeline fallback inputs — the text ramp stays contrast-SOLVED (A3 sweep green); new HAIR + soft status hues; `TEXT_ON_ACCENT`.
- **Rail**: the author token is now the engine+model menu (`_author_menu_items`; the ENGINE pill bar leaves the chrome, all five engines stay reachable + observable — audit invariants moved in lockstep); tokens-only meter (empty until a real usage seam — never estimates); ⌘K hint chip.
- **Underline DIRECT/WORK tabs**; Direct face (you-quote, signed node chip, 132px composer with embedded SEND — fixes a pre-existing roomy-multiline failure); Work face (3px cook bar with reduced-motion static mode, 21px verdict at 360 measure, 64px-key credit grid, soft status dots, acts row); 440/492px reading measures in wide docks.

## Verification

- Every FORGE slice gated: hython `audit_panel.py --strict` exit 0 ×4 + targeted suites.
- **CRUCIBLE adversarial pass: zero production breaks** — headless stdlib fallback, font-bundle-missing (G3 still exit 0 on native fallback), stub-leak gauntlet in both collection orders, double cold-Qt audit, reduced-motion, 380px/280×400/1400px geometry, unconfigured-Custom surfaces Configure (no silent Claude floor), Ollama-down degradation, malformed-settings reopen ×4. +3 new test pins.
- Full stock suite: **3,971 passed, 0 failed**.

## Owed / notes

- G2 live eyeball + pane close/reopen reload on the next Houdini session (hython-offscreen was the only lawful gate).
- Min-pane SEND clearance is 4px — the audit gates it, but anything added below the composer clips SEND first.
- Deliberately out of scope (cartographer hazard map): meter usage seam (`providers/` slice), `.pypanel` help CDATA refresh (HARNESS tier), rail row-2 / context-ribbon retirement, muted status hues for GROW/ERROR/FIRE — each an owner call.

Base is `feat/h22-release-train`; retargets to `master` when PR #38 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
