### PR TITLE
feat(harness): loop upgrades — completion ledger, ratification surface, phantom guardrail

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -19,6 +19,7 @@ export HYTHON="/path/to/Houdini 21.x/bin/hython"   # Windows: ...\bin\hython.exe
 bun run harness/run.ts            # grinds Phase 0 (incl. 0.8/0.9 against the mock MCP)
 bun run harness/run.ts --dry      # plan only — see the queue + gates, spawn nothing
 bun run harness/run.ts --task 0.8 # one task
+bun run harness/run.ts --force    # re-run tasks the completion ledger (done.json) already banked
 ```
 
 **On drop (Mode B, mid-July):** install H22, read the three numbers, then write the trigger:
@@ -34,11 +35,14 @@ bun run harness/run.ts            # probe fires, delta becomes the worklist, loo
 `fresh Generator (WIP=1) → checks.py (hython · doctor · ledger · render · probe · MCP) →
 deterministic guardrail gate → adversarial Evaluator → PASS or repair-ticket → loop`, capped
 at `MAX_ROUNDS` (default 3) before a task is flagged for you. Passing features wait in
-worktrees for **your** merge.
+worktrees for **your** merge. Two facts the arrow compresses: a task already banked in
+`done.json` (refs byte-identical) is **skipped** before generation, and a guardrail `ok:false`
+short-circuits to a repair ticket **before** the Evaluator runs.
 
 ## Guardrails (boundary non-goals — run every sprint)
 `checks.py` runs the `guardrails` set on **every** task in addition to its own `verify` list:
-`scout_no_apex_corpus`, `no_rigging_drift`, `provenance_not_bypassed`. A guardrail with
+`scout_no_apex_corpus`, `no_rigging_drift`, `provenance_not_bypassed`, and `phantom_clean` (no
+newly-introduced phantom `hou.*` API in the sprint's changed `.py`, dir()-symbol-table-gated). A guardrail with
 `ok:false` is a **deterministic FAIL** — run.ts writes a repair ticket and loops *before*
 the Evaluator is called. A guardrail with `ok:null` ("not wired yet") only **warns**. This is
 how `SYNAPSE_H22_BOUNDARY.md §8` stays true no matter what any Generator round does.
@@ -48,16 +52,23 @@ how `SYNAPSE_H22_BOUNDARY.md §8` stays true no matter what any Generator round 
 2. **The drop trigger** — install H22, read Python/USD/PySide, write `drop.json`.
 3. **Merge to main** — harness commits in worktrees only.
 
+The harness also adds one **read-only** touchpoint that is *not* a gate: at run end it surfaces
+flywheel candidates awaiting ratification — each `ratified:false` cycle with its evidence and the
+exact `harness/state/flywheel_queue.json` line to flip. It never writes `ratified` itself; the flip
+is yours, but nothing blocks on it.
+
 ## Files
 | path | role |
 |---|---|
-| `harness/run.ts` | orchestrator — gate loop, guardrail short-circuit, worktree routing, Mode A/B switch |
+| `harness/run.ts` | orchestrator — gate loop, guardrail short-circuit, completion-ledger skip, ratification surface, worktree routing, Mode A/B switch |
 | `harness/tasks.json` | machine source of truth (sync with the checklist — that's task 0.3); holds `guardrails` |
 | `harness/prompts/generator.md` | fresh-instance builder, WIP=1 |
 | `harness/prompts/evaluator.md` | adversarial Houdini TD — the keystone; 5 rubrics incl. boundary |
 | `harness/verify/checks.py` | deterministic checks (the Playwright analog) + MCP checks + guardrails |
 | `harness/state/manifest.schema.json` | verdict / repair-ticket contract (incl. `boundary` score) |
 | `harness/state/claude-progress.md` | state continuity the Generator reads each boot |
+| `harness/state/done.json` | completion ledger — per-task PASS + refs-hash; skips already-banked work on re-run (runtime state, untracked) |
+| `harness/state/flywheel_queue.json` | flywheel cycle candidates; a human flips `ratified`, the harness only surfaces them read-only |
 | `.claude/settings.json` | pre-approved tool allowlist + format hook |
 | `docs/SYNAPSE_H22_BOUNDARY.md` | the boundary doc this harness enforces (the "why") |
 | `docs/SYNAPSE_H22_PROVIDER_APEX.md` | provider-registration spec — what 0.8/2.7 implement |

--- a/harness/run.ts
+++ b/harness/run.ts
@@ -31,6 +31,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
 import { resolve, join } from "node:path";
+import { createHash } from "node:crypto";
 
 // ---------- config ----------
 const REPO = process.cwd();
@@ -43,6 +44,7 @@ const WORKTREE_DIR = process.env.WORKTREE_DIR ?? ".claude/worktrees";
 const args = process.argv.slice(2);
 const DRY = args.includes("--dry");
 const ONLY = args.includes("--task") ? args[args.indexOf("--task") + 1] : null;
+const FORCE = args.includes("--force");   // re-run tasks the completion ledger marks done
 
 const GEN_PROMPT = readFileSync(join(REPO, "harness/prompts/generator.md"), "utf8");
 const EVAL_PROMPT = readFileSync(join(REPO, "harness/prompts/evaluator.md"), "utf8");
@@ -57,6 +59,7 @@ const head = (s: string) => log(`\n${c.sig}━━ ${s}${c.off}`);
 // ---------- mode ----------
 const DROP = join(REPO, "harness/state/drop.json");
 const MODE: "A" | "B" = existsSync(DROP) ? "B" : "A";
+const DONE = join(REPO, "harness/state/done.json");   // completion ledger (runtime state, like drop.json — not tracked)
 
 // ---------- helpers ----------
 function sh(cmd: string, cmdArgs: string[], cwd = REPO) {
@@ -198,6 +201,70 @@ function appendProgress(line: string) {
   writeFileSync(PROGRESS, `${readFileSync(PROGRESS, "utf8")}\n- ${stamp} · ${line}`);
 }
 
+// ---------- completion ledger (Upgrade 1: monotonic progress + resume) ----------
+// The loop had no memory of what passed — a re-run re-did the whole queue, and a kill
+// lost the campaign. This records each PASS keyed by a hash of the task's `refs` source.
+// A task is skipped on re-run only if it passed AND its refs are byte-identical to pass
+// time; editing a ref (or merging its worktree, which changes main) re-arms it. Nothing
+// but PASS is ever recorded — BLOCKED/GATED must surface every run. --force / --task override.
+type DoneRec = { verdict: string; refs_hash: string; commit: string; ts: string };
+function loadDone(): Record<string, DoneRec> {
+  if (!existsSync(DONE)) return {};
+  try { return JSON.parse(readFileSync(DONE, "utf8")); } catch { return {}; }
+}
+const doneLog: Record<string, DoneRec> = loadDone();
+
+// Hash the refs' contents. A ref may be a not-yet-created file or a directory; when it is
+// a readable file we fold its bytes in, else only its path — best-effort skip, never a gate.
+function refsHash(task: any): string {
+  const h = createHash("sha256");
+  for (const ref of (task.refs ?? [])) {
+    h.update(String(ref) + "\0");
+    try { const p = join(REPO, ref); if (existsSync(p)) h.update(readFileSync(p)); } catch {}
+  }
+  return h.digest("hex").slice(0, 16);
+}
+function isDone(task: any): boolean {
+  const rec = doneLog[task.id];
+  return !!rec && rec.verdict === "PASS" && rec.refs_hash === refsHash(task);
+}
+function recordDone(task: any, wt: string) {
+  if (DRY) return;
+  let commit = "";
+  try { const r = sh("git", ["rev-parse", "HEAD"], wt); if (r.status === 0) commit = (r.stdout || "").trim().slice(0, 12); } catch {}
+  doneLog[task.id] = { verdict: "PASS", refs_hash: refsHash(task), commit, ts: new Date().toISOString().slice(0, 19) + "Z" };
+  try { writeFileSync(DONE, JSON.stringify(doneLog, null, 2) + "\n"); } catch {}
+}
+
+// ---------- ratification surface (Upgrade 2: the flywheel's missing seam) ----------
+// run.ts never opened flywheel_queue.json before, so ratified:false candidates sat dormant.
+// This surfaces them at run end with evidence + the exact line to flip — the human's whole
+// interaction is one boolean. STRICTLY READ-ONLY: the harness reads `ratified`, never writes
+// it (the anti-runaway anchor, spec-U1-wiring-flywheel.md). Evidence-free ⇒ flagged INVALID.
+function surfaceRatification() {
+  const QUEUE = join(REPO, "harness/state/flywheel_queue.json");
+  if (!existsSync(QUEUE)) return;
+  let raw = "", data: any;
+  try { raw = readFileSync(QUEUE, "utf8"); data = JSON.parse(raw); } catch { return; }
+  const pending = (data.cycles ?? []).filter((cy: any) => cy.ratified === false);
+  if (!pending.length) return;
+  const lines = raw.split("\n");
+  head("ratification pending — flywheel candidates (a human flips ratified, never the harness)");
+  for (const cyc of pending) {
+    const idLine = lines.findIndex((l: string) => l.includes('"id"') && l.includes(`"${cyc.id}"`));
+    let ratLine = -1;
+    for (let i = idLine; i >= 0 && i < lines.length; i++) { if (/"ratified"\s*:\s*false/.test(lines[i])) { ratLine = i + 1; break; } }
+    const ev = cyc.evidence ?? [];
+    const invalid = ev.length === 0;
+    log(`  ${invalid ? c.bad : c.sig}${cyc.id}${c.off}  ${cyc.title ?? ""}`);
+    log(`     ${c.dim}status:${c.off} ${cyc.status ?? "?"}    ${c.dim}evidence:${c.off} ${invalid ? `${c.bad}NONE — INVALID candidate (evidence-free; reject at review)${c.off}` : `${ev.length} artifact(s)`}`);
+    if (!invalid) for (const e of ev) log(`        ${c.dim}· ${e}${c.off}`);
+    log(ratLine > 0
+      ? `     ${c.warn}→ to arm: set ratified:true at harness/state/flywheel_queue.json:${ratLine}${c.off}`
+      : `     ${c.warn}→ to arm: set this cycle's "ratified" to true in harness/state/flywheel_queue.json${c.off}`);
+  }
+}
+
 // ---------- the loop ----------
 function runTask(task: any): "PASS" | "BLOCKED" | "GATED" {
   // human gate — never auto-handled
@@ -250,7 +317,7 @@ function runTask(task: any): "PASS" | "BLOCKED" | "GATED" {
     const s = verdict.scores ?? {};
     log(`  evaluator → ${verdict.gate_status === "PASS" ? c.ok : c.bad}${verdict.gate_status}${c.off} ${c.dim}${Object.entries(s).map(([k, v]) => `${k}:${v}`).join(" ")}${c.off}`);
 
-    if (verdict.gate_status === "PASS") { appendProgress(`${task.id} PASS — ${task.title}`); return "PASS"; }
+    if (verdict.gate_status === "PASS") { appendProgress(`${task.id} PASS — ${task.title}`); recordDone(task, wt); return "PASS"; }
     writeTicket(wt, verdict.remediation_manifest ?? []);
   }
 
@@ -271,6 +338,11 @@ if (ONLY) queue = queue.filter((t: any) => t.id === ONLY);
 const result: Record<string, string> = {};
 for (const task of queue) {            // WIP = 1 — strictly sequential
   head(`${task.id} · ${task.title}`);
+  if (!ONLY && !FORCE && isDone(task)) {   // completion ledger — skip work already banked
+    log(`  ${c.dim}✓ already passed (refs unchanged) — skipping. --force re-runs.${c.off}`);
+    result[task.id] = "SKIP";
+    continue;
+  }
   result[task.id] = runTask(task);
 }
 
@@ -279,8 +351,13 @@ head("summary");
 const passed = Object.entries(result).filter(([, v]) => v === "PASS").map(([k]) => k);
 const blocked = Object.entries(result).filter(([, v]) => v === "BLOCKED").map(([k]) => k);
 const gated = Object.entries(result).filter(([, v]) => v === "GATED").map(([k]) => k);
-log(`  ${c.ok}PASS ${passed.length}${c.off}  ${c.bad}BLOCKED ${blocked.length}${c.off}  ${c.warn}GATED ${gated.length}${c.off}`);
+const skipped = Object.entries(result).filter(([, v]) => v === "SKIP").map(([k]) => k);
+log(`  ${c.ok}PASS ${passed.length}${c.off}  ${c.bad}BLOCKED ${blocked.length}${c.off}  ${c.warn}GATED ${gated.length}${c.off}  ${c.dim}SKIP ${skipped.length}${c.off}`);
 if (passed.length) log(`  ${c.dim}passing in worktrees, awaiting YOUR merge: ${passed.join(", ")}${c.off}`);
 if (blocked.length) log(`  ${c.warn}needs a human: ${blocked.join(", ")}${c.off}`);
 if (gated.length) log(`  ${c.warn}human-gated (decision required): ${gated.join(", ")}${c.off}`);
+if (skipped.length) log(`  ${c.dim}already banked (completion ledger): ${skipped.join(", ")}${c.off}`);
+
+// Upgrade 2 — surface flywheel candidates awaiting human ratification (read-only)
+surfaceRatification();
 log("");

--- a/harness/run.ts
+++ b/harness/run.ts
@@ -29,7 +29,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync, statSync, renameSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { createHash } from "node:crypto";
 
@@ -226,14 +226,18 @@ function refsHash(task: any): string {
 }
 function isDone(task: any): boolean {
   const rec = doneLog[task.id];
-  return !!rec && rec.verdict === "PASS" && rec.refs_hash === refsHash(task);
+  if (!rec || rec.verdict !== "PASS" || rec.refs_hash !== refsHash(task)) return false;
+  // Only honor a skip when the hash folded REAL file bytes. A task with no refs, or only
+  // directory/missing refs, hashes to a near-constant and would otherwise bank forever.
+  return (task.refs ?? []).some((r: string) => { try { return statSync(join(REPO, r)).isFile(); } catch { return false; } });
 }
 function recordDone(task: any, wt: string) {
   if (DRY) return;
   let commit = "";
   try { const r = sh("git", ["rev-parse", "HEAD"], wt); if (r.status === 0) commit = (r.stdout || "").trim().slice(0, 12); } catch {}
   doneLog[task.id] = { verdict: "PASS", refs_hash: refsHash(task), commit, ts: new Date().toISOString().slice(0, 19) + "Z" };
-  try { writeFileSync(DONE, JSON.stringify(doneLog, null, 2) + "\n"); } catch {}
+  // atomic: a kill mid-write must not truncate done.json (loadDone would then wipe the ledger).
+  try { writeFileSync(DONE + ".tmp", JSON.stringify(doneLog, null, 2) + "\n"); renameSync(DONE + ".tmp", DONE); } catch {}
 }
 
 // ---------- ratification surface (Upgrade 2: the flywheel's missing seam) ----------
@@ -246,15 +250,20 @@ function surfaceRatification() {
   if (!existsSync(QUEUE)) return;
   let raw = "", data: any;
   try { raw = readFileSync(QUEUE, "utf8"); data = JSON.parse(raw); } catch { return; }
-  const pending = (data.cycles ?? []).filter((cy: any) => cy.ratified === false);
+  const cycles = Array.isArray(data.cycles) ? data.cycles : [];
+  const pending = cycles.filter((cy: any) => cy && typeof cy === "object" && cy.ratified === false);
   if (!pending.length) return;
   const lines = raw.split("\n");
   head("ratification pending — flywheel candidates (a human flips ratified, never the harness)");
   for (const cyc of pending) {
     const idLine = lines.findIndex((l: string) => l.includes('"id"') && l.includes(`"${cyc.id}"`));
+    // bound the forward scan to THIS cycle's object — stop before the next cycle's id line, so a
+    // reversed field order or an adjacent cycle can't make us borrow the wrong ratified line.
+    let stop = lines.length;
+    for (let i = idLine + 1; i < lines.length; i++) { if (/"id"\s*:/.test(lines[i])) { stop = i; break; } }
     let ratLine = -1;
-    for (let i = idLine; i >= 0 && i < lines.length; i++) { if (/"ratified"\s*:\s*false/.test(lines[i])) { ratLine = i + 1; break; } }
-    const ev = cyc.evidence ?? [];
+    for (let i = idLine; i >= 0 && i < stop; i++) { if (/"ratified"\s*:\s*false/.test(lines[i])) { ratLine = i + 1; break; } }
+    const ev = Array.isArray(cyc.evidence) ? cyc.evidence : [];
     const invalid = ev.length === 0;
     log(`  ${invalid ? c.bad : c.sig}${cyc.id}${c.off}  ${cyc.title ?? ""}`);
     log(`     ${c.dim}status:${c.off} ${cyc.status ?? "?"}    ${c.dim}evidence:${c.off} ${invalid ? `${c.bad}NONE — INVALID candidate (evidence-free; reject at review)${c.off}` : `${ev.length} artifact(s)`}`);

--- a/harness/state/claude-progress.md
+++ b/harness/state/claude-progress.md
@@ -15,7 +15,9 @@ H21, so drop day is **verification, not surgery**.
 
 ## THE THREE HUMAN GATES — never auto-handle these
 1. **`0.1` architecture: sidecar vs abi3.** *Recommended: **sidecar*** (brain in its own
-   pinned interpreter, immune to H22's Python). Undecided until you commit it. The harness
+   pinned interpreter, immune to H22's Python). Bounded pick now, not a survival cliff — IPC
+   measured a non-discriminator, cp312/cp313 wheels pre-cached, cp311 → no-op, sidecar =
+   post-release durable fix; undecided until you commit it. The harness
    verifies the property ("brain answers"), not the mechanism — either choice keeps the loop valid.
 2. **The drop trigger** (`1.1`/`1.2`): install H22, read Python · USD · PySide, write `drop.json`.
 3. **Merge to main:** the harness commits in worktrees only. Promotion is your call (tag the PR).
@@ -60,3 +62,7 @@ H21, so drop day is **verification, not surgery**.
 - 2026-06-26 21:33 · 0.7 BLOCKED after 1 rounds — needs a human — Rehearse the clean-machine install on H21- 2026-07-02 09:30 · 0.2 UNBLOCKED+DONE by human spec + release train (PR #38) — spec harness/notes/spec-0.2-api-delta-probe.md; probe chain built; Mode-A identity diff EMPTY on 21.0.671 (check_probe_clean ok=True); probe surfaced+fixed 15 product phantoms
 - 2026-07-02 09:35 · 0.8/0.9 checks flip TRUE (mcp_registered, mcp_truth_contract, scout_federates, scout_no_apex_corpus); guardrails: 0 violations, only provenance_not_bypassed unwired (0a-prime track)
 - 2026-07-02 09:50 · Mode-B REHEARSAL PASS (scratch worktree, fake drop.json w/ real H21 numbers): MODE B armed, full 1.1→3.3 queue in order; found+fixed two runbook defects — pxr.__version__ capture one-liner (real API: Usd.GetVersion(), live-verified (0,25,5)) and run.ts --dry mutating (created worktrees/branches; dry now describes, never mutates)
+- 2026-07-02 · P1 harness upgrade (ec4791a): completion ledger `harness/state/done.json` (per-task PASS + refs-hash; skips banked tasks unless a ref changed; --force/--task override) + read-only ratification surface (run.ts surfaces flywheel_queue.json `ratified:false` candidates at run end — never writes `ratified`)
+- 2026-07-02 · P2 harness upgrade (00fc953): phantom-API guardrail `check_phantom_clean` in tasks.json `guardrails.checks` (dir()-symbol-table-gated, scoped to the sprint's changed .py; ok:false ⇒ short-circuit to a repair ticket before the Evaluator, ok:null ⇒ WARN)
+- 2026-07-02 · P1/P2 hardening (44437bd) per closing adversarial pass: GUI-submodule allowlist (hou.ui/qt/… were headless-absent → false-blocked panel/host sprints); added-line precision (only introduced phantoms fail); ledger skips only real-file-ref tasks; atomic done.json; ratification array-guards
+- 2026-07-02 · P3: task 0.1 layer survival→bounded-decision + human_gate.why now cites the measured IPC/wheel-cache evidence; stays gated (sidecar-vs-abi3 is still the human's call)

--- a/harness/tasks.json
+++ b/harness/tasks.json
@@ -16,11 +16,11 @@
   },
   "tasks": [
     {
-      "id": "0.1", "phase": "prep", "mode": "A", "crit": true, "layer": "survival",
+      "id": "0.1", "phase": "prep", "mode": "A", "crit": true, "layer": "bounded-decision",
       "title": "Split the cp311 vendored seam (sidecar vs abi3)",
       "refs": ["python/synapse/__init__.py", "host/daemon.py"],
       "human_gate": { "decision": "sidecar | abi3", "recommended": "sidecar",
-        "why": "Architecture choice, not a cook. Harness prepares + verifies the bridge; you commit the direction." },
+        "why": "Bounded, evidence-backed direction — not a survival cliff. MEASURED: sidecar IPC (harness/notes/gate01_ipc_latency.py) runs p50 ~0.1-0.3ms — ~4 orders under the LLM + ~2s Houdini-cook floor, so IPC does NOT discriminate the arms. cp312/cp313 wheels are pre-cached at harness/state/wheel_cache/ (runbook docs/studio/UPGRADE.md Step 2a), so re-vendor-on-drop is cheap; if H22 ships cp311 this is a no-op. Sidecar is the durable fix, deferrable to the first post-release cycle. Harness verifies the property (brain_answers), not the mechanism; you commit the direction." },
       "verify": ["import_panel", "brain_answers"]
     },
     {

--- a/harness/tasks.json
+++ b/harness/tasks.json
@@ -7,12 +7,12 @@
     "nodes_appear", "ledger", "revert_clean", "render", "theme_ok",
     "mcp_surface_probe", "mcp_registered", "mcp_truth_contract",
     "scout_federates", "scout_no_apex_corpus", "no_rigging_drift",
-    "provenance_not_bypassed",
+    "provenance_not_bypassed", "phantom_clean",
     "connectivity_catalog_fresh", "wiring_conformance", "validator_catches_miswire"
   ],
   "guardrails": {
-    "_comment": "Run on EVERY sprint by checks.py, in addition to the task's own verify list. A guardrail with ok:false ⇒ deterministic FAIL (run.ts short-circuits before the Evaluator and writes a repair ticket). A guardrail with ok:null ⇒ not yet wired ⇒ WARN, never blocks. These enforce SYNAPSE_H22_BOUNDARY.md's non-goals so no Generator round can silently erode the moat: no APEX corpus in scout, no rigging-authoring drift, no mutation that bypasses the ledger.",
-    "checks": ["scout_no_apex_corpus", "no_rigging_drift", "provenance_not_bypassed"]
+    "_comment": "Run on EVERY sprint by checks.py, in addition to the task's own verify list. A guardrail with ok:false ⇒ deterministic FAIL (run.ts short-circuits before the Evaluator and writes a repair ticket). A guardrail with ok:null ⇒ not yet wired ⇒ WARN, never blocks. These enforce SYNAPSE_H22_BOUNDARY.md's non-goals so no Generator round can silently erode the moat: no APEX corpus in scout, no rigging-authoring drift, no mutation that bypasses the ledger, and no newly-introduced phantom hou.* API (dir()-symbol-table-gated).",
+    "checks": ["scout_no_apex_corpus", "no_rigging_drift", "provenance_not_bypassed", "phantom_clean"]
   },
   "tasks": [
     {

--- a/harness/verify/checks.py
+++ b/harness/verify/checks.py
@@ -324,6 +324,96 @@ def check_provenance_not_bypassed(ctx):
     # the sandbox sentinel (runtime, Mode B).
     return {"ok": None, "detail": "ADAPT: wire the provenance-gateway manifest or the runtime ledger-grew sentinel. Warn-only until then."}
 
+# ---------- phantom guardrail (Upgrade 3 / P2): the orphaned gate, wired into the loop ----------
+# forge_evaluator_gate.py::gate_phantom scanned a fixed file list and was never called by the
+# loop. This is the live-loop form: a deterministic guardrail that fails a sprint which
+# INTRODUCES a phantom hou.* API — SYNAPSE's #1 failure class (hou.pdg / hou.secure /
+# hou.lopNetworks / hou.updateGraphTick). Authority is the introspected dir() symbol table
+# (the Spike-2.5 lesson: membership by the table, NEVER a hardcoded denylist — that demotion
+# drove false-phantom 0.667 -> 0). AST-based, so comments / docstrings / string-literals are
+# inherently ignored (a phantom named in prose is a Constant node, never an Attribute).
+
+def _hou_phantoms_in_source(src, table_syms):
+    """[(lineno, "hou.<attr>"), ...] for hou-module attribute accesses the table PROVES absent.
+    Depth-1 hou.<attr> ONLY: the table enumerates every top-level name of `hou` via dir(), so
+    absence there is proof; deeper access (hou.Class.method) is not table-complete, so unknown
+    != phantom (the inner hou.Class is judged + covered; the outer has an Attribute value and is
+    skipped). `import hou as X` aliases resolve to the canonical hou.<attr>."""
+    import ast  # local, mirrors check_version_single_source's local `import re`
+    tree = ast.parse(src)  # SyntaxError on a broken file — the caller handles it
+    hou_names = {"hou"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "hou":
+                    hou_names.add(alias.asname or "hou")
+    hits = []
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name)
+                and node.value.id in hou_names):
+            symbol = "hou." + node.attr
+            if symbol not in table_syms:
+                hits.append((node.lineno, symbol))
+    return hits
+
+def check_phantom_clean(ctx):
+    # Cross-cutting guardrail (tasks.json guardrails.checks): ok:False ⇒ run.ts short-circuits to
+    # a repair ticket BEFORE the Evaluator. Table missing/stale/gate-down ⇒ ok:None (WARN, never
+    # a false block). Scoped to the sprint's CHANGED .py (git diff vs the branch fork point).
+    wt = ctx["wt"]
+    # 1) membership authority — reuse scout's own loader (per-major path + blake2b integrity +
+    #    host-version staleness, for free; pure-python, zero-hou). None ⇒ gate down ⇒ WARN.
+    try:
+        from synapse.cognitive.tools.scout import _load_symbol_table
+    except Exception as e:
+        return {"ok": None, "detail": f"scout unavailable; phantom gate down: {type(e).__name__}: {e}"[:300]}
+    table_syms, status = _load_symbol_table()
+    if table_syms is None:
+        return {"ok": None, "detail": f"symbol table missing/stale; phantom gate down: {status.get('reason')}"[:300]}
+    if "hou" not in table_syms:
+        return {"ok": None, "detail": "symbol table lacks the hou surface — cannot prove hou.* absence "
+                                      "(regenerate via host/introspect_runtime.py)"}
+    # 2) scope to CHANGED .py — base = master HEAD at worktree-add time (fork point, robust if
+    #    master advanced). Single-arg `git diff <base>` = base vs WORKING TREE (committed + staged
+    #    + unstaged in one shot); ls-files --others adds new .py the Generator never `git add`ed.
+    base_rc, base_out, base_err = sh(["git", "merge-base", "master", "HEAD"], cwd=wt)
+    base = base_out.strip()
+    if base_rc != 0 or not base:
+        return {"ok": None, "detail": f"cannot determine diff base (git merge-base failed): "
+                                      f"{(base_err or base_out).strip()[:200]}"}
+    _, d_out, _ = sh(["git", "diff", "--name-only", "--diff-filter=d", base, "--", "*.py"], cwd=wt)
+    _, u_out, _ = sh(["git", "ls-files", "--others", "--exclude-standard", "--", "*.py"], cwd=wt)
+    touched = sorted({ln.strip() for ln in (d_out + "\n" + u_out).splitlines()
+                      if ln.strip().endswith(".py")})
+    if not touched:
+        return {"ok": True, "detail": "no changed .py files in this sprint"}
+    # 3) AST-scan each changed file for table-proven-absent hou.<attr> accesses.
+    offenders, unparseable = [], []
+    for rel in touched:
+        f = Path(wt) / rel
+        if not f.is_file():
+            continue  # rename/deletion artifact, or a path outside the tree
+        try:
+            src = f.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            continue
+        try:
+            hits = _hou_phantoms_in_source(src, table_syms)
+        except SyntaxError:
+            unparseable.append(rel)  # a broken file fails other checks anyway — don't crash the gate
+            continue
+        for lineno, symbol in hits:
+            offenders.append(f"{rel}:{lineno}:{symbol}")
+    ver = status.get("houdini_version", "?")
+    if offenders:
+        note = f" (+{len(unparseable)} unparseable, skipped)" if unparseable else ""
+        return {"ok": False, "detail": (f"phantom hou.* introduced (absent in the {ver} symbol "
+                f"table): {', '.join(sorted(set(offenders))[:12])}{note}")[:500]}
+    clean = f"{len(touched)} changed .py clean of table-proven phantom hou.* APIs (vs {len(table_syms)} live symbols @ {ver})"
+    if unparseable:
+        clean += f" ({len(unparseable)} unparseable, skipped)"
+    return {"ok": True, "detail": clean[:500]}
+
 def check_scout_federates(ctx):
     # D-H22-2: scout returns APEX results tagged as sourced from the federated MCP provider,
     # and exists_in_runtime remains present + authoritative on every hit.
@@ -455,6 +545,7 @@ DISPATCH = {
     # v2 — guardrails
     "scout_no_apex_corpus": check_scout_no_apex_corpus, "no_rigging_drift": check_no_rigging_drift,
     "provenance_not_bypassed": check_provenance_not_bypassed,
+    "phantom_clean": check_phantom_clean,
     # U.1 — utility flywheel: network-wiring truth
     "connectivity_catalog_fresh": check_connectivity_catalog_fresh,
     "wiring_conformance": check_wiring_conformance,

--- a/harness/verify/checks.py
+++ b/harness/verify/checks.py
@@ -333,6 +333,12 @@ def check_provenance_not_bypassed(ctx):
 # drove false-phantom 0.667 -> 0). AST-based, so comments / docstrings / string-literals are
 # inherently ignored (a phantom named in prose is a Constant node, never an Attribute).
 
+# GUI-only top-level hou submodules that a HEADLESS dir() introspection can't see (Houdini
+# doesn't load them without a UI), yet are real, documented, and used across panel/host code —
+# absence from the headless table is an introspection artifact, NOT a phantom, so union them in.
+_GUI_HOU_ABSENT_HEADLESS = {"hou.ui", "hou.qt", "hou.audio", "hou.desktop", "hou.viewportVisualizers"}
+
+
 def _hou_phantoms_in_source(src, table_syms):
     """[(lineno, "hou.<attr>"), ...] for hou-module attribute accesses the table PROVES absent.
     Depth-1 hou.<attr> ONLY: the table enumerates every top-level name of `hou` via dir(), so
@@ -356,6 +362,38 @@ def _hou_phantoms_in_source(src, table_syms):
                 hits.append((node.lineno, symbol))
     return hits
 
+def _sprint_added_py(wt, base):
+    """{relpath: set(added_line_no) | None} for .py touched since <base> — None marks a new
+    untracked file (whole file is new). `git diff --unified=0` gives exact added line numbers
+    (committed + staged + unstaged); ls-files --others adds files the Generator never `git add`ed.
+    Judging only ADDED lines is what makes the gate fail *introduced* phantoms, not pre-existing
+    ones on an unchanged line of a merely-edited file."""
+    import re
+    added = {}
+    _, diff, _ = sh(["git", "diff", "--unified=0", "--diff-filter=d", base, "--", "*.py"], cwd=wt)
+    cur, newline = None, 0
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            cur = line[6:].strip()
+            cur = cur if cur.endswith(".py") else None
+        elif line.startswith("@@"):
+            m = re.search(r"\+(\d+)", line)
+            newline = int(m.group(1)) if m else 0
+        elif line.startswith("+") and not line.startswith("+++"):
+            if cur:
+                added.setdefault(cur, set()).add(newline)
+            newline += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            pass  # deletions don't advance the new-file line counter
+        else:
+            newline += 1
+    _, u_out, _ = sh(["git", "ls-files", "--others", "--exclude-standard", "--", "*.py"], cwd=wt)
+    for ln in u_out.splitlines():
+        rel = ln.strip()
+        if rel.endswith(".py"):
+            added[rel] = None
+    return added
+
 def check_phantom_clean(ctx):
     # Cross-cutting guardrail (tasks.json guardrails.checks): ok:False ⇒ run.ts short-circuits to
     # a repair ticket BEFORE the Evaluator. Table missing/stale/gate-down ⇒ ok:None (WARN, never
@@ -373,23 +411,23 @@ def check_phantom_clean(ctx):
     if "hou" not in table_syms:
         return {"ok": None, "detail": "symbol table lacks the hou surface — cannot prove hou.* absence "
                                       "(regenerate via host/introspect_runtime.py)"}
-    # 2) scope to CHANGED .py — base = master HEAD at worktree-add time (fork point, robust if
-    #    master advanced). Single-arg `git diff <base>` = base vs WORKING TREE (committed + staged
-    #    + unstaged in one shot); ls-files --others adds new .py the Generator never `git add`ed.
+    # GUI-only submodules (hou.ui/qt/audio/…) are real but absent from a HEADLESS dir() table —
+    # union them so a live panel/host sprint isn't false-flagged into a stall.
+    table_syms = table_syms | _GUI_HOU_ABSENT_HEADLESS
+    # 2) scope to the sprint's ADDED .py lines — base = master HEAD at worktree-add time (fork
+    #    point, robust if master advanced). Judging only newly-authored lines means a pre-existing
+    #    phantom on an unchanged line of a merely-edited file never blocks the sprint.
     base_rc, base_out, base_err = sh(["git", "merge-base", "master", "HEAD"], cwd=wt)
     base = base_out.strip()
     if base_rc != 0 or not base:
         return {"ok": None, "detail": f"cannot determine diff base (git merge-base failed): "
                                       f"{(base_err or base_out).strip()[:200]}"}
-    _, d_out, _ = sh(["git", "diff", "--name-only", "--diff-filter=d", base, "--", "*.py"], cwd=wt)
-    _, u_out, _ = sh(["git", "ls-files", "--others", "--exclude-standard", "--", "*.py"], cwd=wt)
-    touched = sorted({ln.strip() for ln in (d_out + "\n" + u_out).splitlines()
-                      if ln.strip().endswith(".py")})
-    if not touched:
-        return {"ok": True, "detail": "no changed .py files in this sprint"}
-    # 3) AST-scan each changed file for table-proven-absent hou.<attr> accesses.
+    added = _sprint_added_py(wt, base)  # {relpath: set(added_lines) | None (=whole new file)}
+    if not added:
+        return {"ok": True, "detail": "no changed .py lines in this sprint"}
+    # 3) AST-scan each changed file; flag table-proven-absent hou.<attr> only on ADDED lines.
     offenders, unparseable = [], []
-    for rel in touched:
+    for rel, addl in added.items():
         f = Path(wt) / rel
         if not f.is_file():
             continue  # rename/deletion artifact, or a path outside the tree
@@ -403,7 +441,8 @@ def check_phantom_clean(ctx):
             unparseable.append(rel)  # a broken file fails other checks anyway — don't crash the gate
             continue
         for lineno, symbol in hits:
-            offenders.append(f"{rel}:{lineno}:{symbol}")
+            if addl is None or lineno in addl:
+                offenders.append(f"{rel}:{lineno}:{symbol}")
     ver = status.get("houdini_version", "?")
     if offenders:
         note = f" (+{len(unparseable)} unparseable, skipped)" if unparseable else ""

--- a/tests/test_phantom_guardrail.py
+++ b/tests/test_phantom_guardrail.py
@@ -1,0 +1,58 @@
+"""Pins the P2 phantom guardrail's core AST logic (harness/verify/checks.py::
+_hou_phantoms_in_source). The harness verify layer isn't a package, so load it by path.
+Authority in production is scout's dir() symbol table; here we pass a tiny fake surface so
+the matrix is hermetic (no hou, no scout, no git)."""
+import importlib.util
+import pathlib
+
+_CHECKS = pathlib.Path(__file__).resolve().parents[1] / "harness" / "verify" / "checks.py"
+_spec = importlib.util.spec_from_file_location("harness_checks", _CHECKS)
+checks = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(checks)
+
+# A stand-in 'live surface': these hou.* exist; anything else (hou.lopNetworks, hou.pdg,
+# hou.secure, hou.updateGraphTick) is absent ⇒ phantom.
+TABLE = {"hou", "hou.node", "hou.LopNode", "hou.hipFile", "hou.pwd"}
+
+
+def _syms(src):
+    return [s for _, s in checks._hou_phantoms_in_source(src, TABLE)]
+
+
+def test_flags_real_phantom_attribute():
+    assert "hou.lopNetworks" in _syms("import hou\nx = hou.lopNetworks()\n")
+
+
+def test_reports_line_number():
+    hits = checks._hou_phantoms_in_source("import hou\n\nhou.secure.foo()\n", TABLE)
+    assert (3, "hou.secure") in hits
+
+
+def test_ignores_phantom_in_string_and_docstring():
+    assert _syms('"""never call hou.lopNetworks()"""\nx = "hou.pdg"\n') == []
+
+
+def test_ignores_phantom_in_comment():
+    assert _syms("import hou\nn = hou.node('a')  # do not use hou.secure\n") == []
+
+
+def test_resolves_import_alias():
+    assert "hou.updateGraphTick" in _syms("import hou as h\nh.updateGraphTick()\n")
+
+
+def test_real_symbol_not_flagged():
+    assert _syms("import hou\nn = hou.node('/obj')\nc = hou.pwd()\n") == []
+
+
+def test_depth2_member_not_flagged():
+    # hou.LopNode is present (covered); .fakeMethod is depth-2, not table-complete → unknown != phantom.
+    assert _syms("import hou\nhou.LopNode.fakeMethod()\n") == []
+
+
+def test_attribute_named_hou_on_other_object_not_flagged():
+    # self.hou.lopNetworks(): value of the outer Attribute is an Attribute, not Name('hou').
+    assert _syms("self.hou.lopNetworks()\n") == []
+
+
+def test_clean_file_is_empty():
+    assert _syms("import hou\nfor i in range(3):\n    print(hou.node(str(i)))\n") == []

--- a/tests/test_phantom_guardrail.py
+++ b/tests/test_phantom_guardrail.py
@@ -56,3 +56,14 @@ def test_attribute_named_hou_on_other_object_not_flagged():
 
 def test_clean_file_is_empty():
     assert _syms("import hou\nfor i in range(3):\n    print(hou.node(str(i)))\n") == []
+
+
+def test_gui_submodules_allowlisted():
+    # hou.ui/qt/audio/desktop/viewportVisualizers are real but absent from a HEADLESS dir() table;
+    # check_phantom_clean unions them in. Simulate that union and confirm they're not flagged.
+    gui = checks._GUI_HOU_ABSENT_HEADLESS
+    assert {"hou.ui", "hou.qt"} <= gui
+    tbl = TABLE | gui
+    assert checks._hou_phantoms_in_source("import hou\nhou.ui.displayMessage('x')\nx = hou.qt.mainWindow()\n", tbl) == []
+    # a genuine phantom still trips even with the allowlist in place
+    assert ("hou.lopNetworks" in [s for _, s in checks._hou_phantoms_in_source("hou.lopNetworks()\n", tbl)])


### PR DESCRIPTION
## Summary

Folds the fifth-synthesis corrections into the **existing** autonomous H22 harness (`harness/run.ts` + `harness/verify/checks.py`) rather than rebuilding it — the request ("long-running, low human-in-the-loop") already describes the live loop. Three additive upgrades; **none crosses a human gate** (no merge, no self-ratify, no auto-decided architecture).

## P1 — completion ledger + ratification surface (`ec4791a`)

- **Completion ledger** (`harness/state/done.json`, untracked runtime state like `drop.json`): the loop now banks each PASS keyed by a sha256 of the task's `refs`; re-runs skip unchanged banked tasks; `--force`/`--task` override; a ref change or a merged worktree re-arms. Makes long runs monotonic + resumable after a kill.
- **Ratification surface**: run-end reads `flywheel_queue.json` and surfaces every `ratified:false` candidate (U.2–U.4) with its evidence and the exact line to flip. **Strictly read-only** — the harness reads the flag, never writes it (the anti-runaway anchor).

## P2 — phantom-API guardrail (`00fc953`)

Ports the orphaned `forge_evaluator_gate.py::gate_phantom` (never called by the loop) into a live deterministic guardrail. `check_phantom_clean` AST-scans the sprint's changed `.py` for `hou.<attr>` accesses that the introspected `dir()` symbol table *proves* absent — membership authority, not a hardcoded denylist (the Spike-2.5 lesson: false-phantom 0.667 → 0). Registered in `tasks.json` `guardrails.checks`, so `run.ts` short-circuits to a repair ticket **before** the Evaluator. AST ⇒ comments/strings/docstrings ignored for free; resolves `import hou as X`; depth-1 only; table missing/stale ⇒ `ok:None` WARN (self-disarms on an H22 build until an `h22_symbol_table.json` exists).

## P3 — ABI re-tag (follow-up commit on this branch)

Re-weights task `0.1` from `layer:"survival"` to a bounded decision per the now-*measured* evidence (IPC latency is a non-discriminator; cp312/cp313 wheels pre-cached). It **stays human-gated** — sidecar-vs-abi3 remains the operator's architecture call; only the framing/urgency is corrected.

## Verification

- **P1**: `--dry` + a seeded-ledger test (skip / `--force` / re-arm).
- **P2**: 9-case AST unit matrix (`tests/test_phantom_guardrail.py`) + end-to-end against the real 33,255-symbol table (flags a scratch `hou.lopNetworks`, ignores `hou.node` / string / comment decoys; `guardrail_violations` wiring confirmed).
- **Closing pass**: full `pytest tests/` + an adversarial review of all three upgrades (results in a PR comment).

## Not in scope — the human gates

Merge to `main`, the **sidecar-vs-abi3** decision, and **flywheel ratification** of U.2–U.4 all remain the operator's calls, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a rerun-friendly completion tracking flow so already successful tasks can be skipped when nothing relevant has changed.
  * Added a command-line override to force tasks to run again.
  * Added clearer end-of-run guidance for manual review, including which items still need ratification.

* **Bug Fixes**
  * Improved validation to catch invalid Houdini API references that are not part of the allowed surface.
  * Updated summaries to include skipped items alongside other run outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->