### PR TITLE
fix(panel): stop the chat-time Houdini UI freeze (Qt-fallback tool dispatch + context poll off main)

### DIFF
--- a/python/synapse/panel/chat_panel.py
+++ b/python/synapse/panel/chat_panel.py
@@ -819,20 +819,51 @@ class SynapseChatPanel:
 
     # -- Actions ---------------------------------------------------------
 
+    def _refresh_context_off_main(self):
+        """Refresh scene context on a short-lived daemon thread.
+
+        Thin wrapper over :func:`synapse.panel.ws_bridge.gather_context_off_main`
+        so the ``hou.*`` read takes the DEFERRED ``run_on_main`` path from off
+        the main thread (bounded, interleaved, C6-instrumented) instead of
+        Fast path 2 inline — the same fix class as the tool-call fallback
+        (6f354ae) and the same pattern ``live_metrics._collect_scene`` uses.
+
+        Fire-and-forget: the ``on_ready`` callback does only thread-safe cache
+        writes and a queued ``emit``; on timeout / busy main thread it sheds
+        silently and the stale cache is kept. The context chips are advisory.
+        """
+        if self._bridge is None or not self._bridge.connected:
+            return
+        from synapse.panel.ws_bridge import gather_context_off_main
+
+        def _on_ready(ctx):
+            import time as _time
+            self._last_context = ctx
+            self._last_context_time = _time.time() * 1000
+            try:
+                self._bridge.context_updated.emit(ctx)
+            except Exception:
+                pass
+
+        gather_context_off_main(_on_ready)
+
     def _gather_context_if_stale(self, max_age_ms=_CONTEXT_MAX_AGE_MS):
-        """Gather context only if cached data is stale."""
+        """Return cached context, refreshing off-main if stale.
+
+        Never gathers inline on the main thread — the chat send path must
+        not do ``hou.*`` work. If the cache is stale, fire-and-forget an
+        off-main refresh (the poll also does this every 10 s) and return
+        the current cache, which may be ``None`` on a cold start. The LLM
+        treats context as advisory, so slightly-stale context is fine.
+        """
         import time
         now = time.time() * 1000
-        if self._last_context_time and (now - self._last_context_time) < max_age_ms:
-            return self._last_context
-        try:
-            from synapse.panel.ws_bridge import _gather_context_on_main_thread
-            ctx = _gather_context_on_main_thread()
-            if ctx:
-                self._last_context = ctx
-                self._last_context_time = time.time() * 1000
-        except Exception:
-            pass
+        stale = not (
+            self._last_context_time
+            and (now - self._last_context_time) < max_age_ms
+        )
+        if stale:
+            self._refresh_context_off_main()
         return self._last_context
 
     def _send_message(self):
@@ -1002,15 +1033,12 @@ class SynapseChatPanel:
             self._bridge.send_command("get_session_report", {})
 
     def _poll_context(self):
-        """Periodically refresh scene context for the context chips."""
-        if self._bridge is not None and self._bridge.connected:
-            try:
-                import time as _time
-                from synapse.panel.ws_bridge import _gather_context_on_main_thread
-                ctx = _gather_context_on_main_thread()
-                if ctx:
-                    self._last_context = ctx
-                    self._last_context_time = _time.time() * 1000
-                    self._bridge.context_updated.emit(ctx)
-            except Exception:
-                pass
+        """Periodically refresh scene context for the context chips (off-main).
+
+        The QTimer slot fires on the main thread; calling the gather inline
+        here would hit run_on_main's Fast path 2 (no timeout, no
+        interleaving). ``_refresh_context_off_main`` spawns the gather on a
+        daemon thread so it takes the deferred path instead — the same fix
+        class as the tool-call fallback (6f354ae).
+        """
+        self._refresh_context_off_main()

--- a/python/synapse/panel/claude_worker.py
+++ b/python/synapse/panel/claude_worker.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import threading
 
 try:
     from PySide6.QtCore import QThread, Signal
@@ -44,6 +45,20 @@ def _wait_budget(tool_name):
         return max(_TOOL_WAIT_TIMEOUT, timeout_for(tool_name) + 5.0)
     except Exception:
         return _TOOL_WAIT_TIMEOUT
+
+
+def _spawn_off_main_tool_thread(executor, request: ToolRequest) -> None:
+    """Run ``executor.execute_tool_off_main(request)`` on a short-lived daemon
+    thread so the handler's internal ``run_on_main`` calls take the DEFERRED
+    path instead of Fast path 2 inline. Lives at module scope so it is testable
+    without constructing a full ClaudeWorker."""
+    t = threading.Thread(
+        target=executor.execute_tool_off_main,
+        args=(request,),
+        name="synapse.panel.tool.{}".format(request.tool_name),
+        daemon=True,
+    )
+    t.start()
 
 
 class ClaudeWorker(QThread):
@@ -91,6 +106,15 @@ class ClaudeWorker(QThread):
             tools if tools is not None else get_anthropic_tools_for_worker()
         )
         self._abort: bool = False
+        # Off-main ToolExecutor for the bridge-DOWN fallback. Built lazily on
+        # first use (on this worker thread) — the panel wires its own executor
+        # to the tool_requested signal for the synchronous Qt slot path, but
+        # this worker has no handle to that instance (the wiring lives in
+        # synapse_panel.py, outside this module). A dedicated executor is safe:
+        # execute_tool_off_main calls _dispatch directly (no Qt signal/slot),
+        # and handler.handle's hou.* work routes through run_on_main regardless
+        # of which ToolExecutor instance owns the handler.
+        self._offmain_executor = None
         # The engine for this turn. Defaults to the Claude floor; the panel
         # passes a selected provider for the multi-provider switch. Transport +
         # request/response translation live in the provider — the loop below is
@@ -321,14 +345,33 @@ class ClaudeWorker(QThread):
         except Exception:
             pass  # MCP unavailable — fall through to signal path
 
-        # --- Fallback: Qt signal to main-thread executor ---
+        # --- Fallback: dispatch on a daemon thread (off-main) ---
+        # The MCP path is down (try_mcp_tool_call returned None above), so the
+        # hwebserver thread is not going to run the handler for us. The OLD
+        # fallback emitted a Qt signal delivered via AutoConnection to
+        # ToolExecutor.execute_tool on the MAIN thread — which meant the entire
+        # handler (including node.render / execute_python / solaris_build_graph)
+        # ran UNINTERRUPTIBLY on the GUI thread: every internal run_on_main call
+        # hit Fast path 2 (main_thread.py:240, "caller IS main thread → fn()
+        # inline, NO timeout possible"). That is the multi-second "cannot
+        # select nodes" freeze the artist feels while chatting.
+        #
+        # Instead, run the SAME dispatch on a daemon thread. Because the daemon
+        # thread is OFF main, handler.handle's internal run_on_main calls take
+        # the DEFERRED path (hdefereval.executeDeferred + per-tool timeout,
+        # interleaved with UI events) — identical to what the MCP path does
+        # when the bridge is up. The main thread is freed for node selection /
+        # viewport / the 1s FreezeChain heartbeat. The tool_requested signal +
+        # execute_tool slot stay in place for any direct/test caller and as a
+        # fallback-of-last-resort, but the worker no longer routes through
+        # them.
         request = ToolRequest(
             tool_use_id=tool_use_id,
             tool_name=tool_name,
             tool_input=tool_input,
         )
 
-        self.tool_requested.emit(request)
+        self._dispatch_off_main(request)
 
         # Block until executor completes (or per-tool timeout — C7)
         budget = _wait_budget(tool_name)
@@ -387,6 +430,35 @@ class ClaudeWorker(QThread):
         except Exception:
             pass
         return result
+
+    # ------------------------------------------------------------------
+    # Off-main fallback dispatch (bridge-DOWN path)
+    # ------------------------------------------------------------------
+
+    def _get_offmain_executor(self):
+        """Lazily build the ToolExecutor used for the off-main fallback.
+
+        Built on the worker thread on first use. ``ToolExecutor`` subclasses
+        ``QObject``; constructing it parentless on a background thread gives it
+        this thread's affinity, which is safe here because the off-main path
+        never drives its Qt signals (``execute_tool_off_main`` skips the
+        ``preflight_warning`` emit and never touches ``tool_requested``). The
+        handler it lazy-loads routes all ``hou.*`` work through ``run_on_main``
+        regardless of which executor instance owns it.
+        """
+        if self._offmain_executor is None:
+            from .tool_executor import ToolExecutor
+            self._offmain_executor = ToolExecutor()
+        return self._offmain_executor
+
+    def _dispatch_off_main(self, request: ToolRequest) -> None:
+        """Spawn the daemon thread that runs the tool off the main thread.
+
+        Thin instance wrapper around :func:`_spawn_off_main_tool_thread` so the
+        executor is resolved via :meth:`_get_offmain_executor`.
+        """
+        executor = self._get_offmain_executor()
+        _spawn_off_main_tool_thread(executor, request)
 
     # ------------------------------------------------------------------
     # Integrity tracking (best-effort)

--- a/python/synapse/panel/tool_executor.py
+++ b/python/synapse/panel/tool_executor.py
@@ -337,13 +337,20 @@ class ToolExecutor(QtCore.QObject):
     # Pre-flight heads-up (TASK 1)
     # ------------------------------------------------------------------
 
-    def _preflight(self, request: ToolRequest) -> None:
-        """Cheap pre-flight before an inline (main-thread) dispatch.
+    def _preflight(self, request: ToolRequest, emit: bool = True) -> None:
+        """Cheap pre-flight before a tool dispatch.
 
         Estimates cost from the tool name + input shape (no round-trip). If the
         op is heavy enough to briefly freeze the Qt loop, log a warning (so the
-        freeze is attributable) and emit a non-blocking advisory the panel can
-        surface. Does NOT block or change the result — best-effort only.
+        freeze is attributable) and — when ``emit`` is True — emit a non-blocking
+        advisory the panel can surface. Does NOT block or change the result —
+        best-effort only.
+
+        ``emit=False`` is used on the off-main path: ``preflight_warning`` is a
+        Qt signal owned by a QObject whose thread affinity may not be the main
+        thread there, so emitting across threads is avoided. The
+        ``logger.warning`` is thread-safe and is always kept — it is the
+        load-bearing part.
         """
         try:
             from synapse.panel.bridge_adapter import estimate_inline_cost
@@ -356,10 +363,11 @@ class ToolExecutor(QtCore.QObject):
 
         self._last_preflight = message
         logger.warning("Pre-flight advisory — %s", message)
-        try:
-            self.preflight_warning.emit(request.tool_name, message)
-        except Exception:
-            pass  # signal surface is optional; the log is the load-bearing part
+        if emit:
+            try:
+                self.preflight_warning.emit(request.tool_name, message)
+            except Exception:
+                pass  # signal surface is optional; the log is the load-bearing part
 
     # ------------------------------------------------------------------
     # Main-thread slot
@@ -379,9 +387,40 @@ class ToolExecutor(QtCore.QObject):
                 and ``request.done`` will be signalled.
         """
         try:
+            self._dispatch(request, emit_preflight=True)
+        finally:
+            # ALWAYS signal done -- the worker thread is blocking on this
+            request.done.set()
+
+    # ------------------------------------------------------------------
+    # Pure dispatch helper (shared by the main-thread slot + the off-main path)
+    # ------------------------------------------------------------------
+
+    def _dispatch(self, request: ToolRequest, emit_preflight: bool = True) -> None:
+        """Resolve the tool, run the handler, and map the response onto the
+        request. Sets ``request.result`` OR ``request.error``. Does NOT touch
+        ``request.done`` and does NOT spawn threads — the caller owns both.
+
+        This is the exact body the historical ``execute_tool`` slot ran, pulled
+        out unchanged so it can be invoked from two threading contexts:
+
+          * ``execute_tool`` (the @Slot) — on the main thread (Qt
+            AutoConnection). ``emit_preflight=True`` so the panel advisory
+            signal fires exactly as before.
+          * ``execute_tool_off_main`` — on a daemon thread the worker spawns
+            when the MCP path is down. ``emit_preflight=False`` (the Qt signal
+            is main-thread-affined; the thread-safe ``logger.warning`` still
+            fires). Because the caller is NOT the main thread, every
+            ``run_on_main`` call inside ``handler.handle`` takes the DEFERRED
+            path (bounded, interleaved with UI events, per-tool timeout)
+            instead of Fast path 2 inline. That is the strictly-intended
+            behaviour — see module docstring lines 20-21 on why MCP (and now
+            the fallback) must not run on the main thread.
+        """
+        try:
             # 0. Pre-flight heads-up (TASK 1): cheap cost estimate; warn + emit a
-            # non-blocking advisory if this inline op may briefly freeze the loop.
-            self._preflight(request)
+            # non-blocking advisory if this op may briefly freeze the loop.
+            self._preflight(request, emit=emit_preflight)
 
             # 1. Resolve tool name to (command_type, payload_builder)
             dispatch = get_tool_dispatch(request.tool_name)
@@ -451,8 +490,36 @@ class ToolExecutor(QtCore.QObject):
             )
             request.error = f"Exception: {exc}"
 
+    # ------------------------------------------------------------------
+    # Off-main entrypoint (the bridge-DOWN fallback the worker now uses)
+    # ------------------------------------------------------------------
+
+    def execute_tool_off_main(self, request: ToolRequest) -> None:
+        """Run :meth:`_dispatch` in the CALLER's thread, then signal ``done``.
+
+        No main-thread affinity is assumed — this must be safe to call from a
+        daemon thread the worker spawns. It deliberately skips the
+        ``preflight_warning`` Qt emit (the signal's QObject may not live on the
+        main thread here; the thread-safe ``logger.warning`` inside
+        ``_preflight`` still fires). The synchronous ``execute_tool`` slot
+        contract is preserved unchanged for tests / direct callers.
+
+        The load-bearing difference from the slot path: because the caller is
+        NOT the main thread, ``run_on_main`` calls inside ``handler.handle``
+        resolve to the DEFERRED path (``hdefereval.executeDeferred`` + per-tool
+        timeout, interleaved with UI events) instead of Fast path 2 inline. The
+        main thread is freed for node selection / viewport / the 1s FreezeChain
+        heartbeat — which is the whole point of the fix. No handler, undo,
+        consent, or integrity logic is touched here; only the threading context
+        of the dispatch changes.
+        """
+        try:
+            self._dispatch(request, emit_preflight=False)
         finally:
-            # ALWAYS signal done -- the worker thread is blocking on this
+            # ALWAYS signal done -- the worker thread is blocking on this.
+            # Idempotent: a late set after the worker's wait() times out is
+            # harmless (the worker has already recorded its timeout error and
+            # will not double-dispatch).
             request.done.set()
 
 

--- a/python/synapse/panel/ws_bridge.py
+++ b/python/synapse/panel/ws_bridge.py
@@ -103,6 +103,62 @@ def _gather_context_on_main_thread():
     return context
 
 
+# Short marshal timeout for the off-main context gather. The panel polls every
+# 10s; this read (selectedNodes / paneTabs / hipFile) is advisory, never
+# load-bearing. A busy main thread (cook/render) is shed within this budget and
+# the stale cache is kept — mirroring live_metrics._SCENE_COLLECT_TIMEOUT.
+_CONTEXT_GATHER_TIMEOUT = 2.0
+
+
+def gather_context_off_main(on_ready, timeout=_CONTEXT_GATHER_TIMEOUT):
+    """Gather scene context on a daemon thread, marshalled onto the main thread.
+
+    Spawns a short-lived daemon thread that calls
+    ``run_on_main(_gather_context_on_main_thread, ...)`` from OFF the main
+    thread, so the ``hou.*`` read takes the DEFERRED path
+    (``hdefereval.executeDeferred`` + bounded timeout, interleaved with UI
+    events) rather than ``run_on_main``'s Fast path 2 (caller IS main thread →
+    ``fn()`` inline, NO timeout possible). This closes the same class of
+    inline-hou-on-main-thread freeze the tool-call fallback closed
+    (6f354ae) and mirrors ``live_metrics._collect_scene``.
+
+    Fire-and-forget: on success ``on_ready(ctx)`` is invoked on the daemon
+    thread (the caller is expected to do only thread-safe cache writes + a
+    queued ``emit``); on timeout / busy main thread it sheds silently.
+    ``record_stall=False`` / ``record_wait=False`` keep this advisory read
+    out of the stall detector and the C6 dispatch-wait histogram
+    (observe-only posture — see ``run_on_main``'s docstring).
+
+    Lives at module scope so it is testable without constructing a
+    SynapseWSBridge / ChatPanel instance (mirrors the
+    ``_spawn_off_main_tool_thread`` seam in claude_worker).
+    """
+    from synapse.server.main_thread import run_on_main
+
+    def _off_main():
+        try:
+            ctx = run_on_main(
+                _gather_context_on_main_thread,
+                timeout=timeout,
+                record_stall=False,
+                record_wait=False,
+            )
+        except Exception:
+            return  # main thread busy / timeout — shed, caller keeps stale cache
+        if ctx:
+            try:
+                on_ready(ctx)
+            except Exception:
+                logger.debug("context on_ready callback failed", exc_info=True)
+
+    t = threading.Thread(
+        target=_off_main,
+        name="synapse.panel.ctx.gather",
+        daemon=True,
+    )
+    t.start()
+
+
 # HDA Progress stages (sent during hda_package execution)
 HDA_STAGES = [
     "parsing_prompt",       # Understanding the request

--- a/tests/test_chat_panel.py
+++ b/tests/test_chat_panel.py
@@ -539,11 +539,23 @@ class TestChatDisplayNodeClick:
 
 
 class TestStaleContextGather:
-    """Test the stale-check context gathering logic."""
+    """Test the stale-check context gathering logic.
+
+    Contract after the panel freeze-hardening (follow-up #1 to 6f354ae):
+    ``_gather_context_if_stale`` NEVER gathers inline on the main thread. It
+    returns the current cache (possibly ``None`` on a cold start) and, when
+    the cache is stale, fire-and-forgets an off-main refresh via
+    ``ws_bridge.gather_context_off_main``. The async refresh updates the
+    cache for the NEXT call; the LLM treats context as advisory, so a
+    slightly-stale value is fine. These tests assert the new contract by
+    patching ``gather_context_off_main`` (not the main-thread gather, which
+    no longer runs synchronously here).
+    """
 
     def test_fresh_context_skips_gather(self):
-        """When context is fresh (<5s old), gather is not called."""
+        """When context is fresh (<5s old), no refresh is dispatched."""
         import time
+        from unittest.mock import patch
         from synapse.panel.chat_panel import SynapseChatPanel
 
         panel = SynapseChatPanel()
@@ -552,12 +564,15 @@ class TestStaleContextGather:
         panel._last_context = {"current_network": "/obj"}
         panel._last_context_time = time.time() * 1000  # now
 
-        result = panel._gather_context_if_stale()
+        with patch("synapse.panel.ws_bridge.gather_context_off_main") as gather:
+            result = panel._gather_context_if_stale()
+
         assert result == {"current_network": "/obj"}
-        panel._bridge.gather_context.assert_not_called()
+        gather.assert_not_called()
 
     def test_stale_context_triggers_gather(self):
-        """When context is stale (>5s old), gather runs directly."""
+        """When context is stale (>5s old), an off-main refresh is
+        fire-and-forget'd and the existing cache is returned unchanged."""
         import time
         from unittest.mock import patch
         from synapse.panel.chat_panel import SynapseChatPanel
@@ -569,14 +584,18 @@ class TestStaleContextGather:
         # Set time 10s in the past
         panel._last_context_time = (time.time() - 10) * 1000
 
-        fresh = {"current_network": "/stage", "selected_nodes": [], "scene_file": "", "frame": 1.0}
-        with patch("synapse.panel.ws_bridge._gather_context_on_main_thread", return_value=fresh):
+        with patch("synapse.panel.ws_bridge.gather_context_off_main") as gather:
             result = panel._gather_context_if_stale()
 
-        assert result["current_network"] == "/stage"
+        # The refresh is dispatched (off-main, fire-and-forget)...
+        assert gather.called, "stale cache must trigger an off-main refresh"
+        # ...but the returned value is the existing (stale) cache, not a
+        # freshly-gathered one — the async refresh updates the NEXT call.
+        assert result == {"current_network": "/obj"}
 
     def test_no_context_time_triggers_gather(self):
-        """When context has never been gathered, trigger a gather."""
+        """When context has never been gathered (cold start), an off-main
+        refresh is dispatched and None is returned (no inline gather)."""
         from unittest.mock import patch
         from synapse.panel.chat_panel import SynapseChatPanel
 
@@ -586,14 +605,16 @@ class TestStaleContextGather:
         panel._last_context = None
         panel._last_context_time = None
 
-        fresh = {"current_network": "/obj", "selected_nodes": [], "scene_file": "", "frame": 1.0}
-        with patch("synapse.panel.ws_bridge._gather_context_on_main_thread", return_value=fresh):
+        with patch("synapse.panel.ws_bridge.gather_context_off_main") as gather:
             result = panel._gather_context_if_stale()
 
-        assert result["current_network"] == "/obj"
+        assert gather.called, "cold start must trigger an off-main refresh"
+        # Cold start: no cache yet — the async refresh will populate it.
+        assert result is None
 
     def test_no_bridge_skips_gather(self):
-        """When bridge is None, gather still works (runs on main thread)."""
+        """When bridge is None, no refresh is dispatched and None is
+        returned (the off-main helper guards on a connected bridge)."""
         from unittest.mock import patch
         from synapse.panel.chat_panel import SynapseChatPanel
 
@@ -602,12 +623,11 @@ class TestStaleContextGather:
         panel._last_context = None
         panel._last_context_time = None
 
-        fresh = {"current_network": "", "selected_nodes": [], "scene_file": "", "frame": 1.0}
-        with patch("synapse.panel.ws_bridge._gather_context_on_main_thread", return_value=fresh):
+        with patch("synapse.panel.ws_bridge.gather_context_off_main") as gather:
             result = panel._gather_context_if_stale()
 
-        # Context is gathered even without bridge (main-thread direct call)
-        assert result is not None
+        gather.assert_not_called()
+        assert result is None
 
 
 # ===========================================================================

--- a/tests/test_context_poll_offmain.py
+++ b/tests/test_context_poll_offmain.py
@@ -1,0 +1,293 @@
+"""Off-main scene-context gather — the panel poll/send freeze-hardening.
+
+Companion to ``test_offmain_fallback.py`` (the tool-call fallback fix,
+6f354ae). That fix closed the inline-hou-on-main-thread freeze on the
+tool-dispatch path; this pins the SAME fix class on the panel's own
+context-gather path (the 10 s ``_poll_context`` QTimer + the send-time
+``_gather_context_if_stale``).
+
+Before: both call sites ran ``_gather_context_on_main_thread()`` directly
+from the main thread (a Qt slot). ``run_on_main``'s Fast path 2
+(``main_thread.py:240`` — "caller IS main thread → fn() inline, NO timeout
+possible") applied, so every ``hou.selectedNodes()`` / ``hou.ui.paneTabs()``
+read froze the GUI for its duration.
+
+After: ``ws_bridge.gather_context_off_main`` spawns a daemon thread that
+calls ``run_on_main(_gather_context_on_main_thread, ...)`` from OFF main,
+so the read takes the DEFERRED path (``hdefereval.executeDeferred`` + bounded
+timeout, interleaved with UI events). On a busy main thread it sheds and
+keeps the stale cache; the chips are advisory.
+
+These tests pin (without a live Houdini):
+
+  * the gather runs on a NON-main thread (so run_on_main would resolve to
+    the DEFERRED path, not Fast path 2),
+  * ``run_on_main`` is called with ``record_stall=False`` and
+    ``record_wait=False`` (observe-only — must not pollute the stall
+    detector or the C6 dispatch-wait histogram),
+  * the fn handed to ``run_on_main`` IS ``_gather_context_on_main_thread``
+    (the real gather, not an inline lambda that would re-introduce the bug),
+  * on success ``on_ready`` is invoked with the context,
+  * on a run_on_main timeout/raise, ``on_ready`` is NOT called (shed → keep
+    stale cache, no exception escapes).
+
+Pure logic + a lightweight PySide6.QtCore stub — runs under stock pytest.
+Patching mirrors ``test_live_metrics_threadsafe.py``: a string-path
+``unittest.mock.patch("synapse.server.main_thread.run_on_main", ...)``, which
+resolves the module fresh and is robust to import-order pollution across the
+full suite (the same pattern the live-metrics tests use for this seam).
+"""
+
+import importlib
+import os
+import sys
+import threading
+import time
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure THIS worktree's synapse.panel.ws_bridge wins.
+_PYTHON_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "python"
+)
+if sys.path and sys.path[0] != _PYTHON_DIR:
+    sys.path.insert(0, _PYTHON_DIR)
+_WORKTREE_PANEL_DIR = os.path.join(_PYTHON_DIR, "synapse", "panel")
+
+
+# ---------------------------------------------------------------------------
+# PySide6.QtCore stub fixture (sys.modules-restoring, no leak)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def ws_bridge_module():
+    """Import ws_bridge headlessly, restoring sys.modules afterward.
+
+    ws_bridge only needs QtCore (QThread/Signal/Slot/QMetaObject/Qt/Q_ARG).
+    If genuine PySide6/PySide2 is present we use it; otherwise we install a
+    minimal QtCore stub whose QThread is a plain base class, Signal is a
+    no-op factory, and everything else is a MagicMock. Then we import
+    synapse.panel.ws_bridge and yield it.
+    """
+    touched = [
+        "PySide6", "PySide6.QtCore",
+        "PySide2", "PySide2.QtCore",
+        "synapse.panel.ws_bridge",
+    ]
+    saved = {k: sys.modules.get(k) for k in touched}
+
+    def _is_genuine_qt(modname):
+        try:
+            mod = importlib.import_module(modname)
+        except Exception:
+            return False
+        return isinstance(getattr(mod, "QThread", None), type)
+
+    real_qt = _is_genuine_qt("PySide6.QtCore") or _is_genuine_qt("PySide2.QtCore")
+
+    if not real_qt:
+        class _StubBase:
+            def __init__(self, *a, **kw):
+                pass
+
+        class _QtCoreStub(types.ModuleType):
+            QThread = _StubBase
+            QObject = _StubBase
+
+            @staticmethod
+            def Signal(*a, **kw):
+                return MagicMock()
+
+            @staticmethod
+            def Slot(*a, **kw):
+                return lambda fn: fn
+
+            def __getattr__(self, name):  # QMetaObject / Qt / Q_ARG / etc.
+                return MagicMock()
+
+        qtcore = _QtCoreStub("PySide6.QtCore")
+        pyside = types.ModuleType("PySide6")
+        pyside.QtCore = qtcore
+        sys.modules["PySide6"] = pyside
+        sys.modules["PySide6.QtCore"] = qtcore
+
+    if "synapse.panel" not in sys.modules:
+        import synapse.panel as _panel_pkg  # noqa: E402
+        _ppath = getattr(_panel_pkg, "__path__", None)
+        if _ppath is not None and _WORKTREE_PANEL_DIR not in list(_ppath):
+            _ppath.insert(0, _WORKTREE_PANEL_DIR)
+
+    sys.modules.pop("synapse.panel.ws_bridge", None)
+    import synapse.panel.ws_bridge as wsb
+
+    try:
+        yield wsb
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+# ---------------------------------------------------------------------------
+# A fake run_on_main that records how it was called + which thread asked.
+# ---------------------------------------------------------------------------
+class _FakeRunOnMain:
+    """Replaces synapse.server.main_thread.run_on_main for the test.
+
+    Records the fn, the record_stall / record_wait flags, and the caller
+    thread ident. Returns ``self.retval`` by default, or raises ``self.exc``
+    if set (simulating a main-thread timeout). NEVER calls fn — the gather
+    fn is the production ``_gather_context_on_main_thread`` which touches
+    hou; the point is to assert what run_on_main is called WITH, not to
+    execute it.
+    """
+    def __init__(self, retval=None, exc=None):
+        self.retval = retval
+        self.exc = exc
+        self.calls = []
+
+    def __call__(self, fn, timeout=10.0, record_stall=True, record_wait=True):
+        self.calls.append({
+            "fn": fn,
+            "timeout": timeout,
+            "record_stall": record_stall,
+            "record_wait": record_wait,
+            "caller_ident": threading.current_thread().ident,
+        })
+        if self.exc is not None:
+            raise self.exc
+        return self.retval
+
+
+def _wait_for_calls(fake, n=1, timeout_s=2.0):
+    """Spin until the daemon thread has hit run_on_main n times."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if len(fake.calls) >= n:
+            return True
+        time.sleep(0.01)
+    return len(fake.calls) >= n
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+def test_gather_runs_off_main_thread(ws_bridge_module):
+    """The on_ready callback (and thus the run_on_main call) happens on a
+    NON-main thread — the precondition for run_on_main's DEFERRED path."""
+    wsb = ws_bridge_module
+    main_ident = threading.main_thread().ident
+
+    fake = _FakeRunOnMain(retval={"selected_nodes": [], "current_network": "/obj"})
+    done = threading.Event()
+    seen_thread = []
+
+    def on_ready(ctx):
+        seen_thread.append(threading.current_thread().ident)
+        done.set()
+
+    with patch("synapse.server.main_thread.run_on_main", fake):
+        wsb.gather_context_off_main(on_ready)
+
+    assert done.wait(2.0), "on_ready was never called"
+    assert fake.calls, "run_on_main was never invoked"
+    assert seen_thread[0] != main_ident, (
+        "gather ran on the main thread — run_on_main would hit Fast path 2 "
+        "(inline, no timeout) and the freeze fix is void"
+    )
+
+
+def test_run_on_main_called_observe_only(ws_bridge_module):
+    """record_stall=False AND record_wait=False — an advisory read must not
+    trip the 2-strike stall detector nor pollute the C6 dispatch-wait
+    histogram (see run_on_main docstring)."""
+    wsb = ws_bridge_module
+    fake = _FakeRunOnMain(retval={"selected_nodes": []})
+    with patch("synapse.server.main_thread.run_on_main", fake):
+        wsb.gather_context_off_main(lambda ctx: None)
+        assert _wait_for_calls(fake), "run_on_main was never invoked"
+    call = fake.calls[0]
+    assert call["record_stall"] is False, (
+        "advisory context gather must opt out of the stall detector — two "
+        "back-to-back timeouts would otherwise fast-fail REAL commands"
+    )
+    assert call["record_wait"] is False, (
+        "advisory context gather must opt out of the C6 dispatch-wait "
+        "histogram — it must stay a measure of REAL command waits"
+    )
+
+
+def test_real_gather_fn_passed_to_run_on_main(ws_bridge_module):
+    """The fn handed to run_on_main IS ``_gather_context_on_main_thread`` —
+    the real gather, not an inline lambda wrapping it (which would defeat
+    the seam and could re-introduce an inline hou call)."""
+    wsb = ws_bridge_module
+    fake = _FakeRunOnMain(retval={"selected_nodes": []})
+    with patch("synapse.server.main_thread.run_on_main", fake):
+        wsb.gather_context_off_main(lambda ctx: None)
+        assert _wait_for_calls(fake), "run_on_main was never invoked"
+    assert fake.calls[0]["fn"] is wsb._gather_context_on_main_thread, (
+        "run_on_main must marshal the real gather fn, not a wrapper"
+    )
+
+
+def test_on_ready_receives_context_on_success(ws_bridge_module):
+    """Success path: on_ready is called with the ctx returned by run_on_main."""
+    wsb = ws_bridge_module
+    ctx = {"selected_nodes": ["/obj/geo1"], "current_network": "/obj",
+           "scene_file": "/tmp/hip.hip", "frame": 24}
+    received = []
+    done = threading.Event()
+
+    def on_ready(c):
+        received.append(c)
+        done.set()
+
+    fake = _FakeRunOnMain(retval=ctx)
+    with patch("synapse.server.main_thread.run_on_main", fake):
+        wsb.gather_context_off_main(on_ready)
+        assert done.wait(2.0), "on_ready was never called on success"
+    assert received[0] is ctx
+
+
+def test_sheds_on_timeout_without_calling_on_ready(ws_bridge_module):
+    """Timeout/busy path: run_on_main raises, on_ready is NOT called, and no
+    exception escapes the daemon thread (shed → caller keeps stale cache)."""
+    wsb = ws_bridge_module
+    called = []
+    fake = _FakeRunOnMain(exc=RuntimeError("main thread didn't respond in time"))
+
+    def on_ready(c):
+        called.append(c)
+
+    with patch("synapse.server.main_thread.run_on_main", fake):
+        wsb.gather_context_off_main(on_ready)
+        assert _wait_for_calls(fake), "run_on_main was never invoked"
+    # The daemon thread hit the exception + shed; on_ready must not fire.
+    time.sleep(0.2)
+    assert called == [], (
+        "on_ready fired after a timeout — a busy main thread would still "
+        "drive the chip update; the shed contract is broken"
+    )
+
+
+def test_on_ready_exception_does_not_escape(ws_bridge_module):
+    """A buggy on_ready callback must not crash the daemon thread (it would
+    otherwise surface as a noisy traceback for an advisory path). The helper
+    swallows it; the thread simply exits."""
+    wsb = ws_bridge_module
+
+    def bad_on_ready(ctx):
+        raise ValueError("buggy chip update")
+
+    fake = _FakeRunOnMain(retval={"x": 1})
+    # Should not raise from gather_context_off_main itself.
+    with patch("synapse.server.main_thread.run_on_main", fake):
+        wsb.gather_context_off_main(bad_on_ready)
+        assert _wait_for_calls(fake), "run_on_main was never invoked"
+    time.sleep(0.2)  # daemon thread runs, exception is swallowed
+    # No assertion possible on absence of a traceback here; reaching this
+    # line (the call returning + the fake being hit) is the pass condition.

--- a/tests/test_offmain_fallback.py
+++ b/tests/test_offmain_fallback.py
@@ -1,0 +1,380 @@
+"""Off-main Qt-fallback tool dispatch — the bridge-DOWN freeze fix.
+
+When the local MCP endpoint is unreachable (the user's current bridge-DOWN
+state), ``ClaudeWorker._execute_tool_block`` used to emit a Qt signal delivered
+via AutoConnection to ``ToolExecutor.execute_tool`` on Houdini's MAIN thread.
+That ran the WHOLE handler inline on the GUI thread: every internal
+``run_on_main`` call hit Fast path 2 (``main_thread.py:240`` — "caller IS main
+thread → fn() inline, NO timeout possible"), freezing node selection / viewport
+/ the 1s FreezeChain heartbeat for the handler's full duration.
+
+The fix dispatches the SAME handler on a daemon thread the worker spawns.
+Because the daemon thread is OFF main, ``run_on_main`` calls inside the handler
+take the DEFERRED path (``hdefereval.executeDeferred`` + per-tool timeout,
+interleaved with UI events) — identical to the MCP path. The main thread is
+freed. No handler / undo / consent / integrity logic is touched; only the
+threading context of the dispatch changes.
+
+These tests pin that:
+
+  * the handler now runs on a NON-main thread (so run_on_main resolves to the
+    DEFERRED path, not Fast path 2),
+  * the ``request.done`` + per-tool budget contract still holds (success →
+    result; raise → error; slow → the existing "did not finish" error with no
+    double-dispatch),
+  * the off-main dispatch still routes read-only tools through
+    ``handler.handle`` and mutating tools through
+    ``bridge_adapter.execute_through_bridge`` exactly as the inline slot did.
+
+Pure logic + a lightweight Qt stub — runs under stock pytest (no live
+Houdini). Mirrors the established ``test_worker_tool_policy.py`` fixture
+convention (PySide stub with sys.modules restore on teardown).
+"""
+
+import importlib
+import os
+import sys
+import threading
+import time
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure THIS worktree's synapse.panel submodules win (same rationale as
+# test_worker_tool_policy.py).
+_PYTHON_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "python"
+)
+if sys.path and sys.path[0] != _PYTHON_DIR:
+    sys.path.insert(0, _PYTHON_DIR)
+_WORKTREE_PANEL_DIR = os.path.join(_PYTHON_DIR, "synapse", "panel")
+
+if "synapse.panel.worker_policy" not in sys.modules:
+    import synapse.panel as _panel_pkg  # noqa: E402
+    _ppath = getattr(_panel_pkg, "__path__", None)
+    if _ppath is not None and _WORKTREE_PANEL_DIR not in list(_ppath):
+        _ppath.insert(0, _WORKTREE_PANEL_DIR)
+
+
+# ---------------------------------------------------------------------------
+# PySide stub fixture (sys.modules-restoring, no leak into sibling tests)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def claude_worker_module():
+    """Import claude_worker headlessly, restoring sys.modules afterward.
+
+    If genuine PySide6/PySide2 (a REAL QThread class) is present we use it;
+    otherwise we install minimal stubs (QThread/QObject as plain base classes,
+    Signal as a no-op factory, Slot as a passthrough) only for this test, then
+    restore every key we touched.
+    """
+    touched = [
+        "PySide6", "PySide6.QtCore",
+        "PySide2", "PySide2.QtCore",
+        "synapse.panel.claude_worker",
+        "synapse.panel.tool_executor",
+    ]
+    saved = {k: sys.modules.get(k) for k in touched}
+
+    def _is_genuine_qt(modname):
+        try:
+            mod = importlib.import_module(modname)
+        except Exception:
+            return False
+        return isinstance(getattr(mod, "QThread", None), type)
+
+    real_qt = _is_genuine_qt("PySide6.QtCore") or _is_genuine_qt("PySide2.QtCore")
+
+    if not real_qt:
+        class _StubBase:
+            def __init__(self, *a, **kw):
+                pass
+
+        class _QtCoreStub(types.ModuleType):
+            QThread = _StubBase
+            QObject = _StubBase
+
+            @staticmethod
+            def Signal(*a, **kw):
+                return MagicMock()
+
+            @staticmethod
+            def Slot(*a, **kw):
+                return lambda fn: fn
+
+            def __getattr__(self, name):  # pragma: no cover - defensive
+                return MagicMock()
+
+        qtcore = _QtCoreStub("PySide6.QtCore")
+        pyside = types.ModuleType("PySide6")
+        pyside.QtCore = qtcore
+        sys.modules["PySide6"] = pyside
+        sys.modules["PySide6.QtCore"] = qtcore
+
+    if not real_qt:
+        sys.modules.pop("synapse.panel.tool_executor", None)
+    sys.modules.pop("synapse.panel.claude_worker", None)
+    import synapse.panel.claude_worker as cw
+
+    try:
+        yield cw
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+# ---------------------------------------------------------------------------
+# Shared fakes
+# ---------------------------------------------------------------------------
+class _Resp:
+    def __init__(self, data, success=True, error=None):
+        self.success = success
+        self.data = data
+        self.error = error
+
+
+class _RecordingHandler:
+    """Fake handler whose handle() records the caller thread ident — the proof
+    that the handler runs off-main (and so run_on_main would take the DEFERRED
+    path, not Fast path 2)."""
+    def __init__(self, data=None, exc=None, sleep_s=None, call_run_on_main=None):
+        self._data = data
+        self._exc = exc
+        self._sleep_s = sleep_s
+        self._call_run_on_main = call_run_on_main
+        self.calls = []
+        self.thread_idents = []
+
+    def handle(self, command):
+        self.calls.append(command)
+        self.thread_idents.append(threading.current_thread().ident)
+        if self._sleep_s is not None:
+            time.sleep(self._sleep_s)
+        if self._call_run_on_main is not None:
+            self._call_run_on_main()
+        if self._exc is not None:
+            raise self._exc
+        return _Resp(self._data)
+
+
+def _make_worker(cw_module, **kwargs):
+    worker = cw_module.ClaudeWorker(messages=[], **kwargs)
+    worker.tool_status = MagicMock()
+    return worker
+
+
+def _wire(worker_module, monkeypatch, handler, *, read_only=True,
+          mutate_bridge=None, tool_name="houdini_get_parm"):
+    """Wire a freshly-built executor's dispatch so the fake handler is reached.
+
+    Returns the executor the worker's off-main path will use (built lazily).
+    Patches the tool_executor + bridge_adapter namespaces the reloaded
+    claude_worker actually imports.
+    """
+    te = sys.modules["synapse.panel.tool_executor"]
+    ba = importlib.import_module("synapse.panel.bridge_adapter")
+
+    monkeypatch.setattr(
+        te, "get_tool_dispatch",
+        lambda name: ("read", lambda inp: dict(inp)),
+    )
+    monkeypatch.setattr(ba, "is_read_only", lambda name: read_only)
+    if mutate_bridge is not None:
+        monkeypatch.setattr(ba, "execute_through_bridge", mutate_bridge)
+
+    worker = _make_worker(worker_module, enforce_worker_policy=False)
+    executor = worker._get_offmain_executor()
+    monkeypatch.setattr(executor, "_get_handler", lambda: handler)
+    return worker, executor
+
+
+def _block(tool_name="houdini_get_parm"):
+    return {"id": "tu_x", "name": tool_name, "input": {"node": "/obj"}}
+
+
+# ===========================================================================
+# 1. The handler runs on a NON-main thread (deferred path, not Fast path 2)
+# ===========================================================================
+
+def test_offmain_fallback_runs_handler_off_main(claude_worker_module, monkeypatch):
+    cw = claude_worker_module
+    # MCP unavailable — forces the Qt-fallback path.
+    monkeypatch.setattr(cw, "try_mcp_tool_call", lambda name, inp: None)
+
+    handler = _RecordingHandler(data={"ok": 1})
+    worker, executor = _wire(cw, monkeypatch, handler, read_only=True)
+
+    main_ident = threading.main_thread().ident
+    result = worker._execute_tool_block(_block())
+
+    assert handler.calls, "handler.handle was invoked"
+    assert len(handler.thread_idents) == 1
+    assert handler.thread_idents[0] != main_ident, (
+        "handler must run OFF the main thread so run_on_main resolves to the "
+        "DEFERRED path (hdefereval.executeDeferred + per-tool timeout), not "
+        "Fast path 2 inline"
+    )
+    assert result["is_error"] is False
+    assert '"ok"' in result["content"]
+
+
+def test_offmain_fallback_run_on_main_called_off_main(claude_worker_module, monkeypatch):
+    """Directly assert run_on_main would take the deferred path: a handler
+    that calls run_on_main does so from a non-main thread."""
+    cw = claude_worker_module
+    monkeypatch.setattr(cw, "try_mcp_tool_call", lambda name, inp: None)
+
+    main_thread = importlib.import_module("synapse.server.main_thread")
+    captured = {}
+
+    def _fake_run_on_main(fn, *a, **kw):
+        captured["caller_ident"] = threading.current_thread().ident
+        return fn()
+
+    monkeypatch.setattr(main_thread, "run_on_main", _fake_run_on_main)
+
+    handler = _RecordingHandler(
+        data={"ok": 1},
+        call_run_on_main=lambda: main_thread.run_on_main(lambda: None),
+    )
+    worker, executor = _wire(cw, monkeypatch, handler, read_only=True)
+
+    worker._execute_tool_block(_block())
+
+    assert "caller_ident" in captured, "handler called run_on_main"
+    assert captured["caller_ident"] != threading.main_thread().ident
+
+
+# ===========================================================================
+# 2. request.done + per-tool budget contract (C7)
+# ===========================================================================
+
+def test_offmain_success_sets_result_and_done(claude_worker_module, monkeypatch):
+    cw = claude_worker_module
+    monkeypatch.setattr(cw, "try_mcp_tool_call", lambda name, inp: None)
+    handler = _RecordingHandler(data={"made": "box"})
+    worker, executor = _wire(cw, monkeypatch, handler, read_only=True)
+
+    result = worker._execute_tool_block(_block())
+
+    assert result["is_error"] is False
+    assert '"made"' in result["content"]
+    assert len(handler.calls) == 1
+
+
+def test_offmain_handler_raise_sets_error(claude_worker_module, monkeypatch):
+    cw = claude_worker_module
+    monkeypatch.setattr(cw, "try_mcp_tool_call", lambda name, inp: None)
+    handler = _RecordingHandler(exc=RuntimeError("boom"))
+    worker, executor = _wire(cw, monkeypatch, handler, read_only=True)
+
+    result = worker._execute_tool_block(_block())
+
+    assert result["is_error"] is True
+    assert "boom" in result["content"]
+
+
+def test_offmain_slow_handler_times_out_no_double_dispatch(claude_worker_module, monkeypatch):
+    cw = claude_worker_module
+    monkeypatch.setattr(cw, "try_mcp_tool_call", lambda name, inp: None)
+    # Shrink the wait budget so the test does not sleep the real 30s floor.
+    monkeypatch.setattr(cw, "_wait_budget", lambda name: 0.5)
+    # Handler slower than the budget.
+    handler = _RecordingHandler(data={"ok": 1}, sleep_s=2.0)
+    worker, executor = _wire(cw, monkeypatch, handler, read_only=True)
+
+    t0 = time.perf_counter()
+    result = worker._execute_tool_block(_block("houdini_render"))
+    elapsed = time.perf_counter() - t0
+
+    assert result["is_error"] is True
+    assert "did not finish" in result["content"]
+    assert elapsed < 1.5, "the worker must report the timeout promptly, not block on the handler"
+    # No double-dispatch: the handler was started exactly once (the abandoned
+    # daemon thread may still be sleeping, but it is not re-dispatched).
+    assert len(handler.calls) == 1
+
+
+# ===========================================================================
+# 3. Routing: read-only vs mutating selects the same code path as the slot
+# ===========================================================================
+
+def test_offmain_read_only_calls_handler_handle_directly(claude_worker_module, monkeypatch):
+    cw = claude_worker_module
+    monkeypatch.setattr(cw, "try_mcp_tool_call", lambda name, inp: None)
+
+    te = sys.modules["synapse.panel.tool_executor"]
+    ba = importlib.import_module("synapse.panel.bridge_adapter")
+
+    bridge_called = {"n": 0}
+
+    def _bridge(*a, **kw):
+        bridge_called["n"] += 1
+        return _Resp({"via": "bridge"})
+
+    handler = _RecordingHandler(data={"via": "handle"})
+    worker, executor = _wire(
+        cw, monkeypatch, handler, read_only=True, mutate_bridge=_bridge,
+    )
+
+    worker._execute_tool_block(_block("synapse_ping"))  # synapse_ping is read-only
+
+    assert len(handler.calls) == 1, "read-only tool routes through handler.handle"
+    assert bridge_called["n"] == 0, "read-only tool must NOT route through the bridge"
+
+
+def test_offmain_mutating_routes_through_bridge(claude_worker_module, monkeypatch):
+    cw = claude_worker_module
+    monkeypatch.setattr(cw, "try_mcp_tool_call", lambda name, inp: None)
+
+    ba = importlib.import_module("synapse.panel.bridge_adapter")
+
+    bridge_called = {"n": 0}
+
+    def _bridge(tool_name, handler, command):
+        bridge_called["n"] += 1
+        return _Resp({"via": "bridge"})
+
+    handler = _RecordingHandler(data={"via": "handle"})  # should NOT be called directly
+    worker, executor = _wire(
+        cw, monkeypatch, handler, read_only=False, mutate_bridge=_bridge,
+    )
+
+    worker._execute_tool_block(_block("houdini_create_node"))
+
+    assert bridge_called["n"] == 1, "mutating tool routes through execute_through_bridge"
+    assert handler.calls == [], "mutating tool must NOT call handler.handle directly"
+
+
+# ===========================================================================
+# 4. The synchronous execute_tool slot contract is preserved (tests stay green)
+# ===========================================================================
+
+def test_execute_tool_slot_still_synchronous_and_sets_done(claude_worker_module, monkeypatch):
+    """A direct/test caller of the @Slot still gets result set before return —
+    the refactor must not have made execute_tool asynchronous."""
+    te = sys.modules["synapse.panel.tool_executor"]
+    ba = importlib.import_module("synapse.panel.bridge_adapter")
+
+    monkeypatch.setattr(
+        te, "get_tool_dispatch",
+        lambda name: ("read", lambda inp: dict(inp)),
+    )
+    monkeypatch.setattr(ba, "is_read_only", lambda name: True)
+    te.reset_panel_inline_stats()
+    handler = _RecordingHandler(data={"slot": "ok"})
+    executor = te.ToolExecutor()
+    monkeypatch.setattr(executor, "_get_handler", lambda: handler)
+
+    req = te.ToolRequest("tu_s", "houdini_get_parm", {"node": "/obj"})
+
+    executor.execute_tool(req)
+
+    assert req.done.is_set()
+    assert req.error is None
+    assert req.result == {"slot": "ok"}
+    assert len(handler.calls) == 1


### PR DESCRIPTION
## What this fixes

The chat-time Houdini UI freeze ("can't select nodes while chatting with Synapse") — a **third inline-main-thread freeze class**, distinct from the render freeze and the marshal deadlock.

**Root cause:** when the local MCP endpoint is down, `ClaudeWorker`'s tool calls fall back to a Qt AutoConnection signal that runs the whole handler **inline on Houdini's main thread**. Every internal `run_on_main` then hits Fast path 2 (`main_thread.py:240` — "caller IS main thread → `fn()` inline, no timeout possible"), so the GUI locks for the handler's full duration. The lying "connected" signal (latency report F6) makes this fire in everyday sessions, not just broken ones.

## The two commits

- **6f354ae — Qt-fallback tool dispatch off the main thread.** The worker spawns a daemon thread (`synapse.panel.tool.<tool>`) targeting `executor.execute_tool_off_main(request)` instead of emitting the Qt signal to the main-thread slot. Because the daemon is off-main, `run_on_main` inside the handler takes the **deferred path** (`hdefereval.executeDeferred` + per-tool timeout, interleaved with UI events) — identical to the MCP path. The worker's `request.done.wait(budget)` + C7 "did not finish, do not retry" are unchanged. No handler / undo / consent / integrity logic touched; only the threading context of the dispatch changes. Pinned by `tests/test_offmain_fallback.py` (8).
- **bf74ed7 — context poll/send gather off the main thread.** The panel's own context-gather path (`_poll_context` 10s QTimer + `_gather_context_if_stale` send path) had the same bug — `hou.selectedNodes()` / `hou.ui.paneTabs()` inline from a Qt slot. New `ws_bridge.gather_context_off_main` (module-scope, mirrors the `_spawn_off_main_tool_thread` seam) spawns a daemon thread → `run_on_main(_gather_context_on_main_thread, timeout=2.0, record_stall=False, record_wait=False)` (observe-only — must not pollute the stall detector or the C6 dispatch-wait histogram). `_gather_context_if_stale` no longer gathers inline: returns the cache, fire-and-forgets a refresh on stale. Context is advisory. Mirrors `live_metrics._collect_scene`. Pinned by `tests/test_context_poll_offmain.py` (6) + updated `tests/test_chat_panel.py::TestStaleContextGather` (4) to the fire-and-forget contract.

## Verification

- **5330 passed, 137 skipped, 0 failed** (was 5322; +8 net). Crucible adversarial review HOLDS.
- Pure logic + Qt-stub tests under stock pytest; no live Houdini required. Patching uses `unittest.mock.patch("synapse.server.main_thread.run_on_main")` — the `test_live_metrics_threadsafe` pattern, robust to full-suite import ordering.
- Not live-measured (bridge was down at diagnosis). The fix targets exactly the bridge-DOWN state, so the live test is: restart the panel with the bridge down, chat mid-tool-call, try selecting nodes.

## What it does NOT fix

- The one residual freeze — a single long in-process render still holds the main thread. Only husk-out-of-process removes that, and husk silently no-ops on Indie (`Unable to load render plugin: karma`). Deferred; needs Commercial/Education license.
- The serial WS connection loop (`websocket.py:471`) — cancel still unreachable. Still open per the marshal-deadlock memo (D3 partial).
- The 7-27 latency report §1 first-principles verdict ("Houdini-side work is milliseconds") is **stale in the bridge-DOWN case** — flagged for an addendum, not edited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Scene context refreshes now run in the background, keeping the interface responsive.
  * Tool fallback processing is handled off the main thread when the primary route is unavailable.
  * Context refreshes are bounded by a timeout and recover gracefully from errors.
  * Tool requests now reliably report completion and errors without duplicate processing.

* **Bug Fixes**
  * Improved handling of stale or unavailable context while background updates are pending.
  * Preserved synchronous tool request behavior while moving execution work off the main thread.

* **Tests**
  * Added coverage for background context gathering, timeout handling, tool fallback routing, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->