### PR TITLE
DRAFT [phantom-sweep review]: alternate pdg/pxr scanner implementation (post-l5 revision, CTO soundness notes)

### DIFF
--- a/harness/clear/PROPOSED-P5.1.md
+++ b/harness/clear/PROPOSED-P5.1.md
@@ -1,0 +1,225 @@
+# PROPOSED-P5.1 — production code phantom-clean across hou/pdg/pxr
+
+> **Status: PROPOSED — surfaced for Joe's ratification.** Not ratified. Do NOT edit
+> `harness/clear/SPEC.md` or `harness/clear/verify.py` until Joe flips this to ratified.
+> This file is the ratification packet: the predicate, the SPEC.md amendment diff (not
+> applied), the verify.py snippet (not applied), and the ask.
+>
+> **Author:** FORGE leg, CLEAR L5 (2026-07-31).
+> **Builds on:** the ratified P3.x phantom guardrail (`harness/verify/checks.py::
+> _hou_phantoms_in_source` + `check_phantom_clean`), pinned by
+> `tests/test_phantom_guardrail.py`.
+
+---
+
+## 1. The gap (why this predicate exists)
+
+SYNAPSE's #1 failure class is phantom APIs (`hou.pdg.*`, `hou.secure`,
+`hou.lopNetworks()`, `pdg.PyEventHandler`, `pdg.EventType`). The membership
+AUTHORITY — `python/synapse/cognitive/tools/data/h22_symbol_table.json`, built by
+`host/introspect_runtime.py` — already authoritatively covers **hou, pdg, AND pxr**:
+its self-check asserts `pdg.EventType` and `pxr.Usd` are in the table (it dir()-walks
+`hou` depth 2, `pdg` depth 2, AND `pxr` depth 1).
+
+The LINT — `harness/verify/checks.py::_hou_phantoms_in_source` — is **hou-ONLY**: it
+collects only `import hou` aliases and flags only `hou.<attr>` depth-1 accesses. It
+does NOT scan `pdg.*` or `pxr.*` accesses. So a bare `pdg.PyEventHandler(fn)` or
+`pdg.EventType.CookComplete` slips through `check_phantom_clean` TODAY even though the
+table knows `pdg.EventType` is real and `pdg.PyEventHandler` is a phantom (no constructor
+on H21.0.671 / H22.0.368).
+
+**The authority covers pdg/pxr; the scanner does not. The gap is real.**
+
+### CTO verdict on the depth asymmetry (advisory — VERIFIED 2026-07-30)
+
+- **pdg — SOUND.** `host/introspect_runtime.py:94-97` does
+  `_walk(pdg, "pdg", 0, DEPTH_HOU_PDG=2, ...)`, iterating `dir(pdg)` at depth 0. Every
+  top-level pdg name is enumerated by the same mechanism hou uses. 235 pdg depth-1 names
+  in the H22 table; `pdg.EventType`, `pdg.PyEventHandler`, `pdg.GraphContext`,
+  `pdg.Scheduler`, `pdg.WorkItem` all present. A depth-1 lint on `pdg.<attr>` carries
+  the same proof-by-absence guarantee as hou. Production code (`shared/bridge.py:1581-
+  1593`) uses `import pdg as _pdg` then `_pdg.EventType.CookComplete`, so the lint MUST
+  resolve `import pdg as <alias>` exactly as the hou lint resolves `import hou as X`.
+- **pxr — NOT SOUND as-is for arbitrary `pxr.<attr>`.** `introspect_runtime.py:101-115`
+  does NOT call `_walk(pxr, ...)`. It does `out.add("pxr")` then enumerates submodules via
+  `pkgutil.iter_modules(pxr.__path__)` + each submodule's depth-1 members. It does NOT
+  enumerate `dir(pxr)` itself — any non-submodule top-level attribute (a function,
+  constant, or dynamically-attached name) is absent from the table. The 41 pxr depth-1
+  names are ALL submodules (Ar, Sdf, Tf, Usd, UsdGeom, ...). A depth-1 lint on
+  `pxr.<attr>` would FALSE-PHANTOM a real `pxr.<non-submodule-attr>`.
+
+  **Practical impact is low and the reach is near-zero:** SYNAPSE production code never
+  uses `pxr.<attr>` Attribute access — it uses `from pxr import Usd` then `Usd.Attribute`
+  (so `node.value.id` is the submodule name, not `pxr`; the depth-1 lint never fires on
+  real pxr usage). The only `pxr.<Capital>` tokens in source are in docstrings, comments,
+  test-mock string literals, and the introspect self-check — all non-Attribute AST nodes
+  the lint ignores. The FORGE implementation extends the lint to pxr ANYWAY (the task
+  asked for it), documents the soundness gap inline, and unions NO allowlist (no real
+  false-phantom fires in current code; the CTO's "only if a real false-phantom would
+  otherwise fire" condition is not met). Closing the gap for real requires a table-build
+  change: add `_walk(pxr, "pxr", 0, 0, ...)` to capture non-submodule top-level attrs.
+
+---
+
+## 2. What FORGE already shipped (the lint extension — DONE, not awaiting ratification)
+
+The AST lint extension is **already implemented** in `harness/verify/checks.py` and
+pinned by extended tests in `tests/test_phantom_guardrail.py` (24 tests pass). This is
+a NOW-probe improvement to the existing guardrail and does NOT require SPEC ratification
+— it closes the "scanner doesn't cover pdg/pxr the table already authorizes" gap inside
+the existing `check_phantom_clean` gate, preserving its current gate-down=WARN
+semantics.
+
+- `_hou_phantoms_in_source` — KEPT INTACT (existing tests pin it).
+- `_module_depth1_phantoms(src, table_syms, module_name)` — NEW generalized depth-1
+  scanner for any module the table dir()-walks at depth 0 (pdg). Documents the pxr
+  soundness gap inline.
+- `_phantoms_in_source(src, table_syms)` — NEW unified scan = hou + pdg + pxr.
+- `check_phantom_clean` — wired to call `_phantoms_in_source`; detail message updated to
+  `phantom hou.*/pdg.*/pxr.* introduced`.
+
+**What this did NOT change:** the gate-down posture. `check_phantom_clean` still returns
+`ok:None` (WARN, never a false block) when the symbol table is missing/stale. That
+clearance-semantics change is what P5.1 ratifies — see §3.
+
+---
+
+## 3. The P5.1 predicate (the ratification ask)
+
+**P5.1 — production code is phantom-clean across hou/pdg/pxr, with clearance
+semantics: a down authority gate is a FAIL, not a WARN.**
+
+Two halves, both required for P5.1 to PASS:
+
+1. **Coverage.** The sprint's changed `.py` introduces no table-proven-absent
+   `hou.<attr>` / `pdg.<attr>` / `pxr.<attr>` depth-1 access. The authority is the
+   introspected dir() symbol table (`h<major>_symbol_table.json`); the scanner is
+   `_phantoms_in_source` (hou + pdg + pxr depth-1). (SHIPPED by FORGE — the lint now
+   covers all three.)
+
+2. **Clearance semantics.** A missing/stale/mismatched symbol table is a **FAIL**, not
+   a WARN. Today `check_phantom_clean` returns `ok:None` (WARN) on a gate-down,
+   reflecting "cannot prove absence ⇒ do not false-block." P5.1 inverts this for the
+   CLEAR bar: a down authority gate means the phantom defense is **off**, and a sprint
+   that cannot prove its code phantom-clean does not clear. `ok:None` → `ok:False` with
+   a detail naming the gate-down reason (missing/stale/build-mismatch).
+
+   **Why this is a ratification, not an auto-fix:** the WARN posture is the deliberate
+   single-user-localhost default (auto-approve on a down gate, never a false block). The
+   CLEAR clearance bar is a stricter posture — it says "if you can't prove it's clean,
+   you don't ship." That is a posture decision, Joe's to make, not FORGE's to flip. The
+   FORGE implementation keeps WARN so the existing harness behavior is unchanged until
+   Joe ratifies.
+
+### Soundness caveat carried into the predicate
+
+The pxr branch is NOT dir()-complete (§1). P5.1's pxr coverage is therefore
+**submodule-scoped in practice**: it catches a phantom `pxr.<BadSubmodule>` (absent
+from the 41-name submodule list) but cannot soundly catch a `pxr.<non-submodule-attr>`
+(the table doesn't enumerate `dir(pxr)`). This is documented inline in
+`_module_depth1_phantoms` and accepted because (a) zero `pxr.<attr>` depth-1 accesses
+exist in production code, and (b) the alternative — silently unioning a blanket pxr
+allowlist — would defeat the lint for the case that DOES matter (phantom submodules).
+A future table-build change (`_walk(pxr, "pxr", 0, 0, ...)`) closes the gap and makes
+P5.1's pxr coverage fully dir()-complete.
+
+---
+
+## 4. SPEC.md amendment diff (NOT applied — for ratification)
+
+Against the ratified `harness/clear/SPEC.md` "Acceptance Predicates" table. This adds
+P5.1 as a new row without altering any existing predicate.
+
+```diff
+ ## Acceptance Predicates
+
+ The bar. These IDs are canonical — used verbatim in PLAN, CHAMPION, verify.py, and the progress bar.
+
+ | ID | Predicate | Check |
+ |---|---|---|
+ | **P1.1** | Latency-relay files are committed at `<sha>` OR dropped via a logged human gate | `git log --all` finds all 6 files, OR a DECISIONS/flywheel entry marks the set dropped |
+ | **P2.1** | Board is non-stale (regenerated <24h) AND cycle C.0 has a recorded human decision (ratified OR explicitly deferred) | `python harness/decisions.py --count` runs + read `harness/state/flywheel_queue.json` C.0 |
+ | **P3.1** | F6 fixed: SessionStart pings before reporting "connected" | `tests/test_sessionstart_ping.py` collects + passes |
+ | **P3.2** | CI mcp drift resolved (mcp pinned OR `mcp_server.py:899` updated) | `python -m pytest tests/test_passthrough_hygiene.py --co -q` collects without the `list_tools` error |
+ | **P3.3** | `websocket.py:471` cancel is reachable mid-frame | a cancel-injection test passes |
+ | **P3.4** | husk render cure is parked behind a named gate (Indie-blocked) | a DECISIONS/flywheel entry exists; no agent claims to "fix" it |
+ | **P3.5** | Latency report §1 addendum appended (Joe's gate) | addendum file exists OR a "gated, deferred" entry |
+ | **P4.1** | v5.34–v5.40 have CHANGELOG entries OR a deliberate "not backfilling" decision | `CHANGELOG.md` grep for `## v5.34`..`## v5.40` + DECISIONS entry |
++| **P5.1** | Production code is phantom-clean across hou/pdg/pxr, with clearance semantics: a down authority gate is a FAIL, not a WARN | `harness/verify/checks.py::check_phantom_clean` over the sprint's changed `.py` returns `ok:True` (no table-proven-absent `hou.<attr>`/`pdg.<attr>`/`pxr.<attr>` depth-1 access) AND a missing/stale/mismatched symbol table yields `ok:False`, not `ok:None` |
+```
+
+And a matching row in the "Verification Strategy" table:
+
+```diff
+ | P4.1 | L1 (grep + entry) | No |
++| P5.1 | L1 (AST lint over changed .py) + L4 (crucible: inject a phantom pdg.*/pxr.* + a downed table, assert FAIL not WARN) | No |
+ | All gates | L4 (crucible: tries to make an agent flip `ratified`, cross Gate C, narrate a false bar) | No |
+```
+
+---
+
+## 5. verify.py snippet (NOT applied — for ratification)
+
+The function P5.1's check would add to the ratified `harness/clear/verify.py`. It
+calls the existing `check_phantom_clean` and judges BOTH halves: coverage (ok:True) AND
+clearance semantics (a down gate is FAIL, not the WARN FORGE shipped). Until ratified,
+this snippet is NOT wired into `PREDICATES` — it lives only in this proposal.
+
+```python
+# --- P5.1: phantom-clean across hou/pdg/pxr, gate-down=FAIL (proposed) ---
+def p5_1():
+    """PASS only if the sprint's changed .py is phantom-clean across hou/pdg/pxr AND a
+    down/stale symbol table is a FAIL (not a WARN). Calls the harness guardrail
+    (harness/verify/checks.py::check_phantom_clean) with the worktree as ctx.
+
+    NOTE: the shipped check_phantom_clean returns ok:None (WARN) on a gate-down. P5.1
+    ratification FLIPS that to ok:False at the CLEAR-bar layer (this function maps
+    ok:None -> FAIL), without mutating the harness guardrail's own posture for the
+    non-CLEAR run.ts path. The harness flip (ok:None -> ok:False inside
+    check_phantom_clean itself) is a separate, follow-on ratification; this predicate
+    enforces the CLEAR-bar posture regardless.
+    """
+    import importlib.util
+    checks_path = REPO / "harness" / "verify" / "checks.py"
+    spec = importlib.util.spec_from_file_location("harness_checks", checks_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    result = mod.check_phantom_clean({"wt": str(REPO), "hython": os.environ.get("HYTHON", "")})
+    ok = result.get("ok")
+    detail = result.get("detail", "")
+    if ok is True:
+        return PASS, detail
+    if ok is None:
+        # P5.1 clearance semantics: a down authority gate is a FAIL, not a WARN.
+        return FAIL, f"authority gate down (P5.1 treats WARN as FAIL): {detail}"
+    return FAIL, detail
+
+
+# When ratified, add to PREDICATES:
+#     ("P5.1", "phantom-clean hou/pdg/pxr (gate-down=FAIL)", p5_1),
+```
+
+---
+
+## 6. The ratification ask
+
+**Joe —** ratify P5.1 to make the CLEAR clearance bar treat a down phantom-authority
+gate as a FAIL instead of a WARN. The coverage half (lint scans hou + pdg + pxr) is
+already shipped and tested; ratification flips the posture:
+
+- **If you ratify:** apply the §4 SPEC.md diff (add the P5.1 row) and the §5 verify.py
+  snippet (add `p5_1` + register it in `PREDICATES`). The harness guardrail
+  (`check_phantom_clean`) can keep its WARN for the run.ts path; the CLEAR bar maps
+  `ok:None -> FAIL` at the bar layer, OR you can ratify the deeper flip (warn → fail
+  inside `check_phantom_clean` itself) as a follow-on.
+- **If you defer:** P5.1 stays PROPOSED. The FORGE lint extension (hou + pdg + pxr
+  coverage, WARN on gate-down) remains in place — the gap "scanner doesn't cover
+  pdg/pxr the table already authorizes" is closed either way; only the stricter
+  gate-down posture waits for you.
+
+**One open question for you:** the pxr branch is submodule-scoped (not dir()-complete).
+Do you want a follow-on table-build change — `_walk(pxr, "pxr", 0, 0, ...)` in
+`host/introspect_runtime.py` — to make P5.1's pxr coverage fully sound, or is the
+documented submodule-scoped acceptance (zero production `pxr.<attr>` accesses today)
+good enough? FORGE recommends the table-build follow-on before any future pxr-heavy
+sprint, but it is not blocking P5.1.

--- a/harness/verify/checks.py
+++ b/harness/verify/checks.py
@@ -415,6 +415,67 @@ def _hou_phantoms_in_source(src, table_syms):
                 hits.append((node.lineno, symbol))
     return hits
 
+def _module_depth1_phantoms(src, table_syms, module_name):
+    """[(lineno, "<module>.<attr>"), ...] for <module>-attribute accesses the table PROVES absent.
+    Generalized depth-1 scanner for any top-level module the introspect table enumerates via
+    dir() at depth 0 — the same proof-by-absence guarantee _hou_phantoms_in_source has for hou.
+    Collects `import <module>` and `import <module> as X` aliases, flags <alias>.<attr> depth-1
+    accesses not in table_syms. Deeper access (<module>.Class.method) is unknown != phantom
+    (the inner <module>.Class is judged + covered; the outer has an Attribute value and is
+    skipped), identical to the hou depth-1 boundary.
+
+    Soundness note (CTO verdict, 2026-07-30):
+    - pdg: SOUND. host/introspect_runtime.py:94-97 calls _walk(pdg, "pdg", 0, DEPTH_HOU_PDG=2,
+      ...) which iterates dir(pdg) at depth 0, so every top-level pdg name is enumerated by the
+      same mechanism hou uses. The H22 table confirms: 235 pdg depth-1 names, and pdg.EventType,
+      pdg.PyEventHandler, pdg.GraphContext, pdg.Scheduler, pdg.WorkItem are all present (self-
+      check at introspect_runtime.py:141 asserts pdg.EventType). pdg.<attr> absence is proof.
+      Codebase caveat: production code (shared/bridge.py:1581-1593) uses `import pdg as _pdg`
+      then `_pdg.EventType.CookComplete`, so alias resolution (`import pdg as X`) is required to
+      reach real code — handled here exactly as the hou lint resolves `import hou as X`.
+    - pxr: NOT dir()-complete. host/introspect_runtime.py:101-115 does NOT call _walk(pxr, ...);
+      it enumerates pxr.<submodule> via pkgutil.iter_modules(pxr.__path__) + each submodule's
+      depth-1 members, but NOT dir(pxr) itself. The 41 pxr depth-1 names in the H22 table are all
+      submodules (Ar, Sdf, Tf, Usd, UsdGeom, ...). A real pxr.<non-submodule> top-level attr (a
+      function/constant/dynamically-attached name) is absent from the table and would FALSE-
+      PHANTOM; the AST checker cannot distinguish submodule vs non-submodule at resolution time.
+      This is a KNOWN SOUNDNESS GAP, accepted because SYNAPSE production code uses
+      `from pxr import X` (so node.value.id is the submodule name, not `pxr`) — zero pxr.<attr>
+      depth-1 Attribute accesses exist today (verified by grep), so no false phantom fires in
+      current code. Closing the gap requires a table-build change (add _walk(pxr, "pxr", 0, 0,
+      ...) to capture non-submodule top-level attrs). No allowlist is unioned here because no
+      real false-phantom would otherwise fire today (the CTO's `only if a real false-phantom
+      would otherwise fire` condition is not met); the gap is documented, not papered over."""
+    import ast
+    tree = ast.parse(src)
+    aliases = {module_name}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == module_name:
+                    aliases.add(alias.asname or module_name)
+    hits = []
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name)
+                and node.value.id in aliases):
+            symbol = module_name + "." + node.attr
+            if symbol not in table_syms:
+                hits.append((node.lineno, symbol))
+    return hits
+
+def _phantoms_in_source(src, table_syms):
+    """Unified depth-1 phantom scan across hou, pdg, pxr. Unions the existing hou scan (kept
+    intact — tests/test_phantom_guardrail.py pins it) with pdg and pxr depth-1 scans. The
+    introspect symbol table authoritatively covers all three modules (its self-check asserts
+    pdg.EventType and pxr.Usd), so this closes the gap where the hou-only lint let
+    pdg.PyEventHandler / pdg.EventType slip through check_phantom_clean even though the table
+    knew they were real. See _module_depth1_phantoms for the pdg-sound / pxr-not-dir()-
+    complete asymmetry (CTO verdict 2026-07-30)."""
+    hits = list(_hou_phantoms_in_source(src, table_syms))
+    hits.extend(_module_depth1_phantoms(src, table_syms, "pdg"))
+    hits.extend(_module_depth1_phantoms(src, table_syms, "pxr"))
+    return hits
+
 def _sprint_added_py(wt, base):
     """{relpath: set(added_line_no) | None} for .py touched since <base> — None marks a new
     untracked file (whole file is new). `git diff --unified=0` gives exact added line numbers
@@ -478,7 +539,10 @@ def check_phantom_clean(ctx):
     added = _sprint_added_py(wt, base)  # {relpath: set(added_lines) | None (=whole new file)}
     if not added:
         return {"ok": True, "detail": "no changed .py lines in this sprint"}
-    # 3) AST-scan each changed file; flag table-proven-absent hou.<attr> only on ADDED lines.
+    # 3) AST-scan each changed file; flag table-proven-absent hou.*/pdg.*/pxr.* only on ADDED lines.
+    # Unified scan (P5.1 extension): the introspect table authoritatively covers hou, pdg, AND pxr
+    # (its self-check asserts pdg.EventType + pxr.Usd); the hou-only lint let pdg.PyEventHandler /
+    # pdg.EventType slip through. _phantoms_in_source unions all three depth-1 surfaces.
     offenders, unparseable = [], []
     for rel, addl in added.items():
         f = Path(wt) / rel
@@ -489,7 +553,7 @@ def check_phantom_clean(ctx):
         except Exception:
             continue
         try:
-            hits = _hou_phantoms_in_source(src, table_syms)
+            hits = _phantoms_in_source(src, table_syms)
         except SyntaxError:
             unparseable.append(rel)  # a broken file fails other checks anyway — don't crash the gate
             continue
@@ -499,9 +563,9 @@ def check_phantom_clean(ctx):
     ver = status.get("houdini_version", "?")
     if offenders:
         note = f" (+{len(unparseable)} unparseable, skipped)" if unparseable else ""
-        return {"ok": False, "detail": (f"phantom hou.* introduced (absent in the {ver} symbol "
+        return {"ok": False, "detail": (f"phantom hou.*/pdg.*/pxr.* introduced (absent in the {ver} symbol "
                 f"table): {', '.join(sorted(set(offenders))[:12])}{note}")[:500]}
-    clean = f"{len(added)} changed .py clean of table-proven phantom hou.* APIs (vs {len(table_syms)} live symbols @ {ver})"
+    clean = f"{len(added)} changed .py clean of table-proven phantom hou.*/pdg.*/pxr.* APIs (vs {len(table_syms)} live symbols @ {ver})"
     if unparseable:
         clean += f" ({len(unparseable)} unparseable, skipped)"
     return {"ok": True, "detail": clean[:500]}

--- a/tests/test_phantom_guardrail.py
+++ b/tests/test_phantom_guardrail.py
@@ -14,9 +14,19 @@ _spec.loader.exec_module(checks)
 # hou.secure, hou.updateGraphTick) is absent ⇒ phantom.
 TABLE = {"hou", "hou.node", "hou.LopNode", "hou.hipFile", "hou.pwd"}
 
+# pdg/pxr surface for the unified scan (P5.1). Mirrors the real H22 table shape: pdg.EventType
+# and pxr.Usd are present (the introspect self-check asserts both); pdg.PyEventHandler is a
+# known phantom (no constructor on H21.0.671 / H22.0.368).
+PDG_PXR_TABLE = TABLE | {"pdg", "pdg.EventType", "pdg.GraphContext", "pdg.Scheduler",
+                         "pdg.WorkItem", "pxr", "pxr.Usd", "pxr.Sdf", "pxr.Tf"}
+
 
 def _syms(src):
     return [s for _, s in checks._hou_phantoms_in_source(src, TABLE)]
+
+
+def _unified_syms(src, table=None):
+    return [s for _, s in checks._phantoms_in_source(src, table or PDG_PXR_TABLE)]
 
 
 def test_flags_real_phantom_attribute():
@@ -67,6 +77,81 @@ def test_gui_submodules_allowlisted():
     assert checks._hou_phantoms_in_source("import hou\nhou.ui.displayMessage('x')\nx = hou.qt.mainWindow()\n", tbl) == []
     # a genuine phantom still trips even with the allowlist in place
     assert ("hou.lopNetworks" in [s for _, s in checks._hou_phantoms_in_source("hou.lopNetworks()\n", tbl)])
+
+
+# ---------- P5.1: unified hou/pdg/pxr depth-1 phantom scan ----------
+
+def test_unified_flags_pdg_phantom_when_absent():
+    # pdg.PyEventHandler has no constructor on H21/H22 — absent from a fake table ⇒ phantom.
+    tbl = PDG_PXR_TABLE - {"pdg.PyEventHandler"} if "pdg.PyEventHandler" in PDG_PXR_TABLE else PDG_PXR_TABLE
+    assert "pdg.PyEventHandler" in _unified_syms("import pdg\nh = pdg.PyEventHandler(fn)\n", tbl)
+
+
+def test_unified_flags_pdg_eventtype_phantom_when_absent():
+    tbl = PDG_PXR_TABLE - {"pdg.EventType"}
+    assert "pdg.EventType" in _unified_syms("import pdg\npdg.EventType.CookComplete\n", tbl)
+
+
+def test_unified_does_not_flag_real_pdg_eventtype():
+    # pdg.EventType IS in the table (self-check asserts it) → not flagged, even at depth-1.
+    assert _unified_syms("import pdg\nev = pdg.EventType.CookComplete\n") == []
+
+
+def test_unified_does_not_flag_real_pxr_usd():
+    # pxr.Usd IS in the table → not flagged.
+    assert _unified_syms("import pxr\ns = pxr.Usd.Stage.CreateNew('x')\n") == []
+
+
+def test_unified_resolves_pdg_alias():
+    # shared/bridge.py uses `import pdg as _pdg` then `_pdg.EventType.CookComplete`.
+    tbl = PDG_PXR_TABLE - {"pdg.EventType"}
+    assert "pdg.EventType" in _unified_syms("import pdg as _pdg\n_pdg.EventType.CookComplete\n", tbl)
+    # and the real alias form is clean when EventType is present
+    assert _unified_syms("import pdg as _pdg\n_pdg.EventType.CookComplete\n") == []
+
+
+def test_unified_resolves_pxr_alias():
+    tbl = PDG_PXR_TABLE - {"pxr.Usd"}
+    assert "pxr.Usd" in _unified_syms("import pxr as _pxr\n_pxr.Usd.Stage\n", tbl)
+
+
+def test_unified_ignores_pdg_in_string_and_comment():
+    assert _unified_syms('x = "pdg.PyEventHandler"\n# pdg.EventType\n') == []
+    assert _unified_syms('"""never call pdg.PyEventHandler()"""\n') == []
+
+
+def test_unified_ignores_pxr_in_string_and_comment():
+    assert _unified_syms('x = "pxr.Usd"\n# pxr.Sdf\n') == []
+
+
+def test_unified_hou_still_flagged():
+    # The unified scan still catches hou phantoms — hou logic is unchanged.
+    tbl = PDG_PXR_TABLE - {"hou.node"} if "hou.node" in PDG_PXR_TABLE else PDG_PXR_TABLE
+    assert "hou.lopNetworks" in _unified_syms("import hou\nhou.lopNetworks()\n")
+
+
+def test_unified_depth2_pdg_member_not_flagged():
+    # pdg.EventType.CookComplete: pdg.EventType is depth-1 (covered), .CookComplete is depth-2
+    # → unknown != phantom (same boundary as hou.LopNode.fakeMethod).
+    assert _unified_syms("import pdg\npdg.EventType.CookComplte\n") == []
+
+
+def test_unified_from_import_pxr_not_flagged_as_pxr_attr():
+    # `from pxr import Usd` makes `Usd` the Name, not `pxr` — `Usd.Attribute` is depth-1 on Usd,
+    # not on pxr, so the pxr branch never fires. This is the production pattern (grep-verified).
+    assert _unified_syms("from pxr import Usd\ns = Usd.Stage.CreateNew('x')\n") == []
+
+
+def test_module_depth1_phantoms_helper_is_sound_for_pdg():
+    # The generalized helper mirrors _hou_phantoms_in_source exactly for pdg.
+    tbl = PDG_PXR_TABLE - {"pdg.GraphContext"}
+    hits = checks._module_depth1_phantoms("import pdg\ngc = pdg.GraphContext()\n", tbl, "pdg")
+    assert ("pdg.GraphContext" in [s for _, s in hits])
+
+
+def test_unified_no_pdg_pxr_imports_is_clean():
+    # A file with only hou usage produces no pdg/pxr hits.
+    assert _unified_syms("import hou\nhou.node('/obj')\n") == []
 
 
 def test_check_phantom_clean_clean_path_returns_ok(monkeypatch, tmp_path):


### PR DESCRIPTION
**Do not merge as-is — this is a review artifact.** Recovered from a stale workflow worktree by lane triage (2026-08-02): a parallel implementation of the pdg/pxr phantom scanner, carrying the 2026-07-30 CTO soundness verdicts (pdg = SOUND via `dir()` walk; **pxr is NOT dir()-complete** — submodule-only enumeration) plus 85 lines of guardrail tests.

The l5 branch independently evolved its own implementation (camelCase near-miss hints, pxr depth-2 via `from pxr import N`). An attempted fold conflicted on both files — **two implementations of the same capability**. The phantom-sweep review should pick one and salvage the other's unique test cases + soundness prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)