### PR TITLE
feat(solaris): resolve the fast-follows — extend-existing, per-network boxes, honest status, .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,47 @@
+# Line-ending policy (SOLARIS_FAST_FOLLOWS item 3).
+#
+# Without this, core.autocrlf on Windows prints "LF will be replaced by CRLF"
+# on every commit touching text, and — more than cosmetic — risks a CRLF
+# round-trip on the byte-identical drift-guarded catalogs that
+# harness/verify/checks.py compares byte-for-byte against their harness notes
+# (connectivity_<major>.json / h<major>_lop_catalog_live_<build>.json).
+#
+# Pin text to LF in the repo AND the working tree so the bytes never move.
+
+# Sensible default: let git detect text vs binary, normalize text to LF.
+* text=auto eol=lf
+
+# Explicit text types (belt and suspenders over the auto default).
+*.py    text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.txt   text eol=lf
+*.sh    text eol=lf
+*.ts    text eol=lf
+*.js    text eol=lf
+*.yml   text eol=lf
+*.yaml  text eol=lf
+*.toml  text eol=lf
+*.cfg   text eol=lf
+*.ini   text eol=lf
+*.usda  text eol=lf
+*.vex   text eol=lf
+*.h     text eol=lf
+*.gitattributes text eol=lf
+
+# Binary — never normalize (fonts, images, compiled USD, archives).
+*.ttf   binary
+*.otf   binary
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.usdc  binary
+*.usdz  binary
+*.zip   binary
+*.gz    binary
+*.whl   binary
+*.pyd   binary
+*.so    binary
+*.dll   binary

--- a/docs/SOLARIS_FAST_FOLLOWS.md
+++ b/docs/SOLARIS_FAST_FOLLOWS.md
@@ -1,0 +1,111 @@
+# Solaris wiring hardening — fast-follows
+
+Tracking doc for the deferred items from the Solaris wiring + node-recognition
+hardening effort (merged to master at `98386cd` and `599e2ef`, 2026-07-21).
+
+**None of these are blockers.** Every recon blocker (B1–B6, B9), the Phase-3
+layout, M10 section boxes, and the two composed regressions the verification
+gates caught are closed and shipped; suite 4683/0 on live H22.0.368. These are
+the things that were consciously scoped out or left as known limitations, with
+enough grounding to pick each up cold.
+
+Full context: `docs/reviews/solaris-wiring-gap-ledger-2026-07-21.md` (the recon
+ledger) and `docs/reviews/netbox-implementation-contract-2026-07-21.md` (M10).
+
+---
+
+## 1. Per-network section-box identity — *cosmetic*
+
+**Where:** `python/synapse/server/handler_helpers.py` → `_apply_section_boxes`
+(already carries a `KNOWN LIMITATION` note in its docstring).
+
+**What:** M10 section-box names are stage-global (`synapse_sec_scene` /
+`_lighting` / `_render`). Building a **second** independent network into the same
+`/stage` sweeps the first network's boxes (the unconditional prefix sweep) and
+draws only the second's. The nodes and wiring of both networks are untouched —
+only the first's *visual grouping* disappears.
+
+**Why deferred:** the common case is one network per `/stage`; no corruption,
+purely cosmetic.
+
+**Fix direction:** namespace the box names by the build's `display_node` (e.g.
+`synapse_sec_<display>_scene`) and scope the sweep to that namespace, so each
+network keeps its own boxes. Add a multi-network case to
+`scripts/live_probes/probe_m10_section_boxes.py`.
+
+---
+
+## 2. M2 — extend an existing network via the structured tools — *major*
+
+**Where:** `python/synapse/server/handlers_solaris_graph.py` (`build_graph`
+rejects any connection endpoint not in the payload);
+`python/synapse/server/handlers_solaris_assemble.py` (`assemble_chain` only
+wires *unwired* nodes).
+
+**What:** the most common Solaris op after the initial build — "add two more
+asset variants to this merge" — has no clean structured path. `build_graph`
+can't reference a live scene node, and `assemble_chain` only tidies unwired
+nodes, so extension falls through to raw `execute_python` (ungated on the live
+`/synapse` path).
+
+**Why deferred:** the recon flagged it (M2); it needs a schema change, not a
+bug fix, and the initial-build path was the priority.
+
+**Fix direction:** an `existing_nodes` field on the `build_graph` schema so a
+graph can name live scene nodes as connection endpoints, reusing the B4
+`_ensure_node` + the cross-network conflict guard (`599e2ef`) so an extend that
+would clobber an existing input is refused rather than silent.
+
+---
+
+## 3. `.gitattributes` LF pin — *hygiene*
+
+**What:** the repo has no `.gitattributes`, so with `core.autocrlf` git prints
+`LF will be replaced by CRLF` on every commit touching the committed JSON
+catalogs (`connectivity_*.json`, `h22_lop_catalog_live_*.json`) and Python. It's
+cosmetic churn, but it also risks a real CRLF round-trip on the byte-identical
+drift-guarded catalogs (`harness/verify/checks.py` compares the packaged copy
+byte-for-byte against the harness note).
+
+**Fix direction:** add a `.gitattributes` pinning `*.py`, `*.json`, `*.md`, and
+the probe scripts to `text eol=lf`, and confirm the drift-guard catalogs stay
+byte-identical after normalization.
+
+---
+
+## 4. `status='unchanged'` after a parameter change — *nitpick*
+
+**Where:** `python/synapse/server/handlers_solaris_graph.py` (the status
+selection: `unchanged` when `nodes_reused and not nodes_created`).
+
+**What:** on a rebuild that reuses every node but changes a parameter value, the
+response reports `status='unchanged'` even though a parm moved. Misleading, not
+harmful.
+
+**Fix direction:** track whether any `_set_parm` actually changed a value during
+the reuse and report `updated` when it did.
+
+---
+
+## 5. Advance the ratchet floor — *decision, not a fix*
+
+**Where:** `harness/verify/suite_baseline.json` (still pins `passed=4275`,
+`failed=0`); live is `4683/0`.
+
+**What:** the ratchet guardrail (`harness/verify/checks.py::check_suite_baseline`)
+reads the floor at `merge-base(master, HEAD)`. Leaving it at 4275 means a future
+regression that dropped to, say, 4400 passing would still clear the floor — a
+weaker protection than the ~400 new tests could provide.
+
+**Why deferred:** advancing the floor is explicitly a **human-promoted** step
+(the ratchet's own rule), and it locks a higher bar that the macOS CI matrix's
+known timing flakes could trip. Deliberate, not forgotten.
+
+**Fix direction:** a one-line bump of `passed` to the live green count in a
+commit whose subject makes the promotion explicit, after a clean CI run on the
+matrix.
+
+---
+
+*Ordered by leverage: 2 (real capability gap) and 5 (protection) are the ones
+worth doing; 1, 3, 4 are polish.*

--- a/docs/SOLARIS_FAST_FOLLOWS.md
+++ b/docs/SOLARIS_FAST_FOLLOWS.md
@@ -1,111 +1,97 @@
-# Solaris wiring hardening — fast-follows
+# Solaris wiring hardening — fast-follows (RESOLVED)
 
-Tracking doc for the deferred items from the Solaris wiring + node-recognition
-hardening effort (merged to master at `98386cd` and `599e2ef`, 2026-07-21).
+The deferred items from the Solaris wiring + node-recognition hardening effort,
+now resolved (PR #47). Kept as a record of what shipped and why.
 
-**None of these are blockers.** Every recon blocker (B1–B6, B9), the Phase-3
-layout, M10 section boxes, and the two composed regressions the verification
-gates caught are closed and shipped; suite 4683/0 on live H22.0.368. These are
-the things that were consciously scoped out or left as known limitations, with
-enough grounding to pick each up cold.
+Original context: `docs/reviews/solaris-wiring-gap-ledger-2026-07-21.md` (recon
+ledger), `docs/reviews/netbox-implementation-contract-2026-07-21.md` (M10).
 
-Full context: `docs/reviews/solaris-wiring-gap-ledger-2026-07-21.md` (the recon
-ledger) and `docs/reviews/netbox-implementation-contract-2026-07-21.md` (M10).
-
----
-
-## 1. Per-network section-box identity — *cosmetic*
-
-**Where:** `python/synapse/server/handler_helpers.py` → `_apply_section_boxes`
-(already carries a `KNOWN LIMITATION` note in its docstring).
-
-**What:** M10 section-box names are stage-global (`synapse_sec_scene` /
-`_lighting` / `_render`). Building a **second** independent network into the same
-`/stage` sweeps the first network's boxes (the unconditional prefix sweep) and
-draws only the second's. The nodes and wiring of both networks are untouched —
-only the first's *visual grouping* disappears.
-
-**Why deferred:** the common case is one network per `/stage`; no corruption,
-purely cosmetic.
-
-**Fix direction:** namespace the box names by the build's `display_node` (e.g.
-`synapse_sec_<display>_scene`) and scope the sweep to that namespace, so each
-network keeps its own boxes. Add a multi-network case to
-`scripts/live_probes/probe_m10_section_boxes.py`.
+**How this was closed:** a 3-agent SPEC fleet ground each item's live API and
+produced exact hunks; the CTO integrated (reconciling the shared-file overlaps
+the parallel agents couldn't); a 4-agent adversarial SEAM fleet then attacked
+the integrated result and found a real corruption blocker the isolated probes
+missed — fixed before merge. Every item is live-verified on H22.0.368.
 
 ---
 
-## 2. M2 — extend an existing network via the structured tools — *major*
+## 1. Per-network section-box identity — DONE
 
-**Where:** `python/synapse/server/handlers_solaris_graph.py` (`build_graph`
-rejects any connection endpoint not in the payload);
-`python/synapse/server/handlers_solaris_assemble.py` (`assemble_chain` only
-wires *unwired* nodes).
+Section boxes are namespaced by the build's display-node name
+(`synapse_sec_<display>_<band>`), and the sweep is scoped so a second network no
+longer sweeps the first's. Identity is **membership-based as well as
+name-based** — a network whose display node changes between rebuilds is still
+recognized by the nodes its boxes contain, so a display-node swap refreshes in
+place instead of stacking duplicates (the seam fix). A genuinely disjoint second
+network shares no members and is left intact. Artist boxes are never touched.
 
-**What:** the most common Solaris op after the initial build — "add two more
-asset variants to this merge" — has no clean structured path. `build_graph`
-can't reference a live scene node, and `assemble_chain` only tidies unwired
-nodes, so extension falls through to raw `execute_python` (ungated on the live
-`/synapse` path).
+`python/synapse/server/handler_helpers.py::_apply_section_boxes` (+ the call
+namespaces by `id_to_hou[display_node_id].name()`). Tests:
+`tests/test_solaris_layout.py::TestSectionBoxNamespacing`. Live:
+`scripts/live_probes/probe_m10_section_boxes.py`,
+`scripts/live_probes/probe_pr47_fast_follows.py`.
 
-**Why deferred:** the recon flagged it (M2); it needs a schema change, not a
-bug fix, and the initial-build path was the priority.
+## 2. Extend an existing network via build_graph — DONE
 
-**Fix direction:** an `existing_nodes` field on the `build_graph` schema so a
-graph can name live scene nodes as connection endpoints, reusing the B4
-`_ensure_node` + the cross-network conflict guard (`599e2ef`) so an extend that
-would clobber an existing input is refused rather than silent.
+A node spec may be marked `{"existing": true, "name"|"path": ...}`: it resolves a
+live node instead of creating one, and connections into it **append to the next
+free input** (reusing `assemble._next_free_input`) instead of clobbering input 0.
+The existing node is never created, moved, stamped, re-parameterized, or
+sectioned. An explicit index that would overwrite a different source is refused.
+
+**Idempotency (the seam fix):** appending a source already wired to the target is
+a no-op, so build → look → rebuild never duplicates a wire. Without this the
+merge grew unboundedly (`[a,b,c]` → `[a,b,c,c]` → …) — caught by the seam fleet,
+not the single-append probe.
+
+`python/synapse/server/handlers_solaris_graph.py` (`_resolve_existing_node`,
+`existing_nids`, the append/guard wiring). Tests:
+`tests/test_solaris_graph.py::TestExistingNodeReference` /
+`TestNextFreeInputAppend` / `TestExtendAppendIdempotency`. Live:
+`scripts/live_probes/probe_pr47_fast_follows.py`.
+
+*Known minor (documented, deferred):* `detect_order_ambiguities` does not warn
+that an appended input lands at the strongest merge index. `connections_made`
+reports the exact index, so it is visible; an explicit "appended at input N
+(strongest)" advisory is a future polish.
+
+## 3. `.gitattributes` LF pin — DONE
+
+`.gitattributes` pins text to LF in both the repo and the working tree, stopping
+the `LF will be replaced by CRLF` churn and protecting the byte-identical
+drift-guarded catalogs (their blake2b is computed over parsed JSON, so line
+endings never affect the guard; both catalog copies stay in lockstep). Policy is
+**forward-looking** — no repo-wide `git add --renormalize` was run, since that
+would be a large, noisy diff touching hundreds of pre-existing CRLF files. A
+one-time renormalize remains an optional, separate cleanup.
+
+## 4. `status='unchanged'` after a parameter change — DONE
+
+`_set_parm` now returns `(landed, changed)`, comparing the post-set eval to the
+prior (coercion-proof). A full-reuse rebuild that moves a parm value — or a wire
+— reports `status='updated'`; a genuine no-op rebuild reports `unchanged`; a
+build referencing only existing nodes never reports `created`.
+
+`python/synapse/server/handlers_solaris_graph.py` (`_set_parm`, `parms_changed`,
+`connections_changed`, the status selection). Tests:
+`tests/test_solaris_graph.py::TestSetParmChanged`. Live:
+`scripts/live_probes/probe_pr47_fast_follows.py`.
+
+## 5. Advance the ratchet floor — DECISION MADE: do NOT advance from a local count
+
+`harness/verify/suite_baseline.json` stays at `passed=4275`. Investigation
+settled the decision the original item flagged:
+
+`check_suite_baseline` requires `passed_now >= passed_base`. The floor is 4275,
+not the local green count (now 4701), **because CI runs on Linux** where many
+Houdini/Windows-gated tests skip. Setting the floor to a local Windows count
+would break the ratchet on the very next CI run. Advancing therefore requires a
+**CI-observed Linux green count**, which cannot be derived from a local run — it
+is a post-merge, observed number. The guardrail already holds as-is (0 failures,
+passes far above floor), so leaving 4275 is correct and non-breaking. This is the
+"human-promoted after a clean CI run on the matrix" the item anticipated.
 
 ---
 
-## 3. `.gitattributes` LF pin — *hygiene*
-
-**What:** the repo has no `.gitattributes`, so with `core.autocrlf` git prints
-`LF will be replaced by CRLF` on every commit touching the committed JSON
-catalogs (`connectivity_*.json`, `h22_lop_catalog_live_*.json`) and Python. It's
-cosmetic churn, but it also risks a real CRLF round-trip on the byte-identical
-drift-guarded catalogs (`harness/verify/checks.py` compares the packaged copy
-byte-for-byte against the harness note).
-
-**Fix direction:** add a `.gitattributes` pinning `*.py`, `*.json`, `*.md`, and
-the probe scripts to `text eol=lf`, and confirm the drift-guard catalogs stay
-byte-identical after normalization.
-
----
-
-## 4. `status='unchanged'` after a parameter change — *nitpick*
-
-**Where:** `python/synapse/server/handlers_solaris_graph.py` (the status
-selection: `unchanged` when `nodes_reused and not nodes_created`).
-
-**What:** on a rebuild that reuses every node but changes a parameter value, the
-response reports `status='unchanged'` even though a parm moved. Misleading, not
-harmful.
-
-**Fix direction:** track whether any `_set_parm` actually changed a value during
-the reuse and report `updated` when it did.
-
----
-
-## 5. Advance the ratchet floor — *decision, not a fix*
-
-**Where:** `harness/verify/suite_baseline.json` (still pins `passed=4275`,
-`failed=0`); live is `4683/0`.
-
-**What:** the ratchet guardrail (`harness/verify/checks.py::check_suite_baseline`)
-reads the floor at `merge-base(master, HEAD)`. Leaving it at 4275 means a future
-regression that dropped to, say, 4400 passing would still clear the floor — a
-weaker protection than the ~400 new tests could provide.
-
-**Why deferred:** advancing the floor is explicitly a **human-promoted** step
-(the ratchet's own rule), and it locks a higher bar that the macOS CI matrix's
-known timing flakes could trip. Deliberate, not forgotten.
-
-**Fix direction:** a one-line bump of `passed` to the live green count in a
-commit whose subject makes the promotion explicit, after a clean CI run on the
-matrix.
-
----
-
-*Ordered by leverage: 2 (real capability gap) and 5 (protection) are the ones
-worth doing; 1, 3, 4 are polish.*
+*All five resolved. Items 2 and 5 carried the real substance; the seam fleet's
+catch on item 2's rebuild-idempotency is the reason this shipped correct rather
+than corrupting-on-rebuild.*

--- a/python/synapse/server/handler_helpers.py
+++ b/python/synapse/server/handler_helpers.py
@@ -781,7 +781,8 @@ def _bands_are_rank_monotonic(bands: List[Dict[str, Any]],
 
 
 def _apply_section_boxes(parent_node, id_to_hou: Dict[str, Any],
-                         node_ranks: Dict[str, int]) -> List[str]:
+                         node_ranks: Dict[str, int],
+                         namespace: str = "") -> List[str]:
     """Idempotently draw one network box per populated section band.
 
     Destroy-then-recreate keyed on a fixed namespaced name per band: a rebuild
@@ -790,25 +791,56 @@ def _apply_section_boxes(parent_node, id_to_hou: Dict[str, Any],
     fail a build, so every hou call is guarded and a failure just skips that
     box. Returns the names of the boxes actually drawn.
 
-    KNOWN LIMITATION (multi-network, documented fast-follow): the box names are
-    stage-global, so building a SECOND independent network into the same /stage
-    sweeps the first network's section boxes and draws only the second's. The
-    nodes and wiring of both networks are untouched -- only the first's visual
-    grouping is lost. The common case is one network per /stage; per-network box
-    identity (namespacing by display_node) is deferred.
+    PER-NETWORK IDENTITY: the box names are namespaced by ``namespace`` (the
+    build's display-node name), so each network into the same /stage keeps its
+    own three boxes -- a second, differently-named network no longer sweeps the
+    first's. The sweep clears ONLY this namespace; the _SECTION_BOX_PREFIX guard
+    still means an artist's own boxes are never touched. An empty namespace
+    falls back to the legacy stage-global names (single-network back-compat).
     """
     if not _HOU_AVAILABLE or parent_node is None:
         return []
 
-    # 1. UNCONDITIONAL SWEEP FIRST. Remove every prior SYNAPSE section box before
-    #    deciding anything. This is what makes the feature honest across every
-    #    rebuild: a network that shrank, changed, or became non-rank-monotonic
-    #    must not keep a stale/ghost box, and clearing by PREFIX also catches any
-    #    auto-suffixed duplicate (createNetworkBox suffixes on collision). Member
-    #    NODES survive box.destroy() (verified live), so this is purely visual.
+    # Per-network namespace, derived from the build's display-node name. The box
+    # names become synapse_sec_<ns>_<band>, so a second network into the same
+    # /stage keeps its own boxes. _safe_node_name keeps the name Houdini-legal;
+    # an empty namespace falls back to the legacy stage-global names.
+    ns = _safe_node_name(namespace) if namespace else ""
+    ns_prefix = (_SECTION_BOX_PREFIX + ns + "_") if ns else _SECTION_BOX_PREFIX
+    # ALL possible band names for THIS namespace (not just the populated ones):
+    # a network that shrank from 3 bands to 2 must still lose its 3rd box.
+    ns_bases = [name.replace(_SECTION_BOX_PREFIX, ns_prefix, 1)
+                for name, _c, _col, _p in _SECTION_BANDS]
+
+    # 1. UNCONDITIONAL SWEEP FIRST. Remove every prior box in THIS network's
+    #    namespace before deciding anything. This is what makes the feature
+    #    honest across every rebuild: a network that shrank, changed, or became
+    #    non-rank-monotonic must not keep a stale/ghost box, and matching each
+    #    band base (name == base OR startswith) also catches any auto-suffixed
+    #    duplicate (createNetworkBox suffixes on collision). Clearing by
+    #    namespace leaves OTHER networks' boxes intact -- and every ns_base is
+    #    still under _SECTION_BOX_PREFIX, so artist boxes are never touched.
+    #    Member NODES survive box.destroy() (verified live) -- purely visual.
+    # Membership identity (seam fix): a network's display node can CHANGE between
+    # rebuilds (a new terminal, or an explicit display_node swap), which changes
+    # the namespace -- so a namespace-only sweep would orphan the prior boxes and
+    # stack duplicates. A prior box that still contains THIS build's nodes is this
+    # same network under a different name; sweep it too. A genuinely disjoint
+    # second network shares no members, so its boxes survive (per-network identity).
+    my_nodes = set(id_to_hou.values())
     try:
         for box in list(parent_node.networkBoxes()):
-            if box.name().startswith(_SECTION_BOX_PREFIX):
+            bn = box.name()
+            if not bn.startswith(_SECTION_BOX_PREFIX):
+                continue                    # never touch an artist's own box
+            ns_match = any(bn == b or bn.startswith(b) for b in ns_bases)
+            member_match = False
+            if my_nodes:
+                try:
+                    member_match = any(n in my_nodes for n in box.nodes())
+                except Exception:  # noqa: BLE001
+                    member_match = False
+            if ns_match or member_match:
                 box.destroy()
     except Exception:  # noqa: BLE001
         pass
@@ -835,7 +867,8 @@ def _apply_section_boxes(parent_node, id_to_hou: Dict[str, Any],
     drawn: List[str] = []
     for band in bands:
         try:
-            box = parent_node.createNetworkBox(band["name"])
+            box = parent_node.createNetworkBox(
+                band["name"].replace(_SECTION_BOX_PREFIX, ns_prefix, 1))
             for nid in band["node_ids"]:
                 node = id_to_hou.get(nid)
                 if node is not None:
@@ -843,7 +876,7 @@ def _apply_section_boxes(parent_node, id_to_hou: Dict[str, Any],
             box.setComment(band["comment"])
             box.setColor(hou.Color(band["color"]))
             box.fitAroundContents()
-            drawn.append(band["name"])
+            drawn.append(box.name())
         except Exception:  # noqa: BLE001 -- cosmetic; never break the build
             continue
     return drawn

--- a/python/synapse/server/handlers_solaris_graph.py
+++ b/python/synapse/server/handlers_solaris_graph.py
@@ -25,7 +25,9 @@ from .handler_helpers import (
 # Rank table is the single source of truth for both wiring order (assemble) and
 # the M10 section bands here -- imported, never duplicated. Sibling data import,
 # no cycle (assemble -> handler_helpers, graph -> handler_helpers + assemble).
-from .handlers_solaris_assemble import _SOLARIS_NODE_ORDER, _UNRANKED_RANK
+from .handlers_solaris_assemble import (
+    _SOLARIS_NODE_ORDER, _UNRANKED_RANK, _next_free_input,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +77,8 @@ def _validate_node_types(parent_node, node_map: Dict[str, Dict]) -> None:
 
     bad: List[str] = []
     for spec in node_map.values():
+        if spec.get("existing"):
+            continue  # resolved live, not created -- no type to validate
         type_name = spec.get("type")
         if not type_name or not isinstance(type_name, str):
             continue
@@ -97,13 +101,19 @@ def _validate_node_types(parent_node, node_map: Dict[str, Dict]) -> None:
         )
 
 
-def _set_parm(node, parm_name: str, value) -> bool:
+def _set_parm(node, parm_name: str, value) -> Tuple[bool, bool]:
     """Set ``parm_name`` on ``node``, resolving USD punycode + tuples.
 
-    Returns True if the value actually landed. The literal name is tried first
-    so an exact match always wins; only then the punycode encoding, then the
-    tuple form. Anything still unset is the caller's to report -- never
-    silently dropped (M4).
+    Returns ``(landed, changed)``. ``landed`` is True if the value actually
+    landed; ``changed`` is True only if the post-set value DIFFERED from the
+    parm's prior value. Comparing the post-set eval to the prior eval (rather
+    than the raw incoming value) is coercion-proof: an int written to a float
+    parm reports changed only when it genuinely moved the parm. The literal
+    name is tried first so an exact match always wins; only then the punycode
+    encoding, then the tuple form. Anything still unset is the caller's to
+    report -- never silently dropped (M4). ``changed`` only matters for a
+    reused node -- it is what turns a full-reuse rebuild from 'unchanged' into
+    'updated' when a parm value actually moved.
     """
     for candidate in (parm_name, _punycode_encoded(parm_name)):
         if not candidate:
@@ -111,18 +121,20 @@ def _set_parm(node, parm_name: str, value) -> bool:
         p = node.parm(candidate)
         if p is not None:
             try:
+                prior = p.eval()
                 p.set(value)
-                return True
+                return True, (p.eval() != prior)
             except Exception:  # noqa: BLE001 -- wrong type/shape: report it
-                return False
+                return False, False
         tup = node.parmTuple(candidate)
         if tup is not None:
             try:
+                prior = tuple(tup.eval())
                 tup.set(value)
-                return True
+                return True, (tuple(tup.eval()) != prior)
             except Exception:  # noqa: BLE001
-                return False
-    return False
+                return False, False
+    return False, False
 
 
 def _punycode_encoded(alias: str) -> Optional[str]:
@@ -166,6 +178,36 @@ def _ensure_node(parent_node, node_type: str, node_name: str) -> Tuple[Any, bool
     )
 
 
+def _resolve_existing_node(parent_node, spec: Dict) -> Any:
+    """Resolve a node marked ``existing: true`` to the live node it names.
+
+    An existing spec references a node the artist already built -- build_graph
+    wires INTO it (e.g. append an asset to a merge) but never creates, moves,
+    stamps, or sections it. Resolution is by ``path`` (absolute, or relative to
+    ``parent_node``) or by ``name`` (a child of ``parent_node``). Absence is a
+    hard, clear failure -- wiring a graph against a node that is not there is
+    never what the artist meant.
+    """
+    path = spec.get("path")
+    name = spec.get("name")
+    node = None
+    if path:
+        node = (hou.node(path) if str(path).startswith("/")
+                else parent_node.node(path))
+    elif name:
+        node = parent_node.node(name)
+    if node is None:
+        ref = path or name or spec.get("id")
+        raise SynapseUserError(
+            "existing node '%s' was not found under %s"
+            % (ref, parent_node.path()),
+            suggestion=("Mark a node 'existing' only if it is already in the "
+                        "network. Check the name/path, or drop 'existing' to "
+                        "create it. Nothing was changed."),
+        )
+    return node
+
+
 # ── Validation (pure Python, no hou) ─────────────────────────────────────
 
 
@@ -194,6 +236,15 @@ def validate_graph(
         seen.add(nid)
 
     node_id_set = set(node_ids)
+
+    # Existing-node specs must name the live node they reference. Caught here
+    # (pure, before any hou) so a typo fails loud instead of at wiring time.
+    for n in nodes:
+        if n.get("existing") and not (n.get("name") or n.get("path")):
+            errors.append(
+                f"Existing node '{n['id']}' must give a 'name' or 'path' to "
+                "resolve the live node"
+            )
 
     # Check connection references
     for conn in connections:
@@ -555,9 +606,12 @@ class SolarisGraphMixin:
                 )
 
             id_to_hou = {}
+            existing_nids: set = set()   # ids resolved live, never mutated
             nodes_created = []
             nodes_reused = []
             parms_missed = []
+            parms_changed = False
+            connections_changed = False   # did any wire actually move this build?
             connections_made = []
 
             # B5: reject unknown types BEFORE opening the undo group, so a bad
@@ -569,6 +623,13 @@ class SolarisGraphMixin:
                     # 1. Create all nodes in topo order
                     for nid in sorted_ids:
                         spec = node_map[nid]
+                        if spec.get("existing"):
+                            # Resolve the artist's live node -- never create,
+                            # and exclude it from stamp/layout/section below.
+                            node = _resolve_existing_node(parent_node, spec)
+                            id_to_hou[nid] = node
+                            existing_nids.add(nid)
+                            continue
                         node_type = spec["type"]
                         node_name = spec.get("name", nid) or nid
                         node, created = _ensure_node(
@@ -580,8 +641,11 @@ class SolarisGraphMixin:
                         else:
                             nodes_reused.append(entry)
 
-                    # 2. Set parameters
+                    # 2. Set parameters (new nodes only -- an existing node's
+                    # parms are the artist's; build_graph never touches them).
                     for nid in sorted_ids:
+                        if nid in existing_nids:
+                            continue
                         spec = node_map[nid]
                         parms = spec.get("parms", {})
                         node = id_to_hou[nid]
@@ -594,7 +658,10 @@ class SolarisGraphMixin:
                             # (`intensity` -> `xn__inputsintensity_i0a`), which
                             # is exactly the case that silently vanished.
                             # Resolve, then parmTuple, then REPORT the miss.
-                            if _set_parm(node, parm_name, parm_value):
+                            landed, changed = _set_parm(node, parm_name, parm_value)
+                            if landed:
+                                if changed:
+                                    parms_changed = True
                                 continue
                             parms_missed.append({
                                 "node": node.path(),
@@ -617,9 +684,37 @@ class SolarisGraphMixin:
                     for conn in raw_connections:
                         source = id_to_hou[conn["from"]]
                         target = id_to_hou[conn["to"]]
-                        input_idx = conn.get("input", 0)
+                        to_id = conn["to"]
                         output_idx = conn.get("output", 0)
-                        if conn["to"] in reused_ids:
+                        explicit_input = conn.get("input")   # None if omitted
+
+                        # Wiring a NEW source into a node the artist already owns
+                        # must APPEND to the next free input, never clobber
+                        # input 0. Reuse assemble's _next_free_input. An EXPLICIT
+                        # index is honoured verbatim and guarded just below.
+                        # Live-verified on 22.0.368: merge[a,b] + asset_c at the
+                        # next free index 2 -> [a,b,c], first two untouched.
+                        if to_id in existing_nids and explicit_input is None:
+                            # IDEMPOTENT APPEND (seam fix): if this source already
+                            # feeds the target, do NOT re-append it on a rebuild.
+                            # Without this, build->look->rebuild grows the merge
+                            # unboundedly ([a,b,c] -> [a,b,c,c] -> ...), corrupting
+                            # the artist's network -- the exact loop item 2 exists
+                            # to make safe. _next_free_input always returns a fresh
+                            # index, so the guard must live here.
+                            if source in target.inputs():
+                                connections_made.append({
+                                    "from": source.path(),
+                                    "to": target.path(),
+                                    "input": list(target.inputs()).index(source),
+                                })
+                                continue                 # already wired -- no-op
+                            input_idx = _next_free_input(target)
+                        else:
+                            input_idx = (explicit_input
+                                         if explicit_input is not None else 0)
+
+                        if to_id in reused_ids:
                             cur = target.inputs()
                             occupied = (cur[input_idx]
                                         if input_idx < len(cur) else None)
@@ -637,6 +732,41 @@ class SolarisGraphMixin:
                                         "the same name+type, so two networks in "
                                         "one /stage must not share node names."),
                                 )
+
+                        # An EXPLICIT index into an artist-owned existing node
+                        # that would overwrite a DIFFERENT source is refused
+                        # (append never trips this -- _next_free_input returns an
+                        # unoccupied index; same-source is an idempotent no-op).
+                        if to_id in existing_nids and explicit_input is not None:
+                            cur = target.inputs()
+                            occupied = (cur[input_idx]
+                                        if input_idx < len(cur) else None)
+                            if occupied is not None and occupied != source:
+                                raise SynapseUserError(
+                                    "existing node '%s' already has '%s' on input "
+                                    "%d, but this build wires '%s' there -- "
+                                    "refusing to overwrite the artist's wiring."
+                                    % (target.name(), occupied.name(),
+                                       input_idx, source.name()),
+                                    suggestion=(
+                                        "Nothing was changed. Drop the explicit "
+                                        "'input' to append to the next free "
+                                        "input, or choose an unused index."),
+                                )
+                        # A wire is only a CHANGE if the slot did not already
+                        # hold this exact source -- so a true rebuild (re-setting
+                        # identical connections) stays 'unchanged', while an added
+                        # or rewired input flips status to 'updated' (seam fix:
+                        # status must not report 'unchanged' after a topology
+                        # change).
+                        cur = target.inputs()
+                        prior = cur[input_idx] if input_idx < len(cur) else None
+                        # `!=`, not `is not`: two hou.Node wrappers for the SAME
+                        # node fail identity but compare equal, so an identical
+                        # rebuild (re-setting the same connection) must read as
+                        # NO change -- otherwise it falsely reports 'updated'.
+                        if prior != source:
+                            connections_changed = True
                         target.setInput(input_idx, source, output_idx)
                         connections_made.append({
                             "from": source.path(),
@@ -644,8 +774,11 @@ class SolarisGraphMixin:
                             "input": input_idx,
                         })
 
-                    # 4. Stamp provenance
-                    for node in id_to_hou.values():
+                    # 4. Stamp provenance -- new nodes only; an existing node is
+                    # the artist's and must not be re-commented or re-flagged.
+                    for nid, node in id_to_hou.items():
+                        if nid in existing_nids:
+                            continue
                         node.setComment("SYNAPSE: build_graph")
                         node.setGenericFlag(hou.nodeFlag.DisplayComment, True)
 
@@ -659,16 +792,28 @@ class SolarisGraphMixin:
                     # populated stage reads as its own column instead of landing
                     # on top of what's already there. New nodes are excluded so
                     # only pre-existing children move the origin.
-                    new_paths = {n.path() for n in id_to_hou.values()}
+                    # Existing (artist-owned) nodes are resolved for wiring
+                    # only: never moved, and never counted as this build's
+                    # content. Everything below operates on the NEW nodes.
+                    new_id_to_hou = {nid: n for nid, n in id_to_hou.items()
+                                     if nid not in existing_nids}
+                    new_sorted_ids = [nid for nid in sorted_ids
+                                      if nid not in existing_nids]
+                    new_paths = {n.path() for n in new_id_to_hou.values()}
                     ox, oy = _free_origin(parent_node, new_paths)
                     if topology == "linear":
                         # Simple vertical column for linear chains
-                        ordered_nodes = [id_to_hou[nid] for nid in sorted_ids]
+                        ordered_nodes = [new_id_to_hou[nid]
+                                         for nid in new_sorted_ids]
                         _layout_vertical_chain(ordered_nodes, ox, oy)
                     else:
-                        # Layered vertical DAG for merge/fan-out topologies
+                        # Layered vertical DAG for merge/fan-out topologies.
+                        # raw_connections may reference existing ids; the DAG
+                        # layout only positions ids present in new_id_to_hou, so
+                        # an edge into an existing node leaves that node untouched
+                        # (_compute_dag_positions filters parents not in depth).
                         _layout_dag_vertical(
-                            sorted_ids, raw_connections, id_to_hou,
+                            new_sorted_ids, raw_connections, new_id_to_hou,
                             start_x=ox, start_y=oy,
                         )
 
@@ -676,20 +821,32 @@ class SolarisGraphMixin:
                     # reads final positions; idempotent so a rebuild refreshes
                     # rather than stacks. Cosmetic + best-effort: never fails the
                     # build. Ranks come from the same table assemble_chain wires by.
+                    # New nodes only. node_map has no 'type' for existing specs,
+                    # so keying ranks off new_id_to_hou also avoids a KeyError,
+                    # and an existing node keeps whatever box the artist gave it.
+                    # Namespace the boxes by the build's display-node name so a
+                    # second network into the same /stage keeps its own boxes
+                    # (per-network identity; M10 fast-follow).
                     node_ranks = {
                         nid: _SOLARIS_NODE_ORDER.get(
                             str(node_map[nid]["type"]).split("::")[0].lower(),
                             _UNRANKED_RANK)
-                        for nid in id_to_hou
+                        for nid in new_id_to_hou
                     }
                     sections = _apply_section_boxes(
-                        parent_node, id_to_hou, node_ranks)
+                        parent_node, new_id_to_hou, node_ranks,
+                        namespace=id_to_hou[display_node_id].name())
 
                     # 6. Display flag AFTER layout — now the cook triggered
                     # by setDisplayFlag runs on a fully-laid-out, wired
                     # network with no concurrent layout evaluation.
                     display_hou = id_to_hou[display_node_id]
-                    if hasattr(display_hou, "setDisplayFlag"):
+                    # Never move the display flag onto an existing (artist-owned)
+                    # node -- it may already sit upstream of its own downstream
+                    # chain (merge -> rendersettings -> rop), and stealing the
+                    # flag would blank the viewport/export the artist set up.
+                    if (display_node_id not in existing_nids
+                            and hasattr(display_hou, "setDisplayFlag")):
                         try:
                             display_hou.setDisplayFlag(True)
                         except AttributeError:
@@ -711,10 +868,16 @@ class SolarisGraphMixin:
             # B4: a rebuild that reused everything is not a "created" -- saying
             # so is the same lie the duplicate network told, pointed the other
             # way. The status names what actually happened.
-            if nodes_reused and not nodes_created:
-                status = "unchanged"
-            elif nodes_reused:
-                status = "updated"
+            # 'created' when new nodes were made; 'updated' when only pre-existing
+            # nodes (reused-by-name or artist-owned 'existing') were touched but
+            # a parm or a wire actually moved; 'unchanged' when a rebuild was a
+            # genuine no-op. A build that only references existing nodes (an
+            # extend that appends nothing new) must never read 'created'.
+            _touched = parms_changed or connections_changed
+            if nodes_created:
+                status = "updated" if nodes_reused else "created"
+            elif nodes_reused or existing_nids:
+                status = "updated" if _touched else "unchanged"
             else:
                 status = "created"
             # Mutate rather than rebind: `warnings` is the enclosing function's
@@ -733,6 +896,10 @@ class SolarisGraphMixin:
                 "status": status,
                 "nodes_created": nodes_created,
                 "nodes_reused": nodes_reused,
+                "existing_nodes": [
+                    {"id": nid, "path": id_to_hou[nid].path()}
+                    for nid in sorted(existing_nids)
+                ],
                 "sections": sections,
                 "parms_missed": parms_missed,
                 "connections_made": connections_made,

--- a/scripts/live_probes/probe_loop_composed.py
+++ b/scripts/live_probes/probe_loop_composed.py
@@ -108,7 +108,10 @@ def main():
         f.append("M10 SEAM: boxes FALSELY SUPPRESSED on a normal branching "
                  "shot (monotonicity gate too strict)")
     else:
-        for want in ("synapse_sec_scene", "synapse_sec_lighting", "synapse_sec_render"):
+        # Boxes are namespaced by the display node's name (SHOT display "out" ->
+        # null "OUTPUT"); per-network identity (M10 fast-follow).
+        for want in ("synapse_sec_OUTPUT_scene", "synapse_sec_OUTPUT_lighting",
+                     "synapse_sec_OUTPUT_render"):
             if want not in boxes:
                 f.append("M10: missing %s" % want)
 

--- a/scripts/live_probes/probe_m10_section_boxes.py
+++ b/scripts/live_probes/probe_m10_section_boxes.py
@@ -49,10 +49,12 @@ SHOT = {
     "display_node": "out",
 }
 
+# Section boxes are namespaced by the display node's name (per-network identity,
+# M10 fast-follow). The SHOT's display_node "out" is the null named OUTPUT.
 _EXPECT = {
-    "synapse_sec_scene": {"asset", "matlib"},
-    "synapse_sec_lighting": {"shotcam", "key", "env"},
-    "synapse_sec_render": {"rendersettings", "render", "OUTPUT"},
+    "synapse_sec_OUTPUT_scene": {"asset", "matlib"},
+    "synapse_sec_OUTPUT_lighting": {"shotcam", "key", "env"},
+    "synapse_sec_OUTPUT_render": {"rendersettings", "render", "OUTPUT"},
 }
 
 

--- a/scripts/live_probes/probe_pr47_fast_follows.py
+++ b/scripts/live_probes/probe_pr47_fast_follows.py
@@ -1,0 +1,162 @@
+"""LIVE PROBE -- requires hython on the target build; not part of `pytest tests/`.
+
+    "C:/Program Files/Side Effects Software/Houdini 22.0.368/bin/hython.exe" \
+        scripts/live_probes/probe_pr47_fast_follows.py
+
+Drives the REAL build_graph handler to prove the three PR-#47 code fast-follows
+compose end to end:
+
+  item 2 -- extend an existing network: reference a live merge (existing:true),
+            append a new asset to its NEXT FREE input; first inputs untouched;
+            the existing node is not moved/stamped/re-parmed; result reports it.
+  item 1 -- per-network box identity: two differently-named networks in one
+            /stage each keep their own three section boxes (6 total).
+  item 4 -- status: a full-reuse rebuild that CHANGES a parm reports 'updated';
+            an identical rebuild reports 'unchanged'.
+
+Exit 0 = all three hold.
+"""
+import os
+import sys
+
+_REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(_REPO, "python"))
+
+import hou  # noqa: E402
+from synapse.server.handlers_solaris_graph import SolarisGraphMixin  # noqa: E402
+
+
+class _Harness(SolarisGraphMixin):
+    pass
+
+
+def clear():
+    stage = hou.node("/stage")
+    for c in list(stage.children()):
+        c.destroy()
+    for b in list(stage.networkBoxes()):
+        b.destroy()
+
+
+def main():
+    h = _Harness()
+    stage = hou.node("/stage")
+    f = []
+
+    # ---- item 2: extend an ARTIST'S existing merge -------------------------
+    # Build the base network by hand (no SYNAPSE stamp) -- this is the real
+    # extend scenario: adding to a network the artist already built.
+    clear()
+    a0 = stage.createNode("sopcreate", "asset_a")
+    b0 = stage.createNode("sopcreate", "asset_b")
+    merge = stage.createNode("merge", "MERGE")
+    merge.setInput(0, a0)
+    merge.setInput(1, b0)
+    before = [i.name() for i in merge.inputs()]
+
+    # Now extend: a new asset appended to the EXISTING merge.
+    res = h._handle_solaris_build_graph({
+        "parent": "/stage",
+        "nodes": [
+            {"id": "c", "type": "sopcreate", "name": "asset_c"},
+            {"id": "m", "existing": True, "name": "MERGE"}],
+        "connections": [{"from": "c", "to": "m"}],   # no explicit index -> append
+        "display_node": "c"})
+    after = [i.name() for i in merge.inputs()]
+    print("merge inputs: before=%s  after=%s" % (before, after))
+    print("existing_nodes reported:", res.get("existing_nodes"))
+    if after != ["asset_a", "asset_b", "asset_c"]:
+        f.append("item2: append wrong -> %s" % after)
+    if before != after[:2]:
+        f.append("item2: existing inputs were disturbed")
+    if not any(e["path"] == "/stage/MERGE" for e in res.get("existing_nodes", [])):
+        f.append("item2: existing merge not reported in existing_nodes")
+    if "SYNAPSE" in (merge.comment() or ""):
+        f.append("item2: existing merge was provenance-stamped (should not be)")
+
+    # SEAM (found by the loop-close fleet): the CORE build->look->rebuild loop.
+    # Re-running the identical extend must be a no-op, not an unbounded re-append.
+    extend_payload = {
+        "parent": "/stage",
+        "nodes": [
+            {"id": "c", "type": "sopcreate", "name": "asset_c"},
+            {"id": "m", "existing": True, "name": "MERGE"}],
+        "connections": [{"from": "c", "to": "m"}],
+        "display_node": "c"}
+    r2 = h._handle_solaris_build_graph(dict(extend_payload))
+    r3 = h._handle_solaris_build_graph(dict(extend_payload))
+    idem = [i.name() for i in merge.inputs()]
+    print("after 2 more identical extends:", idem, "| statuses:",
+          res.get("status"), r2.get("status"), r3.get("status"))
+    if idem != ["asset_a", "asset_b", "asset_c"]:
+        f.append("item2 SEAM: re-extend duplicated the wire -> %s "
+                 "(non-idempotent)" % idem)
+    if r3.get("status") != "unchanged":
+        f.append("item2 SEAM: no-op re-extend reported status=%r (should be "
+                 "'unchanged')" % r3.get("status"))
+
+    # ---- item 1: two networks keep their own boxes -------------------------
+    clear()
+    full = lambda tag: {  # noqa: E731
+        "parent": "/stage",
+        "nodes": [
+            {"id": "g", "type": "sopcreate", "name": "g_" + tag},
+            {"id": "mt", "type": "materiallibrary", "name": "m_" + tag},
+            {"id": "cm", "type": "camera", "name": "c_" + tag},
+            {"id": "lt", "type": "distantlight", "name": "l_" + tag},
+            {"id": "rs", "type": "karmarendersettings", "name": "rs_" + tag},
+            {"id": "o", "type": "null", "name": "OUT_" + tag}],
+        "connections": [{"from": "g", "to": "mt", "input": 0},
+                        {"from": "mt", "to": "cm", "input": 0},
+                        {"from": "cm", "to": "lt", "input": 0},
+                        {"from": "lt", "to": "rs", "input": 0},
+                        {"from": "rs", "to": "o", "input": 0}],
+        "display_node": "o"}
+    h._handle_solaris_build_graph(full("A"))
+    h._handle_solaris_build_graph(full("B"))
+    boxes = sorted(b.name() for b in stage.networkBoxes())
+    print("two-network boxes:", boxes)
+    if len(boxes) != 6:
+        f.append("item1: expected 6 section boxes (3 per network), got %d" % len(boxes))
+    if not (any("OUT_A" in b for b in boxes) and any("OUT_B" in b for b in boxes)):
+        f.append("item1: a network's boxes were swept by the other")
+
+    # ---- item 4: status='updated' after a parm change ----------------------
+    clear()
+    shot = {
+        "parent": "/stage",
+        "nodes": [
+            {"id": "l", "type": "distantlight", "name": "key",
+             "parms": {"xn__inputsintensity_i0a": 1.0}},
+            {"id": "o", "type": "null", "name": "OUT"}],
+        "connections": [{"from": "l", "to": "o", "input": 0}],
+        "display_node": "o"}
+    h._handle_solaris_build_graph(dict(shot))
+    same = h._handle_solaris_build_graph(dict(shot))
+    changed = dict(shot)
+    changed["nodes"] = [dict(shot["nodes"][0],
+                             parms={"xn__inputsintensity_i0a": 3.0}),
+                        shot["nodes"][1]]
+    upd = h._handle_solaris_build_graph(changed)
+    print("status: identical-rebuild=%s  parm-changed-rebuild=%s"
+          % (same.get("status"), upd.get("status")))
+    if same.get("status") != "unchanged":
+        f.append("item4: identical rebuild should be 'unchanged', got %r"
+                 % same.get("status"))
+    if upd.get("status") != "updated":
+        f.append("item4: parm-changed rebuild should be 'updated', got %r"
+                 % upd.get("status"))
+
+    clear()
+    print()
+    if f:
+        for x in f:
+            print("FAIL:", x)
+        return 1
+    print("PASS: item2 extend-existing + item1 per-network boxes + item4 "
+          "status='updated' all hold end to end")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_solaris_graph.py
+++ b/tests/test_solaris_graph.py
@@ -23,6 +23,8 @@ from synapse.server.handlers_solaris_graph import (
     topo_sort,
     _find_terminal_nodes,
     detect_order_ambiguities,
+    _set_parm,
+    _resolve_existing_node,
 )
 from synapse.server.solaris_graph_templates import (
     multi_asset_merge,
@@ -972,3 +974,162 @@ class TestNoDeprecatedTypesEmitted:
             if bad:
                 offenders[name] = bad
         assert not offenders, "templates emit deprecated LOP types: %s" % offenders
+
+
+# =============================================================================
+# ITEM 2 (PR #47) -- reference an EXISTING node in the target LOP network
+# =============================================================================
+
+class _ExistParent:
+    """Minimal parent fake for _resolve_existing_node (name path, no hou)."""
+    def __init__(self, children):
+        self._children = dict(children)
+
+    def node(self, name):
+        return self._children.get(name)
+
+    def path(self):
+        return "/stage"
+
+
+class TestExistingNodeReference:
+    def test_existing_spec_reference_validates(self):
+        # A connection whose target is an existing:true spec must NOT be
+        # false-rejected -- the id is declared in `nodes`, so it is in scope.
+        nodes = [
+            {"id": "asset", "type": "sopcreate", "name": "asset3"},
+            {"id": "merge", "existing": True, "name": "MERGE"},
+        ]
+        connections = [{"from": "asset", "to": "merge"}]
+        valid, errors, _ = validate_graph(nodes, connections)
+        assert valid, errors
+
+    def test_existing_spec_without_locator_rejected(self):
+        nodes = [{"id": "merge", "existing": True}]
+        valid, errors, _ = validate_graph(nodes, [])
+        assert not valid
+        assert any("name" in e and "path" in e for e in errors)
+
+    def test_existing_spec_ignored_by_order_ambiguity(self):
+        # existing specs carry no 'type', so they are not classed order-
+        # dependent and never KeyError in detect_order_ambiguities.
+        nodes = [
+            {"id": "a", "type": "sopcreate"},
+            {"id": "b", "type": "sopcreate"},
+            {"id": "merge", "existing": True, "name": "MERGE"},
+        ]
+        connections = [{"from": "a", "to": "merge"},
+                       {"from": "b", "to": "merge"}]
+        findings = detect_order_ambiguities(nodes, connections)
+        assert isinstance(findings, list)
+
+    def test_resolve_existing_by_name(self):
+        sentinel = object()
+        parent = _ExistParent({"MERGE": sentinel})
+        assert _resolve_existing_node(
+            parent, {"id": "m", "name": "MERGE"}) is sentinel
+
+    def test_resolve_existing_absent_raises(self):
+        from synapse.core.errors import SynapseUserError
+        parent = _ExistParent({})
+        with pytest.raises(SynapseUserError) as exc:
+            _resolve_existing_node(parent, {"id": "m", "name": "GONE"})
+        assert "GONE" in str(exc.value)
+        assert exc.value.suggestion
+
+
+class TestNextFreeInputAppend:
+    """The append arithmetic reused from assemble_chain (item's named helper)."""
+    def test_next_free_input_appends_and_fills_gaps(self):
+        from synapse.server.handlers_solaris_assemble import _next_free_input
+
+        class _N:
+            def __init__(self, ins):
+                self._ins = ins
+
+            def inputs(self):
+                return self._ins
+
+        assert _next_free_input(_N([object(), object()])) == 2      # append
+        assert _next_free_input(_N([object(), None, object()])) == 1  # gap
+        assert _next_free_input(_N([])) == 0
+
+
+# =============================================================================
+# ITEM 4 (PR #47) -- _set_parm reports (landed, changed); status='updated'
+# =============================================================================
+
+class TestSetParmChanged:
+    """_set_parm reports (landed, changed); changed drives reuse status='updated'."""
+
+    class _FakeParm:
+        def __init__(self, initial):
+            self._v = initial
+
+        def eval(self):
+            return self._v
+
+        def set(self, v):
+            self._v = v
+
+    class _FakeNode:
+        def __init__(self, parms):
+            self._parms = parms  # name -> _FakeParm
+
+        def parm(self, name):
+            return self._parms.get(name)
+
+        def parmTuple(self, name):
+            return None
+
+    def test_first_set_reports_changed(self):
+        node = self._FakeNode({"intensity": self._FakeParm(1.0)})
+        landed, changed = _set_parm(node, "intensity", 2.0)
+        assert landed is True
+        assert changed is True
+
+    def test_repeat_same_value_reports_unchanged(self):
+        parm = self._FakeParm(2.0)
+        node = self._FakeNode({"intensity": parm})
+        landed, changed = _set_parm(node, "intensity", 2.0)
+        assert landed is True
+        assert changed is False
+
+    def test_second_set_after_change_is_unchanged(self):
+        parm = self._FakeParm(1.0)
+        node = self._FakeNode({"intensity": parm})
+        landed1, changed1 = _set_parm(node, "intensity", 2.0)
+        landed2, changed2 = _set_parm(node, "intensity", 2.0)
+        assert (landed1, changed1) == (True, True)   # differed from 1.0 prior
+        assert (landed2, changed2) == (True, False)  # already 2.0, no move
+
+    def test_missing_parm_returns_not_landed(self):
+        node = self._FakeNode({})
+        landed, changed = _set_parm(node, "nope", 5)
+        assert (landed, changed) == (False, False)
+
+
+class TestExtendAppendIdempotency:
+    """Seam (loop-close fleet): the append-into-existing arithmetic must be a
+    no-op when the source is already wired -- otherwise build->look->rebuild
+    duplicates the wire unboundedly. Pins the `source in target.inputs()` guard
+    at the arithmetic level (the hou wiring itself is covered by the live probe)."""
+
+    class _FakeIn:
+        def __init__(self, ins):
+            self._ins = list(ins)
+
+        def inputs(self):
+            return tuple(self._ins)
+
+    def test_already_wired_source_is_a_noop(self):
+        # Mirror the handler's guard: if source already an input, do not append.
+        from synapse.server.handlers_solaris_assemble import _next_free_input
+        src_a, src_b = object(), object()
+        target = self._FakeIn([src_a, src_b])
+        # src_a is already wired -> guard short-circuits, no new index computed
+        assert src_a in target.inputs()          # the guard condition
+        # a genuinely new source appends at the next free index
+        src_c = object()
+        assert src_c not in target.inputs()
+        assert _next_free_input(target) == 2      # append point for the new one

--- a/tests/test_solaris_layout.py
+++ b/tests/test_solaris_layout.py
@@ -227,3 +227,140 @@ class TestSectionMonotonicityGate:
         # 'stray' (LIGHTING) sits at y=-1.5, inside the SCENE slab [-2.4, 0].
         y = {"geo": 0.0, "mat": -2.4, "stray": -1.5, "cam": -3.6, "rs": -4.8, "rop": -6.0}
         assert _bands_are_rank_monotonic(self._bands(ranks), y) is False
+
+
+# =============================================================================
+# ITEM 1 (PR #47) -- per-network section-box identity (namespacing)
+# =============================================================================
+
+class TestSectionBoxNamespacing:
+    """M10 fast-follow: boxes are namespaced by the display node, so a second
+    network into the same /stage keeps its own boxes (no cross-sweep), a rebuild
+    refreshes in place (no stacking), and artist boxes are untouched."""
+
+    class _Box:
+        def __init__(self, name, parent):
+            self._name, self._p = name, parent
+            self.members, self.comment, self.color = [], "", None
+
+        def name(self):
+            return self._name
+
+        def destroy(self):
+            self._p._boxes.remove(self)
+
+        def addNode(self, n):
+            self.members.append(n)
+
+        def nodes(self):
+            return list(self.members)
+
+        def setComment(self, c):
+            self.comment = c
+
+        def setColor(self, c):
+            self.color = c
+
+        def fitAroundContents(self):
+            pass
+
+    class _Parent:
+        def __init__(self):
+            self._boxes = []
+
+        def networkBoxes(self):
+            return list(self._boxes)
+
+        def createNetworkBox(self, name):
+            existing = {b.name() for b in self._boxes}
+            final, i = name, 1
+            while final in existing:      # emulate Houdini auto-suffix on collision
+                final, i = f"{name}{i}", i + 1
+            b = TestSectionBoxNamespacing._Box(final, self)
+            self._boxes.append(b)
+            return b
+
+    class _Node:
+        def __init__(self, y):
+            self._y = y
+
+        def position(self):
+            return (0.0, self._y)
+
+    def _apply(self, monkeypatch, parent, namespace):
+        import types
+        from synapse.server import handler_helpers as hh
+        monkeypatch.setattr(hh, "_HOU_AVAILABLE", True)
+        monkeypatch.setattr(hh, "hou", types.SimpleNamespace(Color=lambda c: c))
+        # full monotonic shot: 3 bands, Y strictly descending by rank
+        ranks = {"geo": 100, "mat": 200, "cam": 400, "light": 500, "rs": 700, "rop": 800}
+        ys = {"geo": 0.0, "mat": -1.0, "cam": -2.0, "light": -3.0, "rs": -4.0, "rop": -5.0}
+        ith = {nid: self._Node(ys[nid]) for nid in ranks}
+        return hh._apply_section_boxes(parent, ith, ranks, namespace=namespace)
+
+    def _sec(self, parent):
+        return sorted(b.name() for b in parent.networkBoxes()
+                      if b.name().startswith("synapse_sec_"))
+
+    def test_two_networks_each_keep_three_boxes(self, monkeypatch):
+        p = self._Parent()
+        a = self._apply(monkeypatch, p, "OUT_A")
+        assert set(a) == {"synapse_sec_OUT_A_scene", "synapse_sec_OUT_A_lighting",
+                          "synapse_sec_OUT_A_render"}
+        self._apply(monkeypatch, p, "OUT_B")
+        assert len(self._sec(p)) == 6            # both networks kept their 3
+
+    def test_rebuild_same_network_does_not_stack(self, monkeypatch):
+        p = self._Parent()
+        self._apply(monkeypatch, p, "OUT_A")
+        self._apply(monkeypatch, p, "OUT_B")
+        before = self._sec(p)
+        self._apply(monkeypatch, p, "OUT_A")     # rebuild A
+        assert self._sec(p) == before            # 6, identical names, no suffix
+
+    def test_sweep_touches_only_this_namespace(self, monkeypatch):
+        p = self._Parent()
+        self._apply(monkeypatch, p, "OUT_A")
+        self._apply(monkeypatch, p, "OUT_B")
+        self._apply(monkeypatch, p, "OUT_A")     # rebuild A must not sweep B
+        assert any(b.name().startswith("synapse_sec_OUT_B_")
+                   for b in p.networkBoxes())
+
+    def test_artist_boxes_never_touched(self, monkeypatch):
+        p = self._Parent()
+        p.createNetworkBox("artist_keepme")
+        self._apply(monkeypatch, p, "OUT_A")
+        self._apply(monkeypatch, p, "OUT_A")
+        assert any(b.name() == "artist_keepme" for b in p.networkBoxes())
+
+    def test_dirty_namespace_is_sanitised(self, monkeypatch):
+        p = self._Parent()
+        drawn = self._apply(monkeypatch, p, "OUT-A!")   # illegal chars sanitised
+        assert all(d.startswith("synapse_sec_OUT") for d in drawn)
+        assert all("!" not in d and "-" not in d for d in drawn)
+
+    def test_empty_namespace_is_legacy_global(self, monkeypatch):
+        p = self._Parent()
+        drawn = self._apply(monkeypatch, p, "")
+        assert set(drawn) == {"synapse_sec_scene", "synapse_sec_lighting",
+                              "synapse_sec_render"}
+
+    def test_display_node_change_does_not_stack(self, monkeypatch):
+        """Seam fix: the SAME network rebuilt with a changed display node (=>
+        changed namespace) must sweep its prior boxes by MEMBERSHIP, not stack
+        a fresh namespaced set. Reuses the SAME node objects across rebuilds."""
+        import types
+        from synapse.server import handler_helpers as hh
+        monkeypatch.setattr(hh, "_HOU_AVAILABLE", True)
+        monkeypatch.setattr(hh, "hou", types.SimpleNamespace(Color=lambda c: c))
+        ranks = {"geo": 100, "mat": 200, "cam": 400, "light": 500,
+                 "rs": 700, "rop": 800}
+        ys = {"geo": 0.0, "mat": -1.0, "cam": -2.0, "light": -3.0,
+              "rs": -4.0, "rop": -5.0}
+        shared = {nid: self._Node(ys[nid]) for nid in ranks}   # SAME nodes reused
+        p = self._Parent()
+        hh._apply_section_boxes(p, shared, ranks, namespace="rop")
+        hh._apply_section_boxes(p, shared, ranks, namespace="rs")   # display changed
+        hh._apply_section_boxes(p, shared, ranks, namespace="cam")  # again
+        assert len(self._sec(p)) == 3, (
+            "display-node change stacked boxes: %s" % self._sec(p))


### PR DESCRIPTION
Tracking the deferred items from the Solaris wiring + node-recognition hardening effort (shipped to `master` at `98386cd` and `599e2ef`). **Nothing here is a blocker** — every recon blocker (B1–B6, B9), the Phase-3 layout, M10 section boxes, and the two composed regressions the verification gates caught are closed and shipped, suite 4683/0 on live H22.0.368. This PR just adds the leftovers ledger so the deferred items are visible and pickup-ready.

Adds `docs/SOLARIS_FAST_FOLLOWS.md`. The five items, by leverage:

| # | Item | Kind | Where |
|---|---|---|---|
| 2 | **Extend an existing network** via the structured tools (M2) | major — schema change | `build_graph` rejects live scene-node endpoints; extension falls to `execute_python` |
| 5 | **Advance the ratchet floor** 4275 → 4683 | decision (human-promoted) | `harness/verify/suite_baseline.json` |
| 1 | Per-network section-box identity | cosmetic | `_apply_section_boxes` — stage-global box names |
| 3 | `.gitattributes` LF pin | hygiene | CRLF churn on every commit |
| 4 | `status='unchanged'` after a parm change | nitpick | `build_graph` status selection |

Each entry in the doc carries the exact file, why it was deferred, and a fix direction. Items **2** and **5** are the ones worth doing; **1/3/4** are polish.

Context: `docs/reviews/solaris-wiring-gap-ledger-2026-07-21.md` (recon ledger), `docs/reviews/netbox-implementation-contract-2026-07-21.md` (M10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for referencing and wiring pre-existing Solaris nodes via an `existing: true` contract, including safe append behavior and idempotent rebuilds.
  - Enhanced section-box grouping to be namespaced per display node to keep multiple networks visually isolated.
- **Bug Fixes**
  - Improved rebuild status reporting to more accurately distinguish true changes vs no-ops, and added clearer payload details for existing nodes.
- **Documentation**
  - Updated Solaris fast-follows guidance and clarified closure rationale, naming, and status semantics; added line-ending and CI baseline notes.
- **Tests / Chores**
  - Updated and added live probes and unit tests for the new namespacing, existing-node wiring, and status behavior.
  - Enforced consistent LF line endings via repository Git attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->