### PR TITLE
fix(ci): fetch-depth 0 — give test_d_track its master ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ jobs:
       MONETA_DEPLOY_KEY: ${{ secrets.MONETA_DEPLOY_KEY }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Full history, not the default depth-1 shallow clone.
+          # tests/test_d_track.py anchors its quarantine diff against master and
+          # fails "master ref unresolvable; fetch/create master before trusting
+          # this guard" on a shallow checkout — so the guard was reporting an
+          # environment gap on EVERY pull request, on every matrix leg, with
+          # nothing wrong in the code under test. A guard that cannot resolve
+          # its own baseline is not guarding.
+          fetch-depth: 0
 
       - name: Check out private Moneta backend (when key is configured)
         if: ${{ env.MONETA_DEPLOY_KEY != '' }}


### PR DESCRIPTION
The second half of the CI red documented in PR #53, held since yesterday morning in `.claude/BLOCKED_ci_workflow.diff` because the OAuth app lacked `workflow` scope — granted tonight (account switched to JosephOIbrahim), landing the saved diff verbatim.

`actions/checkout` defaults to a depth-1 shallow clone, so `master` does not exist in the CI working copy and `tests/test_d_track.py` fails on **every pull request** with *"cannot anchor the quarantine diff — master ref unresolvable."* A guard that cannot resolve its own baseline is not guarding.

With this + #53 (detached-HEAD tolerance, merged), CI can finally go fully green on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build workflows to access the complete repository history, improving reliability for history-dependent checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->