### PR TITLE
fix(server): freeze-chain zombie — stop() kills the whole episode, escalation idempotent

### DIFF
--- a/python/synapse/server/freeze_chain.py
+++ b/python/synapse/server/freeze_chain.py
@@ -60,6 +60,7 @@ class FreezeChain:
         self._timer_lock = threading.Lock()
         self._escalation_timer: Optional[threading.Timer] = None
         self._escalated = False
+        self._stopped = False
         self._watchdog = Watchdog(
             heartbeat_interval=heartbeat_interval,
             freeze_threshold=freeze_threshold,
@@ -71,6 +72,23 @@ class FreezeChain:
     # -- the one call the panel makes ------------------------------------
     def heartbeat(self):
         self._watchdog.heartbeat()
+
+    def stop(self):
+        """Shut the WHOLE chain down: watchdog AND any pending escalation.
+
+        Stopping only the watchdog leaves a zombie: an armed escalation Timer
+        survives ``Watchdog.stop()``, and the watchdog's ``_is_frozen`` stays
+        True after stop — so the orphaned timer fires later, passes its
+        is-frozen guard, and acts (dump + breaker force_open) against whatever
+        globals are live AT THAT MOMENT. In tests that double-fired
+        force_open across test boundaries (the two flaky master-CI reds of
+        2026-08-02); in production the same zombie could fire into a
+        successor session after a panel teardown. Idempotent.
+        """
+        self._stopped = True
+        with self._timer_lock:
+            self._cancel_timer_locked()
+        self._watchdog.stop()
 
     @property
     def is_frozen(self) -> bool:
@@ -88,6 +106,8 @@ class FreezeChain:
 
     # -- detection callbacks (Watchdog monitor thread) --------------------
     def _on_freeze(self, elapsed: float):
+        if self._stopped:
+            return  # monitor tick racing a shutdown must not arm a new timer
         logger.warning(
             "Main thread frozen for %.1fs — escalation in %.0fs unless it recovers",
             elapsed, max(0.0, self._escalate_after - elapsed),
@@ -121,6 +141,10 @@ class FreezeChain:
     # -- the acting half (escalation timer thread) ------------------------
     def _escalate(self):
         try:
+            if self._stopped:
+                return  # chain shut down after this timer was armed
+            if self._escalated:
+                return  # already acted for this freeze episode — never twice
             if not self._watchdog.is_frozen:
                 return  # recovered between detection and the deadline
             self._escalated = True

--- a/tests/test_m3_logs_doctor.py
+++ b/tests/test_m3_logs_doctor.py
@@ -200,7 +200,7 @@ def test_escalate_dumps_evidence(tmp_path, monkeypatch):
         data = json.loads(dumps[0].read_text(encoding="utf-8"))
         assert data["reason"] == "sustained_freeze"
     finally:
-        chain._watchdog.stop()
+        chain.stop()
 
 
 def test_dump_failure_never_blocks_escalation(monkeypatch):
@@ -218,7 +218,43 @@ def test_dump_failure_never_blocks_escalation(monkeypatch):
         assert chain.escalated is True
         breaker.force_open.assert_called_once()  # the breaker still ACTED
     finally:
-        chain._watchdog.stop()
+        chain.stop()
+
+
+def test_stop_cancels_pending_escalation(monkeypatch):
+    """FAILS IF: a chain stopped BEFORE its escalation deadline still escalates.
+
+    The zombie that flaked master CI twice (2026-08-02): Watchdog.stop() does
+    not cancel the chain's armed escalation Timer, and _is_frozen stays True
+    after stop — so the orphaned timer fired later, passed its guard, and
+    force_open'd the breaker registered by the NEXT test. chain.stop() must
+    kill the whole episode.
+    """
+    srv, breaker, _bridge = _fake_server(with_bridge=True)
+    ws._register_live_server(srv)
+    chain = _chain()
+    chain.heartbeat()
+    time.sleep(0.1)          # past freeze_threshold (0.06): timer armed
+    chain.stop()             # BEFORE escalate_after (0.2)
+    time.sleep(0.3)          # past the would-be deadline
+    assert chain.escalated is False
+    breaker.force_open.assert_not_called()
+
+
+def test_escalation_is_idempotent_per_episode(monkeypatch):
+    """FAILS IF: one sustained freeze episode acts twice. _escalate must be
+    a no-op once escalated, however many timers reach it."""
+    srv, breaker, _bridge = _fake_server(with_bridge=True)
+    ws._register_live_server(srv)
+    chain = _chain()
+    try:
+        chain.heartbeat()
+        time.sleep(0.6)
+        assert chain.escalated is True
+        chain._escalate()    # a duplicate/zombie timer firing again
+        breaker.force_open.assert_called_once()
+    finally:
+        chain.stop()
 
 
 def test_freeze_dumps_pruned(tmp_path):


### PR DESCRIPTION
The two red ✗ runs on master (#61, #63 merge commits) were one test each in `test_m3_logs_doctor.py` — and the root cause is a **production defect**, not test noise.

**The zombie:** `Watchdog.stop()` never cancelled the chain's armed escalation Timer, and `_is_frozen` stays True after stop. The orphaned timer fires after its chain is torn down, passes its stale guard, and acts on whatever globals are live at that moment — second freeze dump, second `force_open`. In CI: the previous test escalating into the next test's fixtures (`Called 2 times` / `assert 2 == 1`). In production: the same zombie could fire into a successor session after panel teardown.

**Fix (state-anchored, no sleeps widened):** `FreezeChain.stop()` cancels the pending timer + stops the watchdog; `_escalate` no-ops when stopped or already escalated (one episode acts exactly once — recovery still resets, so a genuine refreeze escalates again); `_on_freeze` refuses to arm during shutdown.

**Proof:** two new regression tests pin the zombie · the file ran **20 consecutive times, 0 failures** · full suite **5,299 / 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)