### PR TITLE
docs(cto): RULINGS_02 — decision-list takeover

### DIFF
--- a/harness/legs.json
+++ b/harness/legs.json
@@ -50,7 +50,6 @@
       "state": "done",
       "receipt": "LEDGER.json",
       "branch": "repair/ledger-moneta-seam",
-      "worktree": ".claude/worktrees/ledger-moneta-seam",
       "prompt": "harness/prompts/ledger.md",
       "deps": [],
       "note": "ledger.py:275 _deposit_to_moneta is a hardcoded no-op with pragma:no cover, and ledger.py:329 calls it. Backend went live at b2c2c04; this seam did not. Also fixes MONETA_SRC provenance - the substrate currently resolves to a working directory. Disjoint from RES (tests/solaris) and H3a (read-only), so it runs in parallel.",
@@ -61,7 +60,8 @@
         "docs/studio/DEPLOYMENT.md"
       ],
       "merge_status": "superseded",
-      "merge_note": "Superseded: U1 authored the union from this branch (R91). Its finding is CLOSED - ledger.py:452 _deposit_to_moneta is no longer a no-op, U1 wrote the real implementation and it is called at :548. Pinned done so it cannot re-dispatch and cannot false-flag R92."
+      "merge_note": "Superseded: U1 authored the union from this branch (R91). Its finding is CLOSED - ledger.py:452 _deposit_to_moneta is no longer a no-op, U1 wrote the real implementation and it is called at :548. Pinned done so it cannot re-dispatch and cannot false-flag R92.",
+      "worktree_released": ".claude/worktrees/ledger-moneta-seam"
     },
     {
       "id": "H2",
@@ -69,13 +69,13 @@
       "state": "done",
       "receipt": "H2b.json",
       "branch": "repair/h2-requalify",
-      "worktree": ".claude/worktrees/h2-requalify",
       "prompt": "harness/prompts/h2.md",
       "deps": [
         "RES"
       ],
       "note": "R42/R43: unblocks when residency is gone. Scope includes the 17 bucket-2 decorations.",
-      "closed_note": "state->done 2026-08-02 (bar-truth pass): branch merged to master (ancestor of 8e4c385-era cleanup); findings routed to the decisions board via H2b.json for_ruling"
+      "closed_note": "state->done 2026-08-02 (bar-truth pass): branch merged to master (ancestor of 8e4c385-era cleanup); findings routed to the decisions board via H2b.json for_ruling",
+      "worktree_released": ".claude/worktrees/h2-requalify"
     },
     {
       "id": "H1",
@@ -197,9 +197,9 @@
       "note": "merge, housekeep, prune worktrees. Runs LAST - gated on every evidence-producing leg so integration never merges a picture that is still moving.",
       "prompt": "harness/prompts/f1.md",
       "branch": "repair/f1-integrate",
-      "worktree": ".claude/worktrees/f1-integrate",
       "readonly": false,
-      "closed_note": "state->done 2026-08-02 (bar-truth pass): green_with_findings receipt; findings live on the decisions board; integrate lane concluded"
+      "closed_note": "state->done 2026-08-02 (bar-truth pass): green_with_findings receipt; findings live on the decisions board; integrate lane concluded",
+      "worktree_released": ".claude/worktrees/f1-integrate"
     },
     {
       "id": "H9",
@@ -207,12 +207,12 @@
       "state": "done",
       "receipt": "H9.json",
       "branch": "repair/h9-doc-grounding",
-      "worktree": ".claude/worktrees/h9-doc-grounding",
       "prompt": "harness/prompts/h9.md",
       "deps": [],
       "readonly": true,
       "note": "done. Receipt LOST in the 2026-07-27 housekeeping prune - never committed. Findings survive as R95-R98 with anchors. LOP grounding 18%, COP 6% - both D2-shaped gaps. nodes.zip ships with 22.0.368: 5,034 pages, lop/ 198 at median 4,376B, cop/+cop2/ 525 at median ~2,900B. Measured coverage LOP 179/198=90%, COP 460/491=94%. Harvests to a NEW tier VERIFIED-DOC, reported SEPARATELY from probe-derived grounding - docs supply D2 and cannot supply D3, and karmarenderproperties proves docs go silent (69,921 chars, never mentions its own deprecation). Produces the corpus; wiring it is a separate decision.",
-      "receipt_lost": true
+      "receipt_lost": true,
+      "worktree_released": ".claude/worktrees/h9-doc-grounding"
     },
     {
       "id": "U1",
@@ -238,13 +238,13 @@
       "state": "done",
       "receipt": "V0.json",
       "branch": "retina/v0-m2-reconcile",
-      "worktree": ".claude/worktrees/v0-m2-reconcile",
       "prompt": "harness/prompts/v0.md",
       "deps": [],
       "readonly": true,
       "touches": [],
       "note": "archive/retina-m2-orphan carries 1,966 lines on no other branch - found in a workflow worktree nothing was backing up, preserved minutes before pruning. Verdict only: does it merge, does its 15/15 T0 byte-identity claim hold, does the worker venv it names actually exist. R91 precedent: building on unmerged work is how four decided rulings got stranded.",
-      "closed_note": "state->done 2026-08-02 (bar-truth pass): RETINA M2 verdict banked (v5.29.0 shipped, archive branch rejected); reconcile concluded"
+      "closed_note": "state->done 2026-08-02 (bar-truth pass): RETINA M2 verdict banked (v5.29.0 shipped, archive branch rejected); reconcile concluded",
+      "worktree_released": ".claude/worktrees/v0-m2-reconcile"
     },
     {
       "id": "V1",
@@ -265,13 +265,13 @@
       "state": "done",
       "receipt": "C0.json",
       "branch": "claims/c0-census",
-      "worktree": ".claude/worktrees/c0-census",
       "prompt": "harness/prompts/c0.md",
       "deps": [],
       "readonly": true,
       "touches": [],
       "note": "done. Receipt LOST in the same prune. Findings survive as R117. The positioning document says 'a technical evaluator will open the repo'. This is that evaluator, run internally first. Four SHIPPING claims, each gets a producer path or NONE. Roadmap items exempt - they are honest by construction. Records AGE: claim 3 became defensible on 2026-07-26 and reads as long-established, which is a different risk than being false.",
-      "receipt_lost": true
+      "receipt_lost": true,
+      "worktree_released": ".claude/worktrees/c0-census"
     },
     {
       "id": "C1",
@@ -294,7 +294,6 @@
       "state": "done",
       "receipt": "P1.json",
       "branch": "design/p1-panel-redesign",
-      "worktree": ".claude/worktrees/p1-panel-redesign",
       "prompt": "harness/prompts/p1.md",
       "deps": [],
       "readonly": false,
@@ -306,7 +305,8 @@
       "note": "STALLED 2026-07-27 - worktree unwritten for 3.5h while its process sat alive at 367MB. Its census LANDED and is the useful half (R128): five of eight result-surface setters had zero product callers. P2 built the connection. Pinned done so it cannot re-dispatch.",
       "receipt_lost": true,
       "merge_status": "merged",
-      "merge_note": "Released and merged 2026-07-28 after review. decision_log.py quotes the agent reasoning rather than composing it; P2 shipped the weaker tool-derived version and the wiring choice between them is a follow-up."
+      "merge_note": "Released and merged 2026-07-28 after review. decision_log.py quotes the agent reasoning rather than composing it; P2 shipped the weaker tool-derived version and the wiring choice between them is a follow-up.",
+      "worktree_released": ".claude/worktrees/p1-panel-redesign"
     },
     {
       "id": "RSI0",
@@ -340,13 +340,13 @@
       "state": "done",
       "receipt": "S1.json",
       "branch": "forensic/s1-tool-inventory",
-      "worktree": ".claude/worktrees/s1-forensic",
       "prompt": "harness/prompts/s1.md",
       "deps": [],
       "readonly": true,
       "touches": [],
       "note": "done. Receipt LOST in the same prune. Findings survive as R121-R122. What SYNAPSE DOES today, per tool, mapped to a real artist task. Every tool classified WORKS/PARTIAL/SCAFFOLD/UNREACHABLE/UNKNOWN with its evidence. This week found five Solaris tools registered, tested and completely unreachable - the gap between 'a tool exists' and 'a tool works' is this project's most reliable finding, and this measures it deliberately.",
-      "receipt_lost": true
+      "receipt_lost": true,
+      "worktree_released": ".claude/worktrees/s1-forensic"
     },
     {
       "id": "S2",
@@ -428,13 +428,13 @@
       "state": "done",
       "receipt": "E1.json",
       "branch": "econ/e1-tool-surface-census",
-      "worktree": ".claude/worktrees/e1-econ",
       "prompt": "harness/prompts/e1.md",
       "deps": [],
       "readonly": true,
       "touches": [],
       "note": "READ-ONLY, PARALLEL to E0 on a disjoint question - E0 asks what a turn COSTS, E1 asks what the surface IS. A total is not a plan. Decomposes 17,310 per tool into name / description / schema, because those three compress differently and only one risks correctness. Looks for concentration (is it 20 tools of 120?), duplicated schema fragments (free reduction, no capability lost), and DEAD SURFACE - a registered tool never called costs its full definition every turn, and S1 already found five Solaris tools registered, tested and unreachable. Ends with the honest counter-question: is 2,000 even reachable at 120 tools, or is the real decision FEWER tools rather than smaller ones.",
-      "closed_note": "state->done 2026-08-02 (bar-truth pass): econ/e1-tool-surface-census ancestor-merged into master (deleted in the 2026-08-02 77-branch cleanup)"
+      "closed_note": "state->done 2026-08-02 (bar-truth pass): econ/e1-tool-surface-census ancestor-merged into master (deleted in the 2026-08-02 77-branch cleanup)",
+      "worktree_released": ".claude/worktrees/e1-econ"
     },
     {
       "id": "V2",
@@ -459,7 +459,6 @@
       "state": "done",
       "receipt": "V3.json",
       "branch": "econ/v3-probe-layer",
-      "worktree": ".claude/worktrees/v3-econ",
       "prompt": "harness/prompts/v3.md",
       "deps": [],
       "readonly": false,
@@ -468,7 +467,8 @@
         "python/synapse/panel/providers/registry.py"
       ],
       "note": "Blueprint Mile 4. Routing is probe-derived, never config-declared - and this project has the receipts: hou.ActiveRender documented and absent, EXPECTED_HOUDINI_VERSION declared and never assigned, five Solaris tools registered and unreachable. A model list is the same shape of claim and fails the same way. Returns a structure, no panel work. Colour COMPUTED from probe age and quota, never stored; staleness degrades to GREY, never to green. Zero completion spend - count_tokens is free, completions are not.",
-      "closed_note": "state->done 2026-08-02 (bar-truth pass): econ/v3-probe-layer ancestor-merged into master (same cleanup)"
+      "closed_note": "state->done 2026-08-02 (bar-truth pass): econ/v3-probe-layer ancestor-merged into master (same cleanup)",
+      "worktree_released": ".claude/worktrees/v3-econ"
     }
   ]
 }

--- a/harness/notes/CTO_RULINGS_02.md
+++ b/harness/notes/CTO_RULINGS_02.md
@@ -1,0 +1,93 @@
+# CTO RULINGS — DECISION-LIST TAKEOVER
+
+**Ruled** 2026-08-02 · **Authority** Joe, "Can you take over as CTO on the decision list"
+**Scope** the standing decision list as of master `9d7bd17` (post PR #66; PRs #67/#68 closed with receipts).
+These are decisions, not proposals. Each names its executor: LANE (dispatched now), INLINE (done in this
+sitting), or PASTE (fenced file — the decision is made here; the file edit stays human by the anti-runaway
+anchor's own design, which survives delegation because its purpose is that no agent hand writes `ratified`,
+however authorized the agent).
+
+---
+
+## R201 — The phantom-sweep review branches MERGE, gates executed, not waved
+
+`clear/l5-phantom-scanner` (now @ `65fbe73`: scanner + salvage + the unwalked-pxr soundness fix, 29/29) and
+`fix/corpus-usdrender-rop` (14 commits, thrice-attacked SOUND on 2026-07-31) have been "in review" since
+July 31 while master moved ~20 merges past them. A review branch that rots is worse than either merging or
+rejecting it.
+
+**Ruling:** merge both — with the named gates from `harness/phantoms/QUARANTINE-PACKET-2026-07-31.md`
+executed as merge *conditions*, not waved: corpus digest rebuild, quarantine-list population, and the
+hdefereval headless-blind allowlist carried with the L5 merge. Each branch first absorbs current master and
+proves the full suite green on the merged result. If a gate condition turns out to be unexecutable as
+documented, that lane REFUSES and reports — a refusal correcting the packet is a better outcome than a
+merge that fakes a gate. **Executor: LANE ×2 + crucible each.**
+
+## R202 — protocol.py: cut, but only after the gate-map truth is traced
+
+The retire round left `python/synapse/agent/protocol.py` alive because `tests/test_set_usd_primvar.py:266`
+imports `DEFAULT_GATE_LEVELS` / `classify_gate_level`. That test's own comment calls it "Wiring site 1:
+gate map (protocol.py)" — which means it may be pinning a gate table that **nothing live consults** (the
+agent subsystem around it is deleted; the live gate authority is the bridge/`shared/constants.py` family).
+A test asserting REVIEW in a dead table is pinning a fiction and hiding it under a green check.
+
+**Ruling:** trace where `set_usd_primvar`'s gate level is *actually* enforced at runtime. If protocol.py's
+map is dead wiring: repoint the test at the live authority (preserving test independence — expected values
+stated literally in the test, never read from the module under test), delete `python/synapse/agent/`
+entirely, tombstone note in the commit. If the map turns out live: REFUSE, report the consumer, ruling
+void. **Executor: LANE + crucible.**
+
+## R203 — The seven H21-probed capabilities get their H22 records
+
+PR #68's triage confirmed all seven scout capabilities live on master — verified on **H21.0.671 only**.
+House rule: re-probe per build.
+
+**Ruling:** symbol-table + registry re-verification of all seven against H22 (`22.0.397` table, 35,908
+symbols): every `hou.*`/`pdg.*` call each handler emits, checked; any phantom → named for quarantine.
+Read-only. **Executor: LANE.**
+
+## R204 — H4 (panel IntegrityBlock readout) is RATIFIED as the next panel build — and not built tonight
+
+The last `!1 attention` is real: the receipts are the product differentiator (`harness/CLAUDE.md`: "every
+action reversible and **recorded**" — recorded-but-invisible is half a promise). **Ruling:** ratified as
+the next panel work item, to be built in a fresh session under the panel discipline (hython-offscreen
+verification, full-suite gate — the panel-redesign memory's rules). The bar keeps showing `!1` until it
+ships; that is the bar telling the truth. **Executor: queued, next session.**
+
+## R205 — Flywheel decisions (fenced file → PASTE hunks below)
+
+Decided now, recorded here; `flywheel_queue.json` receives them by human paste per its own `_doc`.
+
+- **C-substrate: ADD + RATIFY.** The RL-3 ruling is executed reality (C-0 merged, backend live).
+- **C.0 (context-capability probe): DEFER.** Real value, wrong moment — behind R201 and R204. Reopen
+  condition: both landed.
+- **U.2 (parm-name truth): RATIFY.** Phantom parms are the #1 failure family's nearest sibling; the
+  catalog already carries the fingerprints. One cycle, real defect class.
+- **U.3 / U.4 (output-index + arity guard): DEFER** until U.2 lands — same machinery, sequenced, or the
+  queue becomes theater again.
+
+**Paste-ready hunks** (append to `cycles` / edit in place):
+
+```json
+{"id": "C.SUB", "title": "Memory substrate: moneta ratified (RATIFY-AND-STABILIZE); C-0 address fix merged PR #60",
+ "status": "done", "ratified": true,
+ "evidence": ["harness/rsi/briefs/C-substrate-decision-brief-2026-08-01.md", "harness/notes/CTO_RULINGS_02.md#R205"],
+ "note": "Ruled 2026-08-01/02 under delegated CTO authority; human paste = the ratified flip."}
+```
+```
+C.0  -> add: "deferred": true, "note": "DEFERRED 2026-08-02 (CTO_RULINGS_02 R205): reopen after R201 merges + H4 ships."
+U.2  -> set: "ratified": true   (note: RATIFIED 2026-08-02 per CTO_RULINGS_02 R205)
+U.3  -> add: "deferred": true   (reopen: U.2 landed)
+U.4  -> add: "deferred": true   (reopen: U.2 landed)
+```
+
+## R206 — legs.json: dead worktree paths cleared
+
+The 13 closed/orphaned legs still point at deleted husk directories. Harmless today, but a stale path is a
+future false-armed waiting for any directory to reappear. **Ruling:** clear `worktree` on legs whose state
+is `done`/`held` and whose path no longer exists. **Executor: INLINE.**
+
+## R207 — The 286 decisions board: no bulk action, ever
+
+The resolution channel (#58) is the only exit, one item at a time, evidence per entry. A bulk sweep would
+recreate the false-open problem in reverse. **Ruling:** standing instruction, no action.


### PR DESCRIPTION
Seven rulings; three dispatched as verified lanes, one executed inline, one ratified-and-queued, one paste-ready for the fenced file, one standing instruction. Full text in `harness/notes/CTO_RULINGS_02.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CTO decision records covering merge validation, capability re-verification, future panel work, queue updates, workspace cleanup, and decision-board handling.
* **Chores**
  * Updated project completion records with closure details, released workspace paths, merge notes, and receipt status.
  * Removed obsolete workspace references from completed or superseded work items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->