### PR TITLE
fix(panel): h7 inline guard + honest thread attribution (freeze class 1)

### DIFF
--- a/python/synapse/panel/tool_executor.py
+++ b/python/synapse/panel/tool_executor.py
@@ -55,17 +55,43 @@ PANEL_INLINE_SLOW_MS = 1000.0  # a single inline op over this is logged as slow
 
 _panel_inline_lock = threading.Lock()
 _panel_inline_stats = {
+    # MAIN-THREAD dispatches only. These are the samples that mean "the Qt loop
+    # was stalled this long"; nothing else may be added to them.
     "count": 0,
     "sum_ms": 0.0,
     "max_ms": 0.0,
     "slow_count": 0,
     "slowest_tool": None,
+    # OFF-MAIN dispatches, counted separately (FREEZE_FORENSICS_20260731 §2,
+    # "Follow-on defect"). Before this split, _dispatch recorded daemon-thread
+    # wall-time into the counters above and logged it as main-thread time. The
+    # forensics recorded that this "corrupted forensics this run and will
+    # corrupt the next one" — an off-main dispatch stalls no Qt loop, so
+    # attributing it as a freeze contribution sends the next investigator at
+    # the wrong mechanism. Kept rather than dropped: the duration is still
+    # useful, it simply is not main-thread hold time.
+    "offmain_count": 0,
+    "offmain_sum_ms": 0.0,
+    "offmain_max_ms": 0.0,
+    "offmain_slowest_tool": None,
 }
 
 
-def _record_panel_inline(tool_name: str, ms: float) -> None:
-    """Record one inline tool-dispatch duration (main-thread)."""
+def _record_panel_inline(tool_name: str, ms: float, on_main: bool = True) -> None:
+    """Record one tool-dispatch duration, attributed by REAL thread identity.
+
+    ``on_main`` must come from an actual thread-identity check at execution
+    time, never from a proxy flag such as which entrypoint was used — a proxy
+    is exactly what rotted the previous version of this counter.
+    """
     with _panel_inline_lock:
+        if not on_main:
+            _panel_inline_stats["offmain_count"] += 1
+            _panel_inline_stats["offmain_sum_ms"] += ms
+            if ms > _panel_inline_stats["offmain_max_ms"]:
+                _panel_inline_stats["offmain_max_ms"] = ms
+                _panel_inline_stats["offmain_slowest_tool"] = tool_name
+            return
         _panel_inline_stats["count"] += 1
         _panel_inline_stats["sum_ms"] += ms
         if ms > _panel_inline_stats["max_ms"]:
@@ -94,6 +120,10 @@ def reset_panel_inline_stats() -> None:
         _panel_inline_stats["max_ms"] = 0.0
         _panel_inline_stats["slow_count"] = 0
         _panel_inline_stats["slowest_tool"] = None
+        _panel_inline_stats["offmain_count"] = 0
+        _panel_inline_stats["offmain_sum_ms"] = 0.0
+        _panel_inline_stats["offmain_max_ms"] = 0.0
+        _panel_inline_stats["offmain_slowest_tool"] = None
 
 
 # ---------------------------------------------------------------------------
@@ -299,11 +329,20 @@ class ToolExecutor(QtCore.QObject):
     # NEVER changes the tool result — hou must run on the main thread regardless.
     preflight_warning = QtCore.Signal(str, str)
 
+    #: Escape hatch for the h7 inline guard below. Default False: a tool the
+    #: pre-flight predicts is heavy is REFUSED when the dispatch is genuinely
+    #: on Houdini's main thread, because at that point no bound is possible
+    #: (handlers_render.py:109-113 — "nothing in Python can interrupt the main
+    #: thread from the main thread"). Set True only by a caller that has
+    #: accepted a GUI freeze for the payload's full duration.
+    _allow_heavy_inline = False
+
     def __init__(self, parent: Optional[QtCore.QObject] = None) -> None:
         super().__init__(parent)
         self._handler = None  # Lazy-loaded SynapseHandler
         self._handler_error: Optional[str] = None  # real import/init failure
         self._last_preflight: Optional[str] = None  # last advisory (diagnostic)
+        self._last_preflight_heavy: bool = False    # drives the h7 inline guard
 
     # ------------------------------------------------------------------
     # Lazy handler initialisation
@@ -352,6 +391,9 @@ class ToolExecutor(QtCore.QObject):
         ``logger.warning`` is thread-safe and is always kept — it is the
         load-bearing part.
         """
+        # Reset first: a stale True from the previous request must never leak
+        # into this one and refuse a light tool.
+        self._last_preflight_heavy = False
         try:
             from synapse.panel.bridge_adapter import estimate_inline_cost
             heavy, message = estimate_inline_cost(request.tool_name, request.tool_input)
@@ -361,6 +403,7 @@ class ToolExecutor(QtCore.QObject):
         if not heavy:
             return
 
+        self._last_preflight_heavy = True
         self._last_preflight = message
         logger.warning("Pre-flight advisory — %s", message)
         if emit:
@@ -422,6 +465,46 @@ class ToolExecutor(QtCore.QObject):
             # non-blocking advisory if this op may briefly freeze the loop.
             self._preflight(request, emit=emit_preflight)
 
+            # h7 INLINE GUARD — FREEZE_FORENSICS_20260731 §5 item 1 (PRIMARY).
+            #
+            # Thread identity is read HERE, from the real thread, not inferred
+            # from which entrypoint was used. execute_tool (the Qt slot) and
+            # execute_tool_off_main (a daemon thread) both land in _dispatch,
+            # and only the first one can stall the Qt loop.
+            #
+            # Why refuse rather than time-box: once a payload is executing on
+            # the main thread it cannot be interrupted from the main thread
+            # (handlers_render.py:109-113). The v5.40.1 class-3 fix bounded the
+            # caller's WAIT and never the running payload, which is precisely
+            # why freezes continued after it — 8 of them on 2026-07-31, up to
+            # 44.4s. A guard that refuses BEFORE entry is the only mechanism
+            # that can work, and it is the same shape as the render
+            # foreground_guard that already protects the render path.
+            #
+            # In production today this should never fire: the worker dispatches
+            # off-main (claude_worker.py:348-374) and h9's tool_requested wire
+            # has zero emitters. It exists so that if that wire is ever armed,
+            # the result is one refused tool with an actionable message instead
+            # of a 46-second frozen UI.
+            _on_main = threading.current_thread() is threading.main_thread()
+            if (_on_main and self._last_preflight_heavy
+                    and not self._allow_heavy_inline):
+                request.error = (
+                    "Refused to run %r inline on Houdini's main thread: the "
+                    "pre-flight predicts a heavy payload, and a payload already "
+                    "running on the main thread cannot be interrupted from the "
+                    "main thread — the UI would freeze for its full duration "
+                    "with no bound. %s Re-dispatch via execute_tool_off_main(), "
+                    "or set _allow_heavy_inline=True to accept the freeze "
+                    "deliberately." % (request.tool_name,
+                                       self._last_preflight or "")
+                ).strip()
+                logger.warning(
+                    "h7 guard refused inline main-thread dispatch of %r "
+                    "(heavy pre-flight)", request.tool_name,
+                )
+                return
+
             # 1. Resolve tool name to (command_type, payload_builder)
             dispatch = get_tool_dispatch(request.tool_name)
             if dispatch is None:
@@ -470,13 +553,27 @@ class ToolExecutor(QtCore.QObject):
                 response = handler.handle(command)
             finally:
                 _elapsed_ms = (time.perf_counter() - _t0) * 1000.0
-                _record_panel_inline(request.tool_name, _elapsed_ms)
+                _record_panel_inline(request.tool_name, _elapsed_ms,
+                                     on_main=_on_main)
                 if _elapsed_ms >= PANEL_INLINE_SLOW_MS:
-                    logger.warning(
-                        "Inline tool %r ran %.0fms on the main thread "
-                        "(Qt loop stalled this long; slow threshold %.0fms)",
-                        request.tool_name, _elapsed_ms, PANEL_INLINE_SLOW_MS,
-                    )
+                    # The label must discriminate. The previous single string
+                    # claimed "on the main thread ... Qt loop stalled this
+                    # long" for BOTH paths, so every off-main dispatch read as
+                    # a freeze contribution. FREEZE_FORENSICS_20260731 §2 names
+                    # this as the follow-on defect that corrupted that run's
+                    # forensics and would corrupt the next one.
+                    if _on_main:
+                        logger.warning(
+                            "Inline tool %r ran %.0fms on the main thread "
+                            "(Qt loop stalled this long; slow threshold %.0fms)",
+                            request.tool_name, _elapsed_ms, PANEL_INLINE_SLOW_MS,
+                        )
+                    else:
+                        logger.warning(
+                            "Off-main tool %r ran %.0fms on a worker thread "
+                            "(Qt loop NOT stalled; slow threshold %.0fms)",
+                            request.tool_name, _elapsed_ms, PANEL_INLINE_SLOW_MS,
+                        )
 
             # 6. Transfer result
             if response.success:

--- a/tests/test_panel_preflight.py
+++ b/tests/test_panel_preflight.py
@@ -11,8 +11,21 @@ hou MUST run on the main thread, so we cannot move it off. Instead:
   TASK 2 — instrument: record every inline tool duration and log when a single
            op exceeds the slow threshold, so the freeze contributor is named.
 
-These tests pin that the pre-flight is advisory ONLY (never blocks, never alters
-the tool result) and that the instrumentation records + flags slow ops.
+These tests pin that the pre-flight is advisory on the OFF-MAIN path (never
+blocks, never alters the tool result) and that the instrumentation records +
+flags slow ops.
+
+⚠ Contract change, 2026-08-01 (FREEZE_FORENSICS_20260731 §5.1). The pre-flight
+is no longer advisory on ALL paths. When a dispatch is genuinely inline on
+Houdini's main thread, a heavy payload is now REFUSED — bounding the caller's
+wait was never enough, because a payload already on the main thread cannot be
+interrupted from the main thread (handlers_render.py:109-113), and freezes
+continued after the v5.40.1 fix for exactly that reason. The advisory-only
+contract still holds on the off-main path, which is what the worker actually
+uses, so the tests below now exercise it there via a real thread. The refusal
+itself is pinned in tests/test_panel_preflight_h7_guard.py — named to sort
+immediately after this module so it inherits this file's Qt stub rather than
+planting its own earlier in collection (see that file's header).
 
 Pure logic + a lightweight Qt stub — runs under stock pytest.
 """
@@ -147,7 +160,26 @@ def _wire_executor(monkeypatch, handler, cmd_type="execute_python"):
 # TASK 1 — pre-flight surfaces an advisory, but never changes the result
 # ===========================================================================
 
+def _run_really_off_main(executor, req, timeout=10.0):
+    """Execute on a REAL non-main thread.
+
+    The h7 guard (FREEZE_FORENSICS_20260731 §5.1) keys on actual thread
+    identity, not on which entrypoint was called — a proxy flag is exactly what
+    rotted the old attribution counter. So calling ``execute_tool_off_main``
+    from the test's own thread is still main-thread execution and is still
+    guarded. Exercising the off-main contract requires a genuine thread.
+    """
+    import threading as _t
+    th = _t.Thread(target=executor.execute_tool_off_main, args=(req,), daemon=True)
+    th.start()
+    th.join(timeout=timeout)
+    assert not th.is_alive(), "off-main dispatch did not finish"
+
+
 def test_heavy_execute_python_logs_advisory_and_returns_result(monkeypatch, caplog):
+    """Off-main (the production path): the advisory is surfaced but the result
+    is delivered unchanged. The pre-flight only REFUSES when the dispatch is
+    genuinely inline on Houdini's main thread, where no bound is possible."""
     te.reset_panel_inline_stats()
     data = {"made": "box"}
     handler = _Handler(data)
@@ -160,7 +192,7 @@ def test_heavy_execute_python_logs_advisory_and_returns_result(monkeypatch, capl
     )
 
     with caplog.at_level("WARNING"):
-        executor.execute_tool(req)
+        _run_really_off_main(executor, req)
 
     # Advisory surfaced (attributable, not silent)...
     assert any("Pre-flight advisory" in r.message for r in caplog.records)
@@ -197,19 +229,20 @@ def test_light_tool_emits_no_advisory_but_still_records(monkeypatch, caplog):
 
 
 def test_preflight_does_not_change_result_heavy_vs_light(monkeypatch):
-    """The pre-flight verdict must not influence the delivered result."""
+    """On the off-main path the pre-flight verdict must not influence the
+    delivered result — heavy and light both come back identical."""
     data = {"value": 42}
 
     heavy_handler = _Handler(data)
     heavy_exec = _wire_executor(monkeypatch, heavy_handler)
     heavy_req = te.ToolRequest("tu_h", "houdini_execute_python",
                                {"code": "z = 1\n" * 1000})
-    heavy_exec.execute_tool(heavy_req)
+    _run_really_off_main(heavy_exec, heavy_req)
 
     light_handler = _Handler(data)
     light_exec = _wire_executor(monkeypatch, light_handler)
     light_req = te.ToolRequest("tu_l", "houdini_execute_python", {"code": "z = 1"})
-    light_exec.execute_tool(light_req)
+    _run_really_off_main(light_exec, light_req)
 
     assert heavy_req.result == light_req.result == data
     assert heavy_req.error is None and light_req.error is None

--- a/tests/test_panel_preflight_h7_guard.py
+++ b/tests/test_panel_preflight_h7_guard.py
@@ -1,0 +1,260 @@
+"""h7 inline guard + honest thread attribution — FREEZE_FORENSICS_20260731.
+
+Pins the three defects the 2026-07-31 forensics left as an unimplemented
+remediation ticket (§5 items 1, 2 and 3).
+
+Background, because the shape is counter-intuitive. The v5.40.1 "chat no longer
+grips the UI" fix bounded the *caller's wait* and never the *running payload*.
+Freezes therefore continued after it: 8 of them on 2026-07-31, up to 44.4s, one
+escalating to SUSTAINED FREEZE. The reason a payload cannot simply be timed out
+is stated verbatim at handlers_render.py:109-113 — "nothing in Python can
+interrupt the main thread from the main thread". A guard that REFUSES before
+entry is the only mechanism available, which is why this mirrors the render
+foreground_guard rather than adding another timeout.
+
+  §5.1 PRIMARY  — a heavy payload must not start inline on the main thread
+  §5.2 SECONDARY— off-main wall-time must never be recorded as main-thread time
+  §5.3 HAZARD   — the armed-but-inert class-3 wire must stay emitter-free
+"""
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Qt stub — mirrors the canonical sibling stub (test_panel_preflight.py /
+# test_timeouts_c7.py) EXACTLY, and only plants when nothing else has.
+#
+# ⚠ THE FILENAME IS LOAD-BEARING. This module is named to sort immediately
+# AFTER test_panel_preflight.py ('.' < '_'), so in a full-suite run that file
+# has already planted the stub and imported tool_executor, and this one
+# inherits both. An earlier name (the first draft was
+# test_freeze_h7_inline_guard.py) made this module the alphabetically-first
+# panel test, which pulled `from synapse.panel import tool_executor` forward in
+# collection — the class then bound QObject from whatever stub existed at that
+# earlier moment, and six previously-green tests in test_panel_preflight.py
+# started failing with `_last_preflight` returning a MagicMock attribute
+# instead of None. They pass on master; the rename, not a code change, fixed
+# them. Do not rename this file without re-running the FULL suite.
+# ---------------------------------------------------------------------------
+if "PySide6" not in sys.modules:
+    class _QObject:
+        def __init__(self, *a, **k):
+            pass
+
+    class _QThread:
+        def __init__(self, *a, **k):
+            pass
+
+    _qtcore = types.ModuleType("PySide6.QtCore")
+    _qtcore.QObject = _QObject
+    _qtcore.QThread = _QThread
+    _qtcore.Slot = lambda *a, **k: (lambda f: f)
+    _qtcore.Signal = lambda *a, **k: MagicMock()
+    _pyside6 = types.ModuleType("PySide6")
+    _pyside6.QtCore = _qtcore
+    sys.modules["PySide6"] = _pyside6
+    sys.modules["PySide6.QtCore"] = _qtcore
+
+from synapse.panel import bridge_adapter as ba
+from synapse.panel import tool_executor as te
+
+REPO = Path(__file__).resolve().parents[1]
+
+HEAVY = {"code": "y = 1\n" * 1000}
+LIGHT = {"code": "hou.node('/obj')"}
+
+
+class _Resp:
+    def __init__(self, data):
+        self.success = True
+        self.data = data
+        self.error = None
+
+
+class _Handler:
+    def __init__(self, data):
+        self._data = data
+        self.calls = []
+
+    def handle(self, command):
+        self.calls.append(command)
+        return _Resp(self._data)
+
+
+def _wire(monkeypatch, handler):
+    ex = te.ToolExecutor()
+    monkeypatch.setattr(te, "get_tool_dispatch",
+                        lambda name: ("execute_python", lambda inp: dict(inp)))
+    monkeypatch.setattr(ba, "is_read_only", lambda name: True)  # skip the bridge
+    monkeypatch.setattr(ex, "_get_handler", lambda: handler)
+    return ex
+
+
+def _really_off_main(ex, req, timeout=10.0):
+    """Run on a genuine non-main thread.
+
+    Calling execute_tool_off_main from the test's own thread is still
+    main-thread execution — the guard reads real thread identity, not the
+    entrypoint. That distinction is the whole point of §5.2.
+    """
+    th = threading.Thread(target=ex.execute_tool_off_main, args=(req,), daemon=True)
+    th.start()
+    th.join(timeout=timeout)
+    assert not th.is_alive(), "off-main dispatch did not finish"
+
+
+# ── §5.1 PRIMARY — the inline guard ────────────────────────────────────────
+
+def test_heavy_tool_is_refused_inline_on_the_main_thread(monkeypatch):
+    """FAILS IF: a payload the pre-flight calls heavy is allowed to start on
+    Houdini's main thread. That is the 46.7-second freeze."""
+    handler = _Handler({"ok": 1})
+    ex = _wire(monkeypatch, handler)
+    req = te.ToolRequest("tu_heavy_main", "houdini_execute_python", HEAVY)
+
+    ex.execute_tool(req)  # the Qt slot path == main thread
+
+    assert req.error is not None, "heavy inline dispatch was NOT refused"
+    assert "main thread" in req.error
+    assert handler.calls == [], "the payload ran anyway — the guard is cosmetic"
+    assert req.done.is_set(), "a refused request must still be completed"
+
+
+def test_light_tool_still_runs_inline(monkeypatch):
+    """FAILS IF: the guard over-fires and refuses ordinary work."""
+    handler = _Handler({"ok": 1})
+    ex = _wire(monkeypatch, handler)
+    req = te.ToolRequest("tu_light_main", "houdini_execute_python", LIGHT)
+
+    ex.execute_tool(req)
+
+    assert req.error is None
+    assert len(handler.calls) == 1
+
+
+def test_heavy_tool_runs_when_genuinely_off_main(monkeypatch):
+    """FAILS IF: the guard blocks the production path. The worker dispatches
+    off-main (claude_worker.py:348-374); heavy work must still get through."""
+    handler = _Handler({"ok": 1})
+    ex = _wire(monkeypatch, handler)
+    req = te.ToolRequest("tu_heavy_off", "houdini_execute_python", HEAVY)
+
+    _really_off_main(ex, req)
+
+    assert req.error is None, "the guard leaked onto the off-main path"
+    assert len(handler.calls) == 1
+
+
+def test_escape_hatch_allows_a_deliberate_inline_freeze(monkeypatch):
+    """A caller that has accepted the freeze can still opt in explicitly."""
+    handler = _Handler({"ok": 1})
+    ex = _wire(monkeypatch, handler)
+    ex._allow_heavy_inline = True
+    req = te.ToolRequest("tu_forced", "houdini_execute_python", HEAVY)
+
+    ex.execute_tool(req)
+
+    assert req.error is None
+    assert len(handler.calls) == 1
+
+
+def test_guard_does_not_leak_between_requests(monkeypatch):
+    """FAILS IF: a heavy request's verdict refuses the NEXT, light request."""
+    handler = _Handler({"ok": 1})
+    ex = _wire(monkeypatch, handler)
+
+    heavy = te.ToolRequest("tu_a", "houdini_execute_python", HEAVY)
+    ex.execute_tool(heavy)
+    assert heavy.error is not None
+
+    light = te.ToolRequest("tu_b", "houdini_execute_python", LIGHT)
+    ex.execute_tool(light)
+    assert light.error is None, "stale heavy verdict leaked into the next request"
+
+
+# ── §5.2 SECONDARY — honest thread attribution ─────────────────────────────
+
+def test_off_main_time_is_not_recorded_as_main_thread_time(monkeypatch):
+    """FAILS IF: daemon-thread wall-time lands in the main-thread counters.
+
+    This is the follow-on defect the forensics said "corrupted forensics this
+    run and will corrupt the next one" — an off-main dispatch stalls no Qt
+    loop, so counting it as main-thread hold time aims the next investigation
+    at the wrong mechanism.
+    """
+    te.reset_panel_inline_stats()
+    handler = _Handler({"ok": 1})
+    ex = _wire(monkeypatch, handler)
+    req = te.ToolRequest("tu_attr", "houdini_execute_python", LIGHT)
+
+    _really_off_main(ex, req)
+
+    stats = te.panel_inline_stats()
+    assert stats["count"] == 0, "off-main dispatch counted as main-thread time"
+    assert stats["offmain_count"] == 1, "off-main dispatch was not recorded at all"
+    assert stats["offmain_slowest_tool"] == "houdini_execute_python"
+
+
+def test_main_thread_dispatch_is_recorded_as_main_thread_time(monkeypatch):
+    """The paired positive control — without it the test above passes vacuously
+    if the counter simply stopped recording anything."""
+    te.reset_panel_inline_stats()
+    handler = _Handler({"ok": 1})
+    ex = _wire(monkeypatch, handler)
+    req = te.ToolRequest("tu_attr2", "houdini_execute_python", LIGHT)
+
+    ex.execute_tool(req)
+
+    stats = te.panel_inline_stats()
+    assert stats["count"] == 1
+    assert stats["offmain_count"] == 0
+
+
+def test_slow_log_discriminates_the_two_paths(monkeypatch, caplog):
+    """FAILS IF: both paths log the same 'Qt loop stalled' sentence."""
+    monkeypatch.setattr(te, "PANEL_INLINE_SLOW_MS", 0.0)
+    handler = _Handler({"ok": 1})
+    ex = _wire(monkeypatch, handler)
+
+    with caplog.at_level("WARNING"):
+        _really_off_main(ex, te.ToolRequest("tu_s1", "houdini_execute_python", LIGHT))
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("Qt loop NOT stalled" in m for m in msgs), (
+        "off-main dispatch must not claim the Qt loop stalled")
+    assert not any("Qt loop stalled this long" in m for m in msgs)
+
+
+# ── §5.3 HAZARD — the armed-but-inert class-3 wire ─────────────────────────
+
+def test_no_production_emitter_of_tool_requested():
+    """FAILS IF: anything in production emits ``tool_requested``.
+
+    synapse_panel.py:1938 connects worker.tool_requested -> execute_tool, the
+    synchronous main-thread slot. The wire is live and has zero emitters, which
+    is the only reason class 3 stays closed. ONE ``.emit`` re-arms a freeze
+    class that already has a verified fix, and nothing else in CI would notice.
+    """
+    offenders = []
+    for path in (REPO / "python").rglob("*.py"):
+        if "_vendor" in path.parts or "test" in path.name:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for n, line in enumerate(text.splitlines(), 1):
+            if "tool_requested" in line and ".emit" in line:
+                offenders.append(f"{path.relative_to(REPO).as_posix()}:{n}: {line.strip()}")
+
+    assert not offenders, (
+        "tool_requested is emitted in production — this re-arms freeze class 3 "
+        "(chat-time Qt fallback, closed at d15d9b2). Dispatch off-main instead:\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
## What this is

The code for `harness/notes/FREEZE_FORENSICS_20260731.md` §5, items 1–3.

That document was **diagnosis-only**. Commit `f427320` added 347 lines across 3 files — all docs and workflow, **zero source changes**. The freeze was mapped in detail and repaired in none of it.

---

## Why a guard and not a timeout

v5.40.1 shipped as *"the chat no longer grips the UI."* It bounded the caller's **wait** and never the running **payload**.

So the freezes continued. On **2026-07-31**, under that release, the main thread froze **8 times**, up to **44.4 s**, one escalating to SUSTAINED FREEZE — with the dump showing `main_thread_direct.count = 0`, meaning the class-3 mechanism never even fired.

A payload cannot be timed out once it is running, and the codebase already says why, verbatim at `handlers_render.py:109-113`:

> nothing in Python can interrupt the main thread from the main thread

So the only mechanism available is **refusing before entry** — the same shape as the render `foreground_guard`, which is already the sole protection on that path.

---

## The three fixes

**§5.1 PRIMARY — the h7 inline guard.** `_dispatch` now reads **real thread identity**, not a proxy for which entrypoint was used. When a dispatch is genuinely on the main thread *and* the pre-flight predicts a heavy payload, it is refused with an actionable error naming `execute_tool_off_main`. `_allow_heavy_inline = True` is the explicit opt-out.

This makes the pre-flight **enforcing** on the inline path where §5.1(b) called it *"advisory-only."* The advisory contract is unchanged on the off-main path, which is what the worker actually uses.

**§5.2 SECONDARY — honest thread attribution.** `_dispatch` is reached from *both* `execute_tool` (Qt slot, main thread) and `execute_tool_off_main` (daemon thread), and only the first can stall the Qt loop. The old `finally` recorded **both** into the main-thread counters and logged both as *"ran on the main thread (Qt loop stalled this long)."*

The forensics recorded that this *"corrupted forensics this run and will corrupt the next one."* Off-main samples now go to separate `offmain_*` counters and log *"Qt loop NOT stalled."* Durations are kept, just no longer misattributed.

**§5.3 HAZARD — the armed class-3 wire.** `synapse_panel.py:1938` connects `worker.tool_requested → execute_tool`. The wire is live with **zero emitters**, which is the only thing keeping class 3 closed; one `.emit` re-arms it and nothing in CI would notice. Pinned by a source scan rather than disconnected, because the slot contract is still used by tests and direct callers — and with the §5.1 guard in place, an accidental re-arm now degrades to a **refusal** instead of a freeze.

---

## What this does NOT fix — stated plainly

A payload dispatched off-main still marshals back to the main thread via `run_on_main` and occupies it for its duration. **The Qt loop still stalls for that long.**

Closing that requires chunking or timeboxing the individual cook-heavy handlers — `handlers_node.py:79`, `handlers_material.py:90/:246/:508`, `handlers_usd.py` (13 sites), `handlers_cops.py:929/:1987/:2127` — a per-handler refactor needing live verification each. **Not attempted here.**

**Freeze class 1 remains MITIGATED, not CLOSED.** What is closed is the unbounded *inline* path and the attribution defect that would mislead the next investigation.

---

## Tests

`tests/test_panel_preflight_h7_guard.py` — 9 new tests: refusal on main, light tools unaffected, heavy tools still run genuinely off-main, the escape hatch, no verdict leak between requests, off-main time not counted as main-thread time (**with a paired positive control** so it cannot pass vacuously), log discrimination, and the h9 emitter scan.

`tests/test_panel_preflight.py` — two tests moved onto a **real thread**. Calling `execute_tool_off_main` from the test's own thread is still main-thread execution, so the guard correctly fires there; exercising the off-main contract requires a genuine thread. The module docstring records the contract change rather than leaving the old "advisory ONLY" claim stale.

### One thing worth reviewing carefully

The new test file's **filename is load-bearing**, and this was found the hard way. The first draft was named `test_freeze_h7_inline_guard.py`, which made it the alphabetically-first panel test. That pulled `from synapse.panel import tool_executor` forward in collection, so the class bound `QObject` from whatever stub existed at that earlier moment — and **six previously-green tests started failing** with `_last_preflight` returning a MagicMock attribute instead of `None`.

I assumed those were pre-existing, then checked against a clean-master worktree instead of trusting the assumption. They passed on master. **The rename fixed them, not a code change.** The header comment records this so the next person doesn't re-break it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
