### PR TITLE
docs(parity): compose-trio aliases labeled promotion-staged (comment-only)

### DIFF
--- a/docs/reviews/panel-capability-parity-2026-08-14.md
+++ b/docs/reviews/panel-capability-parity-2026-08-14.md
@@ -126,6 +126,24 @@ F2 is a design call for Joe, not a bug.
 
 ---
 
+## Post-release dispositions (v5.48.0 loop closure, 2026-08-14)
+
+- **F3/F4 — closed.** Both stale comments were refreshed in the freeze-relief
+  branches themselves (`mcp/server.py` now states 40/36/4; `tool_bridge.py`
+  header says 124). Nothing left to do.
+- **F1 — resolved as *staged*, not dead.** Deleting the compose-trio aliases
+  failed `test_compose_offmain_wp3.py::test_bridge_adapter_marks_touches_disk`,
+  which pins that the shotsetup tool gets `touches_disk=True` elevation. The
+  test is evidence the entries are intentional forward-staging: WS-side real
+  handlers, registry promotion pending. `bridge_adapter.py` now says that
+  in plain words at both sites (comment-only change, zero behavior delta).
+  The remaining design call — *promote the trio into TOOL_DEFS* — is Joe's.
+- **F2 (pause/resume UI wiring)** and **F5 (nine unmounted-module check)** —
+  open, Joe's calls. F2 needs an overflow-menu decision; F5 needs a live-panel
+  or side-channel import scan before any dead/mount claim.
+
+*Dispositions shipped on branch `chore/parity-dead-aliases`.*
+
 *Evidence: full workflow result at
 `C:/Users/User/AppData/Local/Temp/claude/C--Users-User-SYNAPSE/panel-parity-full.json`;
 journal `panel-capability-parity-wf_63b2002b-40c.journal.jsonl` (3 agents,

--- a/python/synapse/panel/bridge_adapter.py
+++ b/python/synapse/panel/bridge_adapter.py
@@ -152,6 +152,12 @@ _TOOL_TO_OPERATION: dict[str, str] = {
     "synapse_batch": "build_from_manifest",
     "synapse_solaris_assemble_chain": "build_from_manifest",
     "synapse_solaris_build_graph": "build_from_manifest",
+    # PROMOTION-STAGED (parity-audit F1, 2026-08-14): the trio below are real
+    # WS handlers (server/handlers.py:741-743) with NO TOOL_DEFS registry
+    # entry — these aliases are unreachable today. They stay as forward
+    # staging: if/when the trio is promoted to the registry, the op-type and
+    # disk classifications apply from day one (pinned by
+    # tests/test_compose_offmain_wp3.py::test_bridge_adapter_marks_touches_disk).
     "synapse_solaris_shotsetup_karma_xpu": "build_from_manifest",
     "synapse_matlib_bind": "build_from_manifest",
     "synapse_assess_render_ready": "inspect_geometry",
@@ -161,7 +167,9 @@ _TOOL_TO_OPERATION: dict[str, str] = {
 # R4 (shared/bridge.py Operation.gate_level): touches_disk elevates the
 # gate to APPROVE. These writes happen outside the undo system.
 _DISK_WRITING_TOOLS = frozenset({
-    "synapse_solaris_shotsetup_karma_xpu",  # department .usd layer files
+    "synapse_solaris_shotsetup_karma_xpu",  # department .usd layer files;
+    # promotion-staged alias (see _TOOL_TO_OPERATION note above) — the disk
+    # elevation must hold the day the registry entry lands
 })
 
 # ── Tool name → inferred AgentID ─────────────────────────────────


### PR DESCRIPTION
## Why
Post-release loop closure on the panel parity audit (docs/reviews/panel-capability-parity-2026-08-14.md). A deletion attempt against the "dead" compose-trio aliases failed `test_bridge_adapter_marks_touches_disk`, which pins `touches_disk` elevation for the shotsetup alias — evidence the entries are intentional forward-staging for an anticipated registry promotion, not drift.

## Changes (comment-only, zero behavior delta)
- `bridge_adapter.py`: honest PROMOTION-STAGED notes at `_TOOL_TO_OPERATION` and `_DISK_WRITING_TOOLS`, pointing at the pinning test and the handlers.
- Parity report gains a post-release dispositions section: F1 staged, F3/F4 already fixed in-tree by the freeze branches, F2/F5 open design calls.

## Evidence
77 passed on the affected slice (bridge_adapter / tool_bridge / parity / read_only / compose_offmain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)