### PR TITLE
fix(tests): kill the sleep-race class — event/state anchoring

### DIFF
--- a/tests/test_m3_logs_doctor.py
+++ b/tests/test_m3_logs_doctor.py
@@ -193,7 +193,9 @@ def test_escalate_dumps_evidence(tmp_path, monkeypatch):
     chain = _chain()
     try:
         chain.heartbeat()                       # arm monitoring
-        time.sleep(0.6)                         # freeze past detection + deadline
+        deadline = time.time() + 10
+        while time.time() < deadline and not chain.escalated:
+            time.sleep(0.01)                    # bounded poll, never a bare sleep
         assert chain.escalated is True
         dumps = list(tmp_path.glob("freeze_dump_*.json"))
         assert len(dumps) == 1
@@ -214,7 +216,9 @@ def test_dump_failure_never_blocks_escalation(monkeypatch):
     chain = _chain()
     try:
         chain.heartbeat()
-        time.sleep(0.6)
+        deadline = time.time() + 10
+        while time.time() < deadline and not chain.escalated:
+            time.sleep(0.01)
         assert chain.escalated is True
         breaker.force_open.assert_called_once()  # the breaker still ACTED
     finally:
@@ -232,12 +236,23 @@ def test_stop_cancels_pending_escalation(monkeypatch):
     """
     srv, breaker, _bridge = _fake_server(with_bridge=True)
     ws._register_live_server(srv)
-    chain = _chain()
+    # LONG deadline: the escalation can never fire naturally during this
+    # test, so no runner speed can turn "stop before deadline" into "stop
+    # after". State-anchored, per the same doctrine as the fix itself.
+    chain = fc.FreezeChain(escalate_after=30.0, heartbeat_interval=0.02,
+                           freeze_threshold=0.06)
     chain.heartbeat()
-    time.sleep(0.1)          # past freeze_threshold (0.06): timer armed
-    chain.stop()             # BEFORE escalate_after (0.2)
-    time.sleep(0.3)          # past the would-be deadline
-    assert chain.escalated is False
+    deadline = time.time() + 10
+    while time.time() < deadline and not chain.is_frozen:
+        time.sleep(0.01)                     # wait for the freeze EDGE
+    assert chain.is_frozen, "freeze never detected"
+    with chain._timer_lock:
+        assert chain._escalation_timer is not None   # timer really armed
+    chain.stop()
+    with chain._timer_lock:
+        assert chain._escalation_timer is None       # stop() cancelled it
+    chain._escalate()                        # even a zombie firing now…
+    assert chain.escalated is False          # …acts on nothing
     breaker.force_open.assert_not_called()
 
 
@@ -249,7 +264,9 @@ def test_escalation_is_idempotent_per_episode(monkeypatch):
     chain = _chain()
     try:
         chain.heartbeat()
-        time.sleep(0.6)
+        deadline = time.time() + 10
+        while time.time() < deadline and not chain.escalated:
+            time.sleep(0.01)
         assert chain.escalated is True
         chain._escalate()    # a duplicate/zombie timer firing again
         breaker.force_open.assert_called_once()

--- a/tests/test_main_thread_hold_metric.py
+++ b/tests/test_main_thread_hold_metric.py
@@ -117,20 +117,49 @@ def test_label_threads_through(monkeypatch):
 
 def test_abandoned_mid_payload_still_records_marked(monkeypatch):
     """A payload the caller abandoned WHILE it was running (C4 residual race)
-    is precisely the interesting hold — it must record, marked abandoned."""
+    is precisely the interesting hold — it must record, marked abandoned.
+
+    Event-anchored (flaked on CI 2026-08-02): the old shape used sleeps, so a
+    starved runner could wake the deferred thread AFTER the 0.1s abandonment —
+    C4 then kills the payload pre-start and the premise ("abandoned while
+    RUNNING") never happened; count stayed 0. Now the payload proves it
+    started before we let the caller time out, and only finishes after the
+    abandonment has demonstrably occurred. No fixed sleep decides anything.
+    """
     mt = _load_mt()
-    monkeypatch.setitem(sys.modules, "hdefereval", _fake_hdefereval(delay=0.02))
+    monkeypatch.setitem(sys.modules, "hdefereval", _fake_hdefereval())
     mt.reset_main_thread_hold_stats()
 
-    out = _from_worker(mt, lambda: time.sleep(0.5), timeout=0.1, label="slow_op")
-    assert "error" in out                     # caller timed out mid-payload
-    time.sleep(0.9)                           # let the zombie payload finish
+    started = threading.Event()
+    release = threading.Event()
 
+    def payload():
+        started.set()
+        assert release.wait(timeout=10), "test bug: release never set"
+
+    out = {}
+    def worker():
+        try:
+            out["value"] = mt.run_on_main(payload, timeout=0.05, label="slow_op")
+        except Exception as e:  # noqa: BLE001
+            out["error"] = e
+    t = threading.Thread(target=worker)
+    t.start()
+    assert started.wait(timeout=10), "payload never started"   # mid-payload…
+    t.join(timeout=10)                                          # …caller gone
+    assert "error" in out                     # caller timed out mid-payload
+    release.set()                             # zombie finishes AFTER abandon
+
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        if mt.main_thread_hold_stats()["count"] == 1:
+            break
+        time.sleep(0.01)
     s = mt.main_thread_hold_stats()
     assert s["count"] == 1
     assert s["abandoned_count"] == 1
     assert s["slowest_label"] == "slow_op"
-    assert s["sum_ms"] >= 300                 # the full ≈500ms hold, recorded
+    assert s["sum_ms"] > 0                    # a real hold was measured
 
 
 def test_abandoned_before_start_records_no_hold(monkeypatch):
@@ -144,7 +173,13 @@ def test_abandoned_before_start_records_no_hold(monkeypatch):
     ran = []
     out = _from_worker(mt, lambda: ran.append(1), timeout=0.05)
     assert "error" in out
-    time.sleep(0.8)                           # let the abandoned wake fire
+    # State-anchored: wait for the abandoned wake to land its dispatch-wait
+    # datum, bounded — never a fixed sleep (CI runners stretch sleeps).
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        if mt.dispatch_wait_stats()["count"] == 1:
+            break
+        time.sleep(0.01)
 
     assert ran == []                          # fn() never executed (C4 intact)
     assert mt.main_thread_hold_stats()["count"] == 0


### PR DESCRIPTION
Master's red at `51011d5` was the OCC lane's abandoned-payload test: on a starved runner the deferred wake lands **after** the abandonment, C4 correctly kills the payload pre-start, and the test asserts against a scenario that never happened. **Handshake, not luck:** started/release Events + bounded polls.

Also fixed **preemptively**: the two zombie regression tests I added earlier today carried the same latent disease — now the stop-cancels-pending test uses a 30s deadline (no runner speed can invert "stop before deadline"), asserts timer *state*, and drives the zombie `_escalate()` directly. The two original 0.6s escalation sleeps became bounded polls.

Both files ×20 consecutive runs, 0 failures. Full suite **5,299 / 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)